### PR TITLE
submit mutation rejects current ccusage output: daily entries now use `period` instead of `date` (Invalid date format: undefined)

### DIFF
--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -23,7 +23,13 @@ export const submit = mutation({
       }),
       daily: v.array(
         v.object({
-          date: v.string(),
+          // ccusage <19 emitted `date`; ccusage >=19 default `--json` emits
+          // `period` (plus `agent`/`metadata`). Accept either; the handler
+          // normalizes `period` -> `date` before validating/storing.
+          date: v.optional(v.string()),
+          period: v.optional(v.string()),
+          agent: v.optional(v.string()),
+          metadata: v.optional(v.any()),
           inputTokens: v.number(),
           outputTokens: v.number(),
           cacheCreationTokens: v.number(),
@@ -121,9 +127,14 @@ export const submit = mutation({
     const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
     
     for (const day of ccData.daily) {
-      if (!dateRegex.test(day.date)) {
-        throw new Error(`Invalid date format: ${day.date}. Expected YYYY-MM-DD`);
+      // ccusage >=19 default `--json` renamed the per-day key `date` -> `period`.
+      // Coalesce into a guaranteed string so the regex and every downstream
+      // read/write sees a valid date; assign it back for the in-loop reads.
+      const date = day.date ?? day.period;
+      if (!date || !dateRegex.test(date)) {
+        throw new Error(`Invalid date format: ${date}. Expected YYYY-MM-DD`);
       }
+      day.date = date;
       
       // Check for negative values
       if (day.totalCost < 0 || day.totalTokens < 0 || 
@@ -157,7 +168,7 @@ export const submit = mutation({
     );
     
     // 5. Sort dates to ensure consistent range
-    const dates = ccData.daily.map((d) => d.date).sort();
+    const dates = ccData.daily.map((d) => (d.date ?? d.period)!).sort();
     dateRange = {
       start: dates[0] || "",
       end: dates[dates.length - 1] || "",
@@ -242,8 +253,9 @@ export const submit = mutation({
       
       // Update with new daily data (overwrites for same dates, adds new dates)
       ccData.daily.forEach(day => {
-        existingDailyMap.set(day.date, {
-          date: day.date,
+        const date = (day.date ?? day.period)!;
+        existingDailyMap.set(date, {
+          date,
           inputTokens: day.inputTokens,
           outputTokens: day.outputTokens,
           cacheCreationTokens: day.cacheCreationTokens,
@@ -335,7 +347,7 @@ export const submit = mutation({
           dateRange,
           modelsUsed,
           dailyBreakdown: ccData.daily.map((day) => ({
-            date: day.date,
+            date: (day.date ?? day.period)!,
             inputTokens: day.inputTokens,
             outputTokens: day.outputTokens,
             cacheCreationTokens: day.cacheCreationTokens,


### PR DESCRIPTION
Fixes #49.

## Problem
Current `ccusage --json` emits each daily entry keyed by **`period`** (plus `agent`/`metadata`) instead of `date`. The `submit` mutation reads `day.date`, which is now `undefined`, so submissions fail with `Invalid date format: undefined. Expected YYYY-MM-DD`. None of the ingestion paths (`packages/viberank-cli/cli.js`, `src/app/api/submit/route.ts`, `submit-to-viberank.sh`) normalize this, so the fix lives at the single chokepoint they all funnel through: `convex/submissions.ts`.

## Change (`convex/submissions.ts`, +19/−7)
1. **Widen the daily args validator** — `date` becomes optional and `period`/`agent`/`metadata` are accepted as optional. Convex `v.object` is strict, so without this it rejects the real payload before the handler runs.
2. **Coalesce `day.date ?? day.period`** in the validation loop and at every incoming-date read plus both stored-write paths (merge + insert), so `dailyBreakdown.date` is always a valid `YYYY-MM-DD`.

`convex/schema.ts` (stored `date: v.string()`, required) is intentionally left unchanged — `period` is normalized to `date` at ingestion.

## Verification
- **Type-neutral** — typechecking the `convex/` sources before and after the patch yields the same result; it introduces no new type errors. Please confirm with your usual `convex deploy` / `tsc`.
- **End-to-end on a real failing `cc.json`** (32 daily entries, all keyed by `period`): pre-change throws the exact reported error; post-change all 32 pass and store valid dates (range 2026-05-01..2026-06-01).

## Coordination notes
- Overlaps **#48** — a comment there independently reports the same missing-`date` crash and the same `date = period` fix; consider deduping.
- **#39** also edits `convex/submissions.ts`; flagging for potential merge-conflict coordination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
