### PR TITLE
fix: Allow current day submissions and improve error handling

### DIFF
--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -143,8 +143,9 @@ export const submit = mutation({
       suspiciousReasons.push(`Average daily cost of $${avgDailyCost.toFixed(2)} is unusually high`);
     }
     
-    // Check for future dates
+    // Check for future dates (allow today)
     const today = new Date();
+    today.setHours(23, 59, 59, 999); // End of today to allow current day submissions
     const futureDate = dates.find(date => new Date(date) > today);
     if (futureDate) {
       throw new Error(`Future date detected: ${futureDate}. Please check your data.`);

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -56,15 +56,20 @@ export async function POST(request: NextRequest) {
   } catch (error) {
     console.error("Submission error:", error);
     
-    // Provide specific error messages
+    // Provide specific error messages for validation errors
     if (error instanceof Error) {
-      if (error.message.includes("Token totals don't match")) {
-        return NextResponse.json(
-          { error: error.message },
-          { status: 400 }
-        );
-      }
-      if (error.message.includes("Invalid date format")) {
+      // Handle validation errors with 400 status
+      const validationErrors = [
+        "Token totals don't match",
+        "Invalid date format",
+        "Future date detected",
+        "Negative values are not allowed",
+        "exceed realistic limits",
+        "Cost per token ratio is unrealistic",
+        "Token components don't sum correctly"
+      ];
+      
+      if (validationErrors.some(msg => error.message.includes(msg))) {
         return NextResponse.json(
           { error: error.message },
           { status: 400 }
@@ -80,7 +85,7 @@ export async function POST(request: NextRequest) {
 }
 
 // Support OPTIONS for CORS if needed
-export async function OPTIONS(request: NextRequest) {
+export async function OPTIONS() {
   return new NextResponse(null, {
     status: 200,
     headers: {


### PR DESCRIPTION
## Summary
Fixes the 500 error issue reported in #5 where users couldn't submit `cc.json` files containing today's date.

## Problem
The date validation logic was too strict, rejecting any date greater than `new Date()`, even if it was the same calendar day. This caused submissions to fail with 500 errors when users included the current day in their usage data.

## Changes Made

### 1. Fix Date Validation Logic (`convex/submissions.ts`)
- Modified date comparison to allow today's date by setting the comparison to end of day (23:59:59.999)
- Users can now submit data for the current day without getting future date errors

### 2. Improve Error Handling (`src/app/api/submit/route.ts`)
- Enhanced error handling to return proper 400 status codes for validation errors instead of generic 500 errors
- Added comprehensive validation error detection for better user experience
- Removed unused parameter to fix linting warning

## Testing
- ✅ Date validation now allows current day submissions
- ✅ Proper error messages are returned for validation failures
- ✅ Code passes linting (new errors were pre-existing)

## Impact
This fix resolves the issue for all users who run `npx ccusage --json > cc.json` and include the current day in their usage data. Users will now receive proper validation error messages instead of generic 500 errors.

Fixes #5