### PR TITLE
Fix stats accuracy and add robust rate limiting

### DIFF
--- a/convex/convex.config.ts
+++ b/convex/convex.config.ts
@@ -1,0 +1,7 @@
+import { defineApp } from "convex/server";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config";
+
+const app = defineApp();
+app.use(rateLimiter);
+
+export default app;

--- a/convex/rateLimiter.ts
+++ b/convex/rateLimiter.ts
@@ -1,0 +1,35 @@
+import { RateLimiter, MINUTE, HOUR } from "@convex-dev/rate-limiter";
+import { components } from "./_generated/api";
+
+export const rateLimiter = new RateLimiter(components.rateLimiter, {
+  // Submission rate limits - very strict to prevent abuse
+  submitData: { 
+    kind: "fixed window", 
+    rate: 1, // Only 1 submission per hour per user
+    period: HOUR,
+  },
+  
+  // API endpoint rate limits
+  apiGeneral: { 
+    kind: "token bucket", 
+    rate: 60, // 60 requests per minute
+    period: MINUTE,
+    capacity: 10, // Allow bursts of up to 10
+  },
+  
+  // Failed submission attempts (even stricter)
+  failedSubmissions: { 
+    kind: "fixed window", 
+    rate: 10, // Only 10 failed attempts per hour
+    period: HOUR,
+  },
+  
+  // Query rate limits for expensive operations
+  expensiveQuery: {
+    kind: "token bucket",
+    rate: 20, // 20 per minute
+    period: MINUTE,
+    capacity: 5,
+    shards: 5, // Use sharding for better performance
+  },
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@auth/core": "^0.40.0",
+    "@convex-dev/rate-limiter": "^0.2.12",
     "@vercel/analytics": "^1.5.0",
     "clsx": "^2.1.1",
     "convex": "^1.25.2",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -131,7 +131,7 @@ export default function Home() {
               className="flex items-center justify-center gap-6 sm:gap-8 text-center flex-wrap mb-12"
             >
               <div>
-                <p className="text-2xl sm:text-3xl font-bold">{stats?.totalSubmissions || 0}</p>
+                <p className="text-2xl sm:text-3xl font-bold">{stats?.totalUsers || 0}</p>
                 <p className="text-xs sm:text-sm text-muted">Developers</p>
               </div>
               <div className="w-px h-12 bg-border/50 hidden sm:block" />


### PR DESCRIPTION
## Summary
- Fixed stats display showing only 100 developers (was showing submission count instead of actual user count)
- Implemented production-ready rate limiting to prevent abuse
- Cleaned up project dependencies

## Changes
### Stats Improvements
- Changed display from `totalSubmissions` to `totalUsers` for accurate developer count
- Increased profile query limit from 1000 to 5000 for more accurate counts  
- Increased submission sample from 100 to 500 for better statistics
- Stats now show actual unique developer count instead of submission count

### Rate Limiting Implementation
- Added Convex rate limiter component (designed for serverless environments)
- Configured strict rate limits:
  - **Submissions**: 1 per hour per user
  - **Failed attempts**: 10 per hour
  - **General API**: 60 requests per minute with burst capacity
- Removed custom in-memory rate limiting (not suitable for Vercel serverless)
- Added proper HTTP 429 responses with Retry-After headers

### Cleanup
- Removed package-lock.json (project uses pnpm)
- Cleaned up unused variables

## Test Plan
- [x] Stats now show accurate developer count
- [x] Rate limiting prevents rapid submission attempts
- [x] Error messages provide clear feedback with wait times
- [x] Works correctly in Vercel's serverless environment

🤖 Generated with [Claude Code](https://claude.ai/code)