### PR TITLE
Fix: Properly encode usernames with spaces in profile URLs

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -100,7 +100,7 @@ export default function AdminPage() {
                             {submission.githubUsername || submission.username}
                           </h3>
                           <Link
-                            href={`/profile/${submission.githubUsername || submission.username}`}
+                            href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
                             className="text-accent hover:underline flex items-center gap-1"
                           >
                             View Profile

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 
 export default function ProfilePage() {
   const params = useParams();
-  const username = params.username as string;
+  const username = decodeURIComponent(params.username as string);
   const [selectedTimeRange, setSelectedTimeRange] = useState<"7d" | "30d" | "all">("30d");
   
   const profileData = useQuery(api.submissions.getProfile, { username });

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -287,7 +287,7 @@ export default function Leaderboard() {
                             <div>
                               <div className="flex items-center gap-1.5">
                                 <Link 
-                                  href={`/profile/${submission.githubUsername || submission.username}`}
+                                  href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
                                   className="font-medium hover:text-accent transition-colors"
                                 >
                                   {submission.githubUsername || submission.username}
@@ -343,7 +343,7 @@ export default function Leaderboard() {
                               </motion.button>
                             )}
                             <Link
-                              href={`/profile/${submission.githubUsername || submission.username}`}
+                              href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
                               className="p-1.5 rounded-lg hover:bg-card/50 transition-all opacity-0 group-hover:opacity-100"
                             >
                               <ArrowUpRight className="w-3.5 h-3.5 text-muted hover:text-foreground" />
@@ -402,7 +402,7 @@ export default function Leaderboard() {
                         )}
                         <div className="min-w-0">
                           <Link 
-                            href={`/profile/${submission.githubUsername || submission.username}`}
+                            href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
                             className="group inline-flex items-center gap-1 font-medium hover:text-accent transition-colors text-sm truncate"
                           >
                             <span className="truncate">{submission.githubUsername || submission.username}</span>


### PR DESCRIPTION
## Summary
- Fixes #4 where usernames containing spaces broke profile URLs
- Added proper URL encoding/decoding for usernames in profile links
- Fully backward compatible - existing URLs continue to work

## Changes
- Added `encodeURIComponent()` when generating profile links in:
  - Leaderboard component (3 locations)
  - Admin page (1 location)
- Added `decodeURIComponent()` when parsing username from URL params in profile page

## Test Plan
- [x] Tested with usernames containing spaces (e.g., "Gosuto Inzasheru")
- [x] Verified backward compatibility with existing URLs
- [x] Confirmed usernames without special characters work unchanged
- [x] Checked that database queries remain unaffected

## Example
Before: `https://viberank.app/profile/Gosuto Inzasheru` (broken)
After: `https://viberank.app/profile/Gosuto%20Inzasheru` (working)

🤖 Generated with [Claude Code](https://claude.ai/code)