### PR TITLE
viberank v2 redesign — flat dark theme, podium, tool chips

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,25 +1,26 @@
 @import "tailwindcss";
 
 :root {
-  /* Dark theme with subtle warmth */
-  --background: #121212;
-  --background-secondary: #1a1a1a;
-  --foreground: #efefef;
-  --muted: #888888;
+  /* Modern flat dark — higher contrast, no gradients */
+  --background: #0a0a0b;
+  --background-secondary: #101012;
+  --foreground: #fafafa;
+  --muted: #9a9aa5;
   --accent: #f97316;
-  --accent-hover: #ea580c;
-  --card: #1e1e1e;
-  --card-hover: #262626;
-  --border: #2e2e2e;
-  --border-subtle: #242424;
+  --accent-hover: #fb8a3c;
+  --accent-soft: rgba(249, 115, 22, 0.12);
+  --card: #131316;
+  --card-hover: #1a1a1f;
+  --border: #26262d;
+  --border-subtle: #1b1b21;
   --success: #22c55e;
   --error: #ef4444;
 
-  /* Surface colors */
-  --surface-1: #161616;
-  --surface-2: #1e1e1e;
-  --surface-3: #262626;
-  --surface-4: #2e2e2e;
+  /* Surface colors (flat, stepped) */
+  --surface-1: #0f0f12;
+  --surface-2: #16161a;
+  --surface-3: #1e1e23;
+  --surface-4: #26262d;
 }
 
 @theme inline {
@@ -27,8 +28,17 @@
   --color-foreground: var(--foreground);
   --color-muted: var(--muted);
   --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
   --color-card: var(--card);
+  --color-card-hover: var(--card-hover);
   --color-border: var(--border);
+  --color-border-subtle: var(--border-subtle);
+  --color-success: var(--success);
+  --color-error: var(--error);
+  --color-surface-1: var(--surface-1);
+  --color-surface-2: var(--surface-2);
+  --color-surface-3: var(--surface-3);
+  --color-surface-4: var(--surface-4);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -49,11 +59,9 @@ body {
   box-sizing: border-box;
 }
 
-/* Very subtle background gradient */
+/* Flat background (gradients intentionally removed) */
 .gradient-mesh {
-  background:
-    radial-gradient(ellipse 80% 50% at 50% -10%, rgba(249, 115, 22, 0.06) 0%, transparent 50%),
-    radial-gradient(ellipse 60% 40% at 100% 100%, rgba(249, 115, 22, 0.03) 0%, transparent 40%);
+  background: var(--background);
 }
 
 /* Simple fade animation */
@@ -88,32 +96,26 @@ body {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
 }
 
-/* Rank badges - solid colors, no excessive glow */
+/* Rank badges - flat solid colors */
 .rank-gold {
-  background: linear-gradient(135deg, #fbbf24 0%, #d97706 100%);
+  background: #f5b008;
 }
 
 .rank-silver {
-  background: linear-gradient(135deg, #d1d5db 0%, #9ca3af 100%);
+  background: #b8bcc4;
 }
 
 .rank-bronze {
-  background: linear-gradient(135deg, #fdba74 0%, #ea580c 100%);
+  background: #c2703f;
 }
 
-/* Text gradient for headers only */
+/* Header text helpers (flat — no gradient fill) */
 .text-gradient {
-  background: linear-gradient(135deg, var(--foreground) 0%, var(--muted) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--foreground);
 }
 
 .text-gradient-accent {
-  background: linear-gradient(135deg, var(--accent) 0%, #fb923c 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--accent);
 }
 
 /* Scrollbar */
@@ -156,14 +158,9 @@ body {
   background: var(--surface-2);
 }
 
-/* Stat shimmer - subtle */
+/* Stat shimmer removed (flat) */
 .stat-shimmer {
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.02) 50%,
-    transparent 100%
-  );
+  background: transparent;
 }
 
 /* Button glow - minimal */

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -41,16 +41,16 @@ function getInitials(name?: string): string {
 }
 
 function generateGradient(name?: string): string {
-  // Generate a consistent gradient based on the name
+  // Generate a consistent solid color based on the name (flat — no gradient)
   const colors = [
-    "from-orange-500 to-amber-500",
-    "from-blue-500 to-cyan-500",
-    "from-purple-500 to-pink-500",
-    "from-green-500 to-emerald-500",
-    "from-red-500 to-rose-500",
-    "from-indigo-500 to-violet-500",
-    "from-teal-500 to-cyan-500",
-    "from-yellow-500 to-orange-500",
+    "bg-orange-500",
+    "bg-blue-500",
+    "bg-purple-500",
+    "bg-emerald-500",
+    "bg-rose-500",
+    "bg-indigo-500",
+    "bg-teal-500",
+    "bg-amber-500",
   ];
 
   if (!name) return colors[0];
@@ -93,7 +93,7 @@ export default function Avatar({
       <div
         className={`${sizeClasses[size]} rounded-full flex items-center justify-center ${ringClass} ${className} ${
           initials
-            ? `bg-gradient-to-br ${gradient}`
+            ? gradient
             : "bg-card"
         }`}
       >

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Trophy, Medal, Award, DollarSign, Zap, Calendar, Share2, X, ChevronDown, BadgeCheck, Loader2, Terminal, Copy, Check, Users } from "lucide-react";
+import { Trophy, Medal, Award, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2, Terminal, Copy, Check, Users } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import ShareCard from "./ShareCard";
 import Avatar from "./Avatar";
-import { formatNumber, formatCurrency } from "@/lib/utils";
+import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
 import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useSubmissions";
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
 import type { Submission } from "@/lib/data/types";
@@ -17,6 +17,103 @@ type SortBy = "cost" | "tokens";
 interface LeaderboardProps {
   onCopyCommand?: () => void;
   copiedToClipboard?: boolean;
+}
+
+// Small flat pills showing which tools a submission used.
+function ToolChips({ tools, max = 3, className = "" }: { tools?: string[]; max?: number; className?: string }) {
+  if (!tools || tools.length === 0) return null;
+  const shown = tools.slice(0, max);
+  const extra = tools.length - shown.length;
+  return (
+    <div className={`flex items-center gap-1 flex-wrap ${className}`}>
+      {shown.map((t) => (
+        <span
+          key={t}
+          className="text-[10px] font-medium leading-none px-1.5 py-1 rounded-md bg-surface-3 text-muted border border-border-subtle"
+        >
+          {toolLabel(t)}
+        </span>
+      ))}
+      {extra > 0 && <span className="text-[10px] text-muted leading-none">+{extra}</span>}
+    </div>
+  );
+}
+
+const RANK_META = [
+  { label: "1st", Icon: Trophy, color: "text-[#f5b008]" },
+  { label: "2nd", Icon: Medal, color: "text-[#b8bcc4]" },
+  { label: "3rd", Icon: Award, color: "text-[#c2703f]" },
+];
+
+function PodiumCard({
+  submission,
+  rank,
+  isCurrentUser,
+}: {
+  submission: Submission;
+  rank: number;
+  isCurrentUser: boolean;
+}) {
+  const meta = RANK_META[rank - 1];
+  const { Icon } = meta;
+  const featured = rank === 1;
+  return (
+    <Link
+      href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
+      className={`group flex flex-col rounded-2xl border bg-surface-1 p-4 transition-colors hover:bg-surface-2 ${
+        featured ? "border-accent/40 sm:p-5" : "border-border"
+      } ${isCurrentUser ? "ring-1 ring-accent" : ""}`}
+    >
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-1.5">
+          <Icon className={`w-4 h-4 ${meta.color}`} />
+          <span className="text-xs font-semibold text-muted">{meta.label}</span>
+        </div>
+        {submission.verified ? (
+          <BadgeCheck className="w-4 h-4 text-blue-500" />
+        ) : (
+          <span className="text-[9px] font-mono uppercase tracking-wider px-1 py-px rounded bg-muted/15 text-muted">cli</span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 mb-4">
+        <Avatar
+          src={submission.githubAvatar}
+          githubUsername={submission.githubUsername}
+          name={submission.githubName || submission.username}
+          size={featured ? "lg" : "md"}
+        />
+        <div className="min-w-0">
+          <div className="font-semibold truncate group-hover:text-accent transition-colors">
+            {submission.githubUsername || submission.username}
+          </div>
+          {submission.githubName && submission.githubName !== submission.githubUsername && (
+            <div className="text-xs text-muted truncate">{submission.githubName}</div>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-auto">
+        <div className={`font-mono font-bold text-accent ${featured ? "text-2xl" : "text-xl"}`}>
+          ${formatCurrency(submission.totalCost)}
+        </div>
+        <div className="text-xs text-muted font-mono mt-0.5">{formatNumber(submission.totalTokens)} tokens</div>
+        <ToolChips tools={submission.tools} className="mt-3" />
+      </div>
+    </Link>
+  );
+}
+
+function StatCard({ icon: Icon, label, value, accent = false }: { icon: typeof Users; label: string; value: string; accent?: boolean }) {
+  return (
+    <div className="bg-surface-1 rounded-xl px-4 py-3.5 border border-border">
+      <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5">
+        <Icon className="w-3.5 h-3.5" />
+        {label}
+      </div>
+      <div className={`text-xl font-bold font-mono truncate ${accent ? "text-accent" : ""}`}>{value}</div>
+    </div>
+  );
 }
 
 export default function Leaderboard({ onCopyCommand, copiedToClipboard }: LeaderboardProps) {
@@ -92,18 +189,6 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
     return () => observer.disconnect();
   }, [regularResult?.hasMore, isLoading, isDateFiltered, allItems.length]);
 
-  const getRankIcon = (rank: number) => {
-    if (rank === 1) return <Trophy className="w-4 h-4 text-yellow-500" />;
-    if (rank === 2) return <Medal className="w-4 h-4 text-gray-400" />;
-    if (rank === 3) return <Award className="w-4 h-4 text-amber-600" />;
-    return null;
-  };
-
-  const getRankStyle = (rank: number) => {
-    if (rank <= 3) return "bg-surface-1/50";
-    return "";
-  };
-
   const setQuickFilter = (days: number | null) => {
     if (days === null) {
       setDateFrom("");
@@ -123,14 +208,18 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
     return diff === days;
   };
 
+  const podiumCount = Math.min(3, allItems.length);
+  const podium = allItems.slice(0, podiumCount);
+  const rest = allItems.slice(podiumCount);
+
   return (
     <div className="h-full flex flex-col">
       {/* Header */}
       <div className="flex-shrink-0 px-6 py-5 border-b border-border">
         <div className="flex items-center justify-between gap-4 mb-5">
           <div>
-            <h1 className="text-2xl font-bold">Claude Code, Codex &amp; AI Coding Leaderboard</h1>
-            <p className="text-sm text-muted mt-1">Who's spending the most on AI coding?</p>
+            <h1 className="text-2xl font-bold tracking-tight">Claude Code, Codex &amp; AI Coding Leaderboard</h1>
+            <p className="text-sm text-muted mt-1">Who's spending the most across AI coding tools?</p>
           </div>
           {onCopyCommand && (
             <button
@@ -151,34 +240,10 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
         {/* Aggregated Stats */}
         {globalStats && (
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            <div className="bg-surface-1 rounded-xl px-4 py-3 border border-border">
-              <div className="flex items-center gap-1.5 text-xs text-muted mb-1">
-                <Users className="w-3.5 h-3.5" />
-                Users
-              </div>
-              <div className="text-lg font-bold">{formatNumber(globalStats.totalUsers)}</div>
-            </div>
-            <div className="bg-surface-1 rounded-xl px-4 py-3 border border-border">
-              <div className="flex items-center gap-1.5 text-xs text-muted mb-1">
-                <DollarSign className="w-3.5 h-3.5" />
-                Total Spent
-              </div>
-              <div className="text-lg font-bold font-mono text-accent">${formatCurrency(globalStats.totalCost)}</div>
-            </div>
-            <div className="bg-surface-1 rounded-xl px-4 py-3 border border-border">
-              <div className="flex items-center gap-1.5 text-xs text-muted mb-1">
-                <Zap className="w-3.5 h-3.5" />
-                Total Tokens
-              </div>
-              <div className="text-lg font-bold font-mono">{formatNumber(globalStats.totalTokens)}</div>
-            </div>
-            <div className="bg-surface-1 rounded-xl px-4 py-3 border border-border">
-              <div className="flex items-center gap-1.5 text-xs text-muted mb-1">
-                <Trophy className="w-3.5 h-3.5" />
-                Top Spender
-              </div>
-              <div className="text-lg font-bold font-mono truncate">${formatCurrency(globalStats.topCost)}</div>
-            </div>
+            <StatCard icon={Users} label="Users" value={formatNumber(globalStats.totalUsers)} />
+            <StatCard icon={DollarSign} label="Total Spent" value={`$${formatNumber(globalStats.totalCost)}`} accent />
+            <StatCard icon={Zap} label="Total Tokens" value={formatNumber(globalStats.totalTokens)} />
+            <StatCard icon={Trophy} label="Top Spender" value={`$${formatNumber(globalStats.topCost)}`} />
           </div>
         )}
       </div>
@@ -223,7 +288,7 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
                 <option value="">All tools</option>
                 {availableTools.map((t) => (
                   <option key={t} value={t}>
-                    {t.charAt(0).toUpperCase() + t.slice(1)}
+                    {toolLabel(t)}
                   </option>
                 ))}
               </select>
@@ -285,104 +350,109 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
         </AnimatePresence>
       </div>
 
-      {/* List */}
+      {/* Body */}
       <div className="flex-1 overflow-auto">
         {allItems.length > 0 ? (
-          <div>
-            {/* Column Headers */}
-            <div className="flex items-center gap-3 px-6 py-2 text-xs text-muted border-b border-border bg-surface-1 sticky top-0">
-              <div className="w-10 text-center">#</div>
-              <div className="flex-1">User</div>
-              <div className="w-24 text-right">Cost</div>
-              <div className="w-24 text-right hidden sm:block">Tokens</div>
-              <div className="w-8" />
-            </div>
-
-            <div className="divide-y divide-border">
-              {allItems.map((submission, index) => {
-                const rank = index + 1;
-                const isCurrentUser = session?.user?.username === submission.githubUsername;
-                const rankIcon = getRankIcon(rank);
-
+          <div className="px-6 py-5">
+            {/* Podium */}
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:items-end mb-6">
+              {podium.map((submission, i) => {
+                const rank = i + 1;
+                const order = rank === 1 ? "order-1 sm:order-2" : rank === 2 ? "order-2 sm:order-1" : "order-3";
                 return (
-                  <Link
-                    key={submission.id}
-                    href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
-                    className={`flex items-center gap-3 px-6 py-3.5 hover:bg-surface-1/80 transition-all cursor-pointer group ${getRankStyle(rank)} ${isCurrentUser ? "bg-accent/10 border-l-2 border-l-accent" : ""}`}
-                  >
-                    {/* Rank */}
-                    <div className="w-10 flex-shrink-0 text-center">
-                      {rankIcon || <span className="text-sm text-muted font-mono">{rank}</span>}
-                    </div>
-
-                    {/* User */}
-                    <div className="flex items-center gap-3 flex-1 min-w-0">
-                      <Avatar
-                        src={submission.githubAvatar}
-                        githubUsername={submission.githubUsername}
-                        name={submission.githubName || submission.username}
-                        size="sm"
-                      />
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-1.5">
-                          <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
-                            {submission.githubUsername || submission.username}
-                          </span>
-                          {submission.verified ? (
-                            <div className="relative group/badge">
-                              <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />
-                              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-card border border-border rounded text-[10px] text-muted whitespace-nowrap opacity-0 group-hover/badge:opacity-100 transition-opacity pointer-events-none">
-                                GitHub verified
-                              </div>
-                            </div>
-                          ) : (
-                            <div className="relative group/badge">
-                              <span className="text-[9px] font-mono uppercase tracking-wider px-1 py-px rounded bg-muted/15 text-muted flex-shrink-0">
-                                cli
-                              </span>
-                              <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-1 px-2 py-1 bg-card border border-border rounded text-[10px] text-muted whitespace-nowrap opacity-0 group-hover/badge:opacity-100 transition-opacity pointer-events-none">
-                                Unverified CLI submission
-                              </div>
-                            </div>
-                          )}
-                        </div>
-                        {submission.githubName && submission.githubName !== submission.githubUsername && (
-                          <div className="text-xs text-muted truncate">{submission.githubName}</div>
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Cost */}
-                    <div className="w-24 text-right flex-shrink-0">
-                      <div className="text-sm font-mono font-semibold text-accent">${formatCurrency(submission.totalCost)}</div>
-                    </div>
-
-                    {/* Tokens */}
-                    <div className="w-24 text-right flex-shrink-0 hidden sm:block">
-                      <div className="text-sm font-mono text-muted">{formatNumber(submission.totalTokens)}</div>
-                    </div>
-
-                    {/* Actions */}
-                    <div className="w-8 flex-shrink-0">
-                      {isCurrentUser && (
-                        <button
-                          onClick={(e) => { e.preventDefault(); setShowShareCard(submission.id); }}
-                          className="p-1.5 text-muted hover:text-foreground hover:bg-surface-2 rounded transition-colors"
-                        >
-                          <Share2 className="w-4 h-4" />
-                        </button>
-                      )}
-                    </div>
-                  </Link>
+                  <div key={submission.id} className={order}>
+                    <PodiumCard
+                      submission={submission}
+                      rank={rank}
+                      isCurrentUser={session?.user?.username === submission.githubUsername}
+                    />
+                  </div>
                 );
               })}
-
-              {!isDateFiltered && regularResult?.hasMore && (
-                <div ref={loadMoreRef} className="py-4 text-center">
-                  <Loader2 className="w-4 h-4 animate-spin mx-auto text-muted" />
-                </div>
-              )}
             </div>
+
+            {/* Full table */}
+            {rest.length > 0 && (
+              <div className="rounded-2xl border border-border overflow-hidden">
+                <div className="flex items-center gap-3 px-4 py-2.5 text-xs text-muted bg-surface-1 border-b border-border">
+                  <div className="w-8 text-center">#</div>
+                  <div className="flex-1">User</div>
+                  <div className="hidden md:block w-44">Tools</div>
+                  <div className="w-28 text-right">Cost</div>
+                  <div className="w-24 text-right hidden sm:block">Tokens</div>
+                  <div className="w-8" />
+                </div>
+
+                <div className="divide-y divide-border-subtle">
+                  {rest.map((submission, i) => {
+                    const rank = podiumCount + i + 1;
+                    const isCurrentUser = session?.user?.username === submission.githubUsername;
+                    return (
+                      <Link
+                        key={submission.id}
+                        href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
+                        className={`flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors cursor-pointer group ${isCurrentUser ? "bg-accent/10 border-l-2 border-l-accent" : ""}`}
+                      >
+                        <div className="w-8 flex-shrink-0 text-center text-sm text-muted font-mono">{rank}</div>
+
+                        <div className="flex items-center gap-3 flex-1 min-w-0">
+                          <Avatar
+                            src={submission.githubAvatar}
+                            githubUsername={submission.githubUsername}
+                            name={submission.githubName || submission.username}
+                            size="sm"
+                          />
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-1.5">
+                              <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
+                                {submission.githubUsername || submission.username}
+                              </span>
+                              {submission.verified ? (
+                                <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />
+                              ) : (
+                                <span className="text-[9px] font-mono uppercase tracking-wider px-1 py-px rounded bg-muted/15 text-muted flex-shrink-0">cli</span>
+                              )}
+                            </div>
+                            {submission.githubName && submission.githubName !== submission.githubUsername && (
+                              <div className="text-xs text-muted truncate">{submission.githubName}</div>
+                            )}
+                          </div>
+                        </div>
+
+                        <div className="hidden md:block w-44">
+                          <ToolChips tools={submission.tools} max={3} />
+                        </div>
+
+                        <div className="w-28 text-right flex-shrink-0">
+                          <div className="text-sm font-mono font-semibold text-accent">${formatCurrency(submission.totalCost)}</div>
+                        </div>
+
+                        <div className="w-24 text-right flex-shrink-0 hidden sm:block">
+                          <div className="text-sm font-mono text-muted">{formatNumber(submission.totalTokens)}</div>
+                        </div>
+
+                        <div className="w-8 flex-shrink-0 flex justify-end">
+                          {isCurrentUser && (
+                            <button
+                              onClick={(e) => { e.preventDefault(); setShowShareCard(submission.id); }}
+                              className="p-1.5 text-muted hover:text-foreground hover:bg-surface-2 rounded transition-colors"
+                            >
+                              <Share2 className="w-4 h-4" />
+                            </button>
+                          )}
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {!isDateFiltered && regularResult?.hasMore && (
+              <div ref={loadMoreRef} className="py-6 text-center">
+                <Loader2 className="w-4 h-4 animate-spin mx-auto text-muted" />
+              </div>
+            )}
           </div>
         ) : isLoading ? (
           <div className="flex items-center justify-center py-16">

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,10 +6,34 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatNumber(num: number): string {
+  if (num >= 1e12) return `${(num / 1e12).toFixed(1)}T`;
   if (num >= 1e9) return `${(num / 1e9).toFixed(1)}B`;
   if (num >= 1e6) return `${(num / 1e6).toFixed(1)}M`;
   if (num >= 1e3) return `${(num / 1e3).toFixed(1)}K`;
   return num.toLocaleString();
+}
+
+// Friendly display labels for ccusage tool/agent keys.
+const TOOL_LABELS: Record<string, string> = {
+  claude: "Claude",
+  codex: "Codex",
+  gemini: "Gemini",
+  copilot: "Copilot",
+  opencode: "OpenCode",
+  openclaw: "OpenClaw",
+  amp: "Amp",
+  droid: "Droid",
+  goose: "Goose",
+  qwen: "Qwen",
+  kimi: "Kimi",
+  hermes: "Hermes",
+  pi: "pi",
+  codebuff: "Codebuff",
+  kilo: "Kilo",
+};
+
+export function toolLabel(tool: string): string {
+  return TOOL_LABELS[tool.toLowerCase()] ?? tool.charAt(0).toUpperCase() + tool.slice(1);
 }
 
 export function formatCurrency(num: number): string {


### PR DESCRIPTION
Bolder UI revamp on top of v2 multi-tool support (reviewed locally before push).

- **Refreshed flat dark theme** (`#0a0a0b`, higher contrast); removed every decorative gradient (mesh, rank badges, text fills, avatar fallbacks → solid colors)
- **Top-3 podium** — #1 elevated + accent-bordered, #2/#3 flanking, stacks on mobile
- **Tool chips** on podium + table rows so multi-tool usage is visible at a glance (e.g. Claude · Codex · Gemini)
- **Fixed stat formatting** — tokens now roll to **T** (`2.3T`), cost compacted (`$2.1M`, `$56.7K`)
- **Full leaderboard** (rank 4+) in a bordered card with a Tools column
- Registered surface/accent/border tokens in `@theme`

Historical `submissions.tools` were backfilled from `models_used` so chips populate across the existing leaderboard.

`pnpm build` green · `pnpm test` 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)