### PR TITLE
fix: Adjust validation for cache read tokens and fix date range merging

### DIFF
--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -58,7 +58,7 @@ export const submit = mutation({
     // 2. Validate realistic ranges
     const MAX_DAILY_COST = 5000; // $5k/day is extremely high usage
     const MAX_DAILY_TOKENS = 50_000_000; // 50M tokens/day
-    const MIN_COST_PER_TOKEN = 0.000001; // Sanity check for cost/token ratio
+    const MIN_COST_PER_TOKEN = 0.0000001; // Adjusted for cache read tokens which are very cheap
     const MAX_COST_PER_TOKEN = 0.1; // Sanity check for cost/token ratio
     
     // Check totals
@@ -125,7 +125,7 @@ export const submit = mutation({
     
     // 5. Sort dates to ensure consistent range
     const dates = ccData.daily.map((d) => d.date).sort();
-    const dateRange = {
+    let dateRange = {
       start: dates[0] || "",
       end: dates[dates.length - 1] || "",
     };
@@ -225,7 +225,7 @@ export const submit = mutation({
       
       // Update date range to encompass all dates
       const allDates = mergedDailyBreakdown.map(d => d.date);
-      const mergedDateRange = {
+      dateRange = {
         start: allDates[0] || dateRange.start,
         end: allDates[allDates.length - 1] || dateRange.end,
       };
@@ -246,7 +246,7 @@ export const submit = mutation({
         outputTokens: mergedTotals.outputTokens,
         cacheCreationTokens: mergedTotals.cacheCreationTokens,
         cacheReadTokens: mergedTotals.cacheReadTokens,
-        dateRange: mergedDateRange,
+        dateRange: dateRange,
         modelsUsed: allModelsUsed,
         dailyBreakdown: mergedDailyBreakdown,
         submittedAt: Date.now(),

--- a/test_cc.json
+++ b/test_cc.json
@@ -1,0 +1,20 @@
+{
+  "totals": {
+    "cacheCreationTokens": 10319123,
+    "cacheReadTokens": 308720701,
+    "inputTokens": 78274,
+    "outputTokens": 257437,
+    "totalCost": 135.40929855000002,
+    "totalTokens": 319375535
+  },
+  "daily": [{
+    "date": "2025-09-08",
+    "inputTokens": 78274,
+    "outputTokens": 257437,
+    "cacheCreationTokens": 10319123,
+    "cacheReadTokens": 308720701,
+    "totalTokens": 319375535,
+    "totalCost": 135.40929855000002,
+    "modelsUsed": ["claude-3-5-sonnet"]
+  }]
+}

--- a/test_solaris.json
+++ b/test_solaris.json
@@ -1,0 +1,20 @@
+{
+  "totals": {
+    "cacheCreationTokens": 77666747,
+    "cacheReadTokens": 808540708,
+    "inputTokens": 86374,
+    "outputTokens": 1127571,
+    "totalCost": 708.87304425,
+    "totalTokens": 887421400
+  },
+  "daily": [{
+    "date": "2025-09-08",
+    "inputTokens": 86374,
+    "outputTokens": 1127571,
+    "cacheCreationTokens": 77666747,
+    "cacheReadTokens": 808540708,
+    "totalTokens": 887421400,
+    "totalCost": 708.87304425,
+    "modelsUsed": ["claude-3-5-sonnet"]
+  }]
+}


### PR DESCRIPTION
## Summary
- Fixed "Cost per token ratio is unrealistic" error by adjusting MIN_COST_PER_TOKEN from 0.000001 to 0.0000001
- Fixed "dateRange is not defined" error by properly scoping the dateRange variable
- Both issues were causing submission failures in production

## Problem
Multiple users were unable to submit their usage data due to two validation errors:
1. Cache read tokens have very low cost per token ratios (below 0.000001) which was triggering the unrealistic ratio validation
2. When merging submissions, the dateRange variable was incorrectly scoped causing a reference error

## Solution
- Adjusted MIN_COST_PER_TOKEN threshold to accommodate cache read tokens which are 10x cheaper than regular tokens
- Changed dateRange from const to let and properly reassigned it when merging submissions

## Test plan
- [x] Tested locally with previously failing submissions
- [x] Verified submissions now succeed with cache-heavy token usage
- [x] Confirmed date range merging works correctly
- [x] Deployed to production and verified working

🤖 Generated with [Claude Code](https://claude.ai/code)