### PR TITLE
Fix: Keep only token limit increase at 250M, revert dollar limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ To maintain leaderboard integrity, viberank validates all submissions:
 - ✅ **Realistic limits** - Flags unusually high usage for review
 
 #### Validation Limits
-- Maximum daily cost: $25,000
+- Maximum daily cost: $5,000
 - Maximum daily tokens: 250 million
 - Cost per token ratio: 0.000001 to 0.1
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -43,12 +43,12 @@ inputTokens + outputTokens + cacheCreationTokens + cacheReadTokens = totalTokens
 These submissions are accepted but flagged for review:
 
 ### 1. High Daily Usage
-- Daily cost > $25,000
-- Daily tokens > 250 million
-- These are possible but rare (limits increased 5x to reduce false positives)
+- Daily cost > $5,000
+- Daily tokens > 250 million (increased 5x from 50M to reduce false positives)
+- These are possible but rare
 
 ### 2. High Average Usage
-- Average daily cost > $12,500
+- Average daily cost > $2,500
 - Indicates sustained high usage
 
 ### 3. Flagging Behavior

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -56,7 +56,7 @@ export const submit = mutation({
     }
     
     // 2. Validate realistic ranges
-    const MAX_DAILY_COST = 25000; // $25k/day is extremely high usage (increased 5x from $5k)
+    const MAX_DAILY_COST = 5000; // $5k/day is extremely high usage
     const MAX_DAILY_TOKENS = 250_000_000; // 250M tokens/day (increased 5x from 50M)
     const MIN_COST_PER_TOKEN = 0.000001; // Sanity check for cost/token ratio
     const MAX_COST_PER_TOKEN = 0.1; // Sanity check for cost/token ratio


### PR DESCRIPTION
## Summary
Corrects the previous PR to only increase the token limit as requested, not the dollar limit.

## Changes
- ✅ **Kept token limit at 250M** (5x increase from 50M) to reduce false positives
- ⏪ **Reverted dollar limit back to $5k** (was incorrectly increased to $25k)
- 📝 Updated documentation to reflect correct limits

## Why this fix?
The previous PR accidentally increased both limits, but the request was only to increase the token limit to reduce false flagging of legitimate heavy users.

🤖 Generated with [Claude Code](https://claude.ai/code)