### PR TITLE
SEO: SSR homepage leaderboard + per-tool landing pages + FAQ schema

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Upload, Merge, X, Terminal, Copy, Check } from "lucide-react";
+import FileUpload from "@/components/FileUpload";
+import Leaderboard from "@/components/Leaderboard";
+import UpdatesModal from "@/components/UpdatesModal";
+import NavBar from "@/components/NavBar";
+import { useSession } from "next-auth/react";
+import { useCheckClaimableSubmissions, useClaimAndMergeSubmissions } from "@/lib/data/hooks/useSubmissions";
+import type { Submission, GlobalStats } from "@/lib/data/types";
+
+interface HomeClientProps {
+  initialItems: Submission[];
+  initialStats?: GlobalStats;
+}
+
+export default function HomeClient({ initialItems, initialStats }: HomeClientProps) {
+  const [showUploadModal, setShowUploadModal] = useState(false);
+  const [showUpdatesModal, setShowUpdatesModal] = useState(false);
+  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
+  const [showMergeBanner, setShowMergeBanner] = useState(true);
+  const [merging, setMerging] = useState(false);
+
+  const { data: session } = useSession();
+  const { data: claimStatus } = useCheckClaimableSubmissions(
+    session?.user?.username || undefined
+  );
+  const { mutate: claimAndMerge } = useClaimAndMergeSubmissions();
+
+  const copyCommand = () => {
+    navigator.clipboard.writeText("npx viberank-cli");
+    setCopiedToClipboard(true);
+    setTimeout(() => setCopiedToClipboard(false), 2000);
+  };
+
+  const handleClaimAndMerge = async () => {
+    if (!session?.user?.username) return;
+
+    setMerging(true);
+    try {
+      await claimAndMerge();
+      setShowMergeBanner(false);
+      window.location.reload();
+    } catch (error) {
+      console.error("Failed to process:", error);
+      alert("Failed to process submissions. Please try again.");
+    } finally {
+      setMerging(false);
+    }
+  };
+
+  return (
+    <div className="h-screen flex flex-col overflow-hidden bg-background">
+      {/* Navigation */}
+      <NavBar
+        onUploadClick={() => setShowUploadModal(true)}
+        onUpdatesClick={() => setShowUpdatesModal(true)}
+      />
+
+      {/* Claim/Merge Banner */}
+      <AnimatePresence>
+        {showMergeBanner && claimStatus?.actionNeeded && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            className="flex-shrink-0 bg-accent/10 border-b border-accent/20 px-4 py-2 mt-14 md:mt-16"
+          >
+            <div className="max-w-6xl mx-auto flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2 text-sm">
+                <Merge className="w-4 h-4 text-accent" />
+                <span>{claimStatus.actionText}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleClaimAndMerge}
+                  disabled={merging}
+                  className="px-3 py-1 bg-accent text-white text-xs rounded font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
+                >
+                  {merging ? "..." : claimStatus.actionNeeded === "claim" ? "Verify" : "Merge"}
+                </button>
+                <button onClick={() => setShowMergeBanner(false)} className="text-muted hover:text-foreground">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Main Content */}
+      <main className={`flex-1 flex flex-col min-h-0 ${!(showMergeBanner && claimStatus?.actionNeeded) ? 'pt-14' : ''}`}>
+        <div className="flex-1 min-h-0">
+          <Leaderboard
+            onCopyCommand={copyCommand}
+            copiedToClipboard={copiedToClipboard}
+            initialItems={initialItems}
+            initialStats={initialStats}
+          />
+        </div>
+      </main>
+
+      {/* Upload Modal */}
+      <AnimatePresence>
+        {showUploadModal && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          >
+            <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setShowUploadModal(false)} />
+            <motion.div
+              initial={{ opacity: 0, scale: 0.95, y: 10 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.95, y: 10 }}
+              className="relative bg-card border border-border rounded-lg shadow-xl max-w-sm w-full"
+            >
+              <div className="px-4 py-3 flex items-center justify-between border-b border-border">
+                <h3 className="font-medium">Submit Stats</h3>
+                <button onClick={() => setShowUploadModal(false)} className="p-1 text-muted hover:text-foreground rounded hover:bg-surface-2">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="p-4 space-y-4">
+                {/* CLI option */}
+                <div className="p-3 rounded-lg bg-accent/5 border border-accent/20">
+                  <div className="flex items-center justify-between mb-2">
+                    <div className="flex items-center gap-2 text-sm">
+                      <Terminal className="w-4 h-4 text-accent" />
+                      <span className="font-medium">CLI</span>
+                    </div>
+                    <span className="text-[10px] px-1.5 py-0.5 bg-accent/20 text-accent rounded">Recommended</span>
+                  </div>
+                  <button
+                    onClick={copyCommand}
+                    className="w-full flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border hover:border-accent/50 transition-colors"
+                  >
+                    <code className="text-sm font-mono text-accent">npx viberank-cli</code>
+                    {copiedToClipboard ? (
+                      <Check className="w-4 h-4 text-green-500" />
+                    ) : (
+                      <Copy className="w-4 h-4 text-muted" />
+                    )}
+                  </button>
+                </div>
+
+                {/* Divider */}
+                <div className="flex items-center gap-3">
+                  <div className="flex-1 h-px bg-border" />
+                  <span className="text-xs text-muted">or</span>
+                  <div className="flex-1 h-px bg-border" />
+                </div>
+
+                {/* Upload option */}
+                <div>
+                  <div className="flex items-center gap-2 mb-2 text-sm">
+                    <Upload className="w-4 h-4 text-muted" />
+                    <span className="font-medium">Upload cc.json</span>
+                  </div>
+                  <FileUpload onSuccess={() => setShowUploadModal(false)} />
+                </div>
+              </div>
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <UpdatesModal isOpen={showUpdatesModal} onClose={() => setShowUpdatesModal(false)} />
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,163 +1,29 @@
-"use client";
+import { getServerDataLayer } from "@/lib/data";
+import HomeClient from "./HomeClient";
+import type { Submission, GlobalStats } from "@/lib/data/types";
 
-import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
-import { Upload, Github, Merge, X, Terminal, Copy, Check } from "lucide-react";
-import FileUpload from "@/components/FileUpload";
-import Leaderboard from "@/components/Leaderboard";
-import UpdatesModal from "@/components/UpdatesModal";
-import NavBar from "@/components/NavBar";
-import { useSession } from "next-auth/react";
-import { useCheckClaimableSubmissions, useClaimAndMergeSubmissions } from "@/lib/data/hooks/useSubmissions";
+// Refresh the server-rendered snapshot every 5 min; the client hooks fetch
+// live data on mount regardless, so this only governs the SEO/first-paint HTML.
+export const revalidate = 300;
 
-export default function Home() {
-  const [showUploadModal, setShowUploadModal] = useState(false);
-  const [showUpdatesModal, setShowUpdatesModal] = useState(false);
-  const [copiedToClipboard, setCopiedToClipboard] = useState(false);
-  const [showMergeBanner, setShowMergeBanner] = useState(true);
-  const [merging, setMerging] = useState(false);
+// Fetch the first leaderboard page + global stats on the server so the
+// leaderboard renders in the initial HTML (SEO + no first-paint spinner).
+// The client hooks take over for filtering, sorting and infinite scroll.
+export default async function Home() {
+  let initialItems: Submission[] = [];
+  let initialStats: GlobalStats | undefined;
 
-  const { data: session } = useSession();
-  const { data: claimStatus } = useCheckClaimableSubmissions(
-    session?.user?.username || undefined
-  );
-  const { mutate: claimAndMerge } = useClaimAndMergeSubmissions();
+  try {
+    const dataLayer = await getServerDataLayer();
+    const [lb, stats] = await Promise.all([
+      dataLayer.submissions.getLeaderboard({ sortBy: "cost", page: 0, pageSize: 25 }).catch(() => null),
+      dataLayer.stats.getGlobalStats().catch(() => null),
+    ]);
+    initialItems = lb?.items ?? [];
+    initialStats = stats ?? undefined;
+  } catch {
+    // Fall back to client-side fetch if the server read fails.
+  }
 
-  const copyCommand = () => {
-    navigator.clipboard.writeText("npx viberank-cli");
-    setCopiedToClipboard(true);
-    setTimeout(() => setCopiedToClipboard(false), 2000);
-  };
-
-  const handleClaimAndMerge = async () => {
-    if (!session?.user?.username) return;
-
-    setMerging(true);
-    try {
-      await claimAndMerge();
-      setShowMergeBanner(false);
-      window.location.reload();
-    } catch (error) {
-      console.error("Failed to process:", error);
-      alert("Failed to process submissions. Please try again.");
-    } finally {
-      setMerging(false);
-    }
-  };
-
-  return (
-    <div className="h-screen flex flex-col overflow-hidden bg-background">
-      {/* Navigation */}
-      <NavBar
-        onUploadClick={() => setShowUploadModal(true)}
-        onUpdatesClick={() => setShowUpdatesModal(true)}
-      />
-
-      {/* Claim/Merge Banner */}
-      <AnimatePresence>
-        {showMergeBanner && claimStatus?.actionNeeded && (
-          <motion.div
-            initial={{ opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: "auto" }}
-            exit={{ opacity: 0, height: 0 }}
-            className="flex-shrink-0 bg-accent/10 border-b border-accent/20 px-4 py-2 mt-14 md:mt-16"
-          >
-            <div className="max-w-6xl mx-auto flex items-center justify-between gap-3">
-              <div className="flex items-center gap-2 text-sm">
-                <Merge className="w-4 h-4 text-accent" />
-                <span>{claimStatus.actionText}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  onClick={handleClaimAndMerge}
-                  disabled={merging}
-                  className="px-3 py-1 bg-accent text-white text-xs rounded font-medium hover:bg-accent-hover transition-colors disabled:opacity-50"
-                >
-                  {merging ? "..." : claimStatus.actionNeeded === "claim" ? "Verify" : "Merge"}
-                </button>
-                <button onClick={() => setShowMergeBanner(false)} className="text-muted hover:text-foreground">
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {/* Main Content */}
-      <main className={`flex-1 flex flex-col min-h-0 ${!(showMergeBanner && claimStatus?.actionNeeded) ? 'pt-14' : ''}`}>
-        <div className="flex-1 min-h-0">
-          <Leaderboard onCopyCommand={copyCommand} copiedToClipboard={copiedToClipboard} />
-        </div>
-      </main>
-
-      {/* Upload Modal */}
-      <AnimatePresence>
-        {showUploadModal && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          >
-            <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setShowUploadModal(false)} />
-            <motion.div
-              initial={{ opacity: 0, scale: 0.95, y: 10 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.95, y: 10 }}
-              className="relative bg-card border border-border rounded-lg shadow-xl max-w-sm w-full"
-            >
-              <div className="px-4 py-3 flex items-center justify-between border-b border-border">
-                <h3 className="font-medium">Submit Stats</h3>
-                <button onClick={() => setShowUploadModal(false)} className="p-1 text-muted hover:text-foreground rounded hover:bg-surface-2">
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-              <div className="p-4 space-y-4">
-                {/* CLI option */}
-                <div className="p-3 rounded-lg bg-accent/5 border border-accent/20">
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2 text-sm">
-                      <Terminal className="w-4 h-4 text-accent" />
-                      <span className="font-medium">CLI</span>
-                    </div>
-                    <span className="text-[10px] px-1.5 py-0.5 bg-accent/20 text-accent rounded">Recommended</span>
-                  </div>
-                  <button
-                    onClick={copyCommand}
-                    className="w-full flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border hover:border-accent/50 transition-colors"
-                  >
-                    <code className="text-sm font-mono text-accent">npx viberank-cli</code>
-                    {copiedToClipboard ? (
-                      <Check className="w-4 h-4 text-green-500" />
-                    ) : (
-                      <Copy className="w-4 h-4 text-muted" />
-                    )}
-                  </button>
-                </div>
-
-                {/* Divider */}
-                <div className="flex items-center gap-3">
-                  <div className="flex-1 h-px bg-border" />
-                  <span className="text-xs text-muted">or</span>
-                  <div className="flex-1 h-px bg-border" />
-                </div>
-
-                {/* Upload option */}
-                <div>
-                  <div className="flex items-center gap-2 mb-2 text-sm">
-                    <Upload className="w-4 h-4 text-muted" />
-                    <span className="font-medium">Upload cc.json</span>
-                  </div>
-                  <FileUpload onSuccess={() => setShowUploadModal(false)} />
-                </div>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      <UpdatesModal isOpen={showUpdatesModal} onClose={() => setShowUpdatesModal(false)} />
-    </div>
-  );
+  return <HomeClient initialItems={initialItems} initialStats={initialStats} />;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,10 +1,19 @@
 import type { MetadataRoute } from "next";
 import { createClient } from "@supabase/supabase-js";
+import { FEATURED_TOOLS } from "@/lib/utils";
 
 const SITE = "https://www.viberank.app";
 
+const toolEntries: MetadataRoute.Sitemap = FEATURED_TOOLS.map((t) => ({
+  url: `${SITE}/tool/${t.key}`,
+  lastModified: new Date(),
+  changeFrequency: "daily" as const,
+  priority: 0.8,
+}));
+
 const staticEntries: MetadataRoute.Sitemap = [
   { url: SITE, lastModified: new Date(), changeFrequency: "daily", priority: 1 },
+  ...toolEntries,
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
   { url: `${SITE}/blog/mcp-servers-guide`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
   { url: `${SITE}/blog/cursor-vs-claude-code-vs-copilot`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -1,0 +1,172 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, BadgeCheck } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import { formatNumber, formatCurrency, toolLabel, toolBlurb, FEATURED_TOOLS } from "@/lib/utils";
+
+interface ToolParams {
+  params: Promise<{ tool: string }>;
+}
+
+const SITE = "https://www.viberank.app";
+
+// Regenerate per-tool boards hourly.
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return FEATURED_TOOLS.map((t) => ({ tool: t.key }));
+}
+
+export async function generateMetadata({ params }: ToolParams): Promise<Metadata> {
+  const { tool: raw } = await params;
+  const tool = decodeURIComponent(raw).toLowerCase();
+  const label = toolLabel(tool);
+  const title = `${label} Usage Leaderboard — Track ${label} Spend & Tokens | Viberank`;
+  const description = `See who's using ${label} (${toolBlurb(tool)}) the most. Ranked by cost and tokens from real ccusage data. Submit your own with npx viberank-cli.`;
+  const canonical = `${SITE}/tool/${encodeURIComponent(tool)}`;
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: { title, description, url: canonical, siteName: "Viberank", type: "website" },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function ToolPage({ params }: ToolParams) {
+  const { tool: raw } = await params;
+  const tool = decodeURIComponent(raw).toLowerCase();
+  const label = toolLabel(tool);
+
+  let items: Awaited<ReturnType<Awaited<ReturnType<typeof getServerDataLayer>>["submissions"]["getLeaderboard"]>>["items"] = [];
+  try {
+    const dataLayer = await getServerDataLayer();
+    const lb = await dataLayer.submissions.getLeaderboard({ sortBy: "cost", page: 0, pageSize: 50, tool });
+    items = lb.items;
+  } catch {
+    // render empty state
+  }
+
+  const faqs = [
+    {
+      q: `What is the ${label} usage leaderboard?`,
+      a: `It ranks developers by how much they've spent and how many tokens they've used with ${label} (${toolBlurb(tool)}), based on real usage data exported by ccusage.`,
+    },
+    {
+      q: `How do I get on the ${label} leaderboard?`,
+      a: `Run npx viberank-cli, which reads your local ccusage data (including ${label}) and submits it. Sign in with GitHub to get a verified badge.`,
+    },
+    {
+      q: `How is ${label} usage measured?`,
+      a: `ccusage reads ${label}'s local logs and computes tokens and USD cost from model pricing. Viberank aggregates that per developer and ranks it.`,
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Leaderboard", item: SITE },
+      { "@type": "ListItem", position: 2, name: `${label} Usage Leaderboard`, item: `${SITE}/tool/${encodeURIComponent(tool)}` },
+    ],
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbLd, faqLd]) }} />
+
+      <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-50">
+        <div className="max-w-4xl mx-auto px-6">
+          <div className="flex items-center h-14">
+            <Link href="/" className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors text-sm">
+              <ArrowLeft className="w-4 h-4" />
+              Back to leaderboard
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <div className="max-w-4xl mx-auto px-6 py-10">
+        <h1 className="text-3xl font-bold tracking-tight mb-2">{label} Usage Leaderboard</h1>
+        <p className="text-muted mb-6 max-w-2xl">
+          Developers ranked by their {label} usage ({toolBlurb(tool)}) — by cost and tokens, from real{" "}
+          <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">ccusage</a>{" "}
+          data. Submit yours with <code className="font-mono text-accent">npx viberank-cli</code>.
+        </p>
+
+        {/* Browse other tools */}
+        <div className="flex flex-wrap items-center gap-2 mb-8 text-sm">
+          <span className="text-muted">Browse:</span>
+          {FEATURED_TOOLS.map((t) => (
+            <Link
+              key={t.key}
+              href={`/tool/${t.key}`}
+              className={`px-2.5 py-1 rounded-md border transition-colors ${
+                t.key === tool ? "bg-accent text-white border-accent" : "bg-surface-1 border-border text-muted hover:text-foreground"
+              }`}
+            >
+              {toolLabel(t.key)}
+            </Link>
+          ))}
+        </div>
+
+        {items.length > 0 ? (
+          <div className="rounded-2xl border border-border overflow-hidden mb-12">
+            <div className="flex items-center gap-3 px-4 py-2.5 text-xs text-muted bg-surface-1 border-b border-border">
+              <div className="w-8 text-center">#</div>
+              <div className="flex-1">User</div>
+              <div className="w-28 text-right">Cost</div>
+              <div className="w-24 text-right hidden sm:block">Tokens</div>
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {items.map((s, i) => (
+                <Link
+                  key={s.id}
+                  href={`/profile/${encodeURIComponent(s.githubUsername || s.username)}`}
+                  className="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors group"
+                >
+                  <div className="w-8 text-center text-sm text-muted font-mono">{i + 1}</div>
+                  <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                    <span className="text-sm font-medium truncate group-hover:text-accent transition-colors">
+                      {s.githubUsername || s.username}
+                    </span>
+                    {s.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+                  </div>
+                  <div className="w-28 text-right text-sm font-mono font-semibold text-accent">${formatCurrency(s.totalCost)}</div>
+                  <div className="w-24 text-right text-sm font-mono text-muted hidden sm:block">{formatNumber(s.totalTokens)}</div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-border p-10 text-center mb-12">
+            <p className="font-medium mb-1">No {label} submissions yet</p>
+            <p className="text-sm text-muted">Be the first — run <code className="font-mono text-accent">npx viberank-cli</code></p>
+          </div>
+        )}
+
+        {/* FAQ */}
+        <section>
+          <h2 className="text-xl font-bold tracking-tight mb-4">{label} leaderboard FAQ</h2>
+          <div className="space-y-3">
+            {faqs.map((f) => (
+              <div key={f.q} className="rounded-xl border border-border bg-surface-1 p-4">
+                <h3 className="font-medium mb-1.5">{f.q}</h3>
+                <p className="text-sm text-muted">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -7,16 +7,20 @@ import { useSession } from "next-auth/react";
 import Link from "next/link";
 import ShareCard from "./ShareCard";
 import Avatar from "./Avatar";
-import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
+import { formatNumber, formatCurrency, toolLabel, FEATURED_TOOLS } from "@/lib/utils";
 import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useSubmissions";
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
-import type { Submission } from "@/lib/data/types";
+import type { Submission, GlobalStats } from "@/lib/data/types";
 
 type SortBy = "cost" | "tokens";
 
 interface LeaderboardProps {
   onCopyCommand?: () => void;
   copiedToClipboard?: boolean;
+  // Server-fetched first page + stats, so the leaderboard renders in the SSR
+  // HTML (SEO + no first-paint spinner) before the client hooks take over.
+  initialItems?: Submission[];
+  initialStats?: GlobalStats;
 }
 
 // Small flat pills showing which tools a submission used.
@@ -116,7 +120,7 @@ function StatCard({ icon: Icon, label, value, accent = false }: { icon: typeof U
   );
 }
 
-export default function Leaderboard({ onCopyCommand, copiedToClipboard }: LeaderboardProps) {
+export default function Leaderboard({ onCopyCommand, copiedToClipboard, initialItems, initialStats }: LeaderboardProps) {
   const [sortBy, setSortBy] = useState<SortBy>("cost");
   const [tool, setTool] = useState<string | null>(null);
   const [showShareCard, setShowShareCard] = useState<string | null>(null);
@@ -124,10 +128,12 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
   const [dateTo, setDateTo] = useState<string>("");
   const [showFilters, setShowFilters] = useState(false);
   const [page, setPage] = useState(0);
-  const [allItems, setAllItems] = useState<Submission[]>([]);
+  const [allItems, setAllItems] = useState<Submission[]>(initialItems ?? []);
   const { data: session } = useSession();
   const loadMoreRef = useRef<HTMLDivElement>(null);
-  const { data: globalStats } = useGlobalStats();
+  const firstRender = useRef(true);
+  const { data: liveStats } = useGlobalStats();
+  const globalStats = liveStats ?? initialStats;
 
   const ITEMS_PER_PAGE = 25;
   const isDateFiltered = dateFrom && dateTo;
@@ -150,6 +156,12 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
     : [];
 
   useEffect(() => {
+    // Keep the server-seeded items on first render; only reset when a filter
+    // actually changes (avoids clearing the SSR'd rows during hydration).
+    if (firstRender.current) {
+      firstRender.current = false;
+      return;
+    }
     setAllItems([]);
     setPage(0);
   }, [sortBy, dateFrom, dateTo, tool]);
@@ -220,6 +232,15 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard }: Leader
           <div>
             <h1 className="text-2xl font-bold tracking-tight">Claude Code, Codex &amp; AI Coding Leaderboard</h1>
             <p className="text-sm text-muted mt-1">Who's spending the most across AI coding tools?</p>
+            <div className="hidden sm:flex flex-wrap items-center gap-x-2 gap-y-1 mt-2 text-xs text-muted">
+              <span>Per-tool boards:</span>
+              {FEATURED_TOOLS.map((t, i) => (
+                <span key={t.key} className="flex items-center gap-2">
+                  <Link href={`/tool/${t.key}`} className="hover:text-accent transition-colors">{toolLabel(t.key)}</Link>
+                  {i < FEATURED_TOOLS.length - 1 && <span className="text-border">·</span>}
+                </span>
+              ))}
+            </div>
           </div>
           {onCopyCommand && (
             <button

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,20 @@ export function toolLabel(tool: string): string {
   return TOOL_LABELS[tool.toLowerCase()] ?? tool.charAt(0).toUpperCase() + tool.slice(1);
 }
 
+// Tools that get their own SEO landing page (/tool/<key>). One-liners are used
+// in page copy + meta descriptions.
+export const FEATURED_TOOLS: { key: string; blurb: string }[] = [
+  { key: "claude", blurb: "Anthropic's Claude Code CLI" },
+  { key: "codex", blurb: "OpenAI's Codex CLI" },
+  { key: "gemini", blurb: "Google's Gemini CLI" },
+  { key: "copilot", blurb: "GitHub Copilot CLI" },
+  { key: "opencode", blurb: "the OpenCode agent" },
+];
+
+export function toolBlurb(tool: string): string {
+  return FEATURED_TOOLS.find((t) => t.key === tool.toLowerCase())?.blurb ?? `the ${toolLabel(tool)} CLI`;
+}
+
 export function formatCurrency(num: number): string {
   return num.toLocaleString('en-US', {
     minimumFractionDigits: 2,


### PR DESCRIPTION
The two biggest remaining wins from the list.

### 1. Homepage leaderboard is now server-rendered
Previously client-only — crawlers saw an empty board and users saw a spinner. Now `page.tsx` is a server component that fetches the first page + global stats and seeds the leaderboard, so **rows + stats are in the SSR HTML**. Client hooks still own filter/sort/infinite-scroll (interactivity lives in `HomeClient.tsx`). ISR `revalidate 300`.

### 2. Per-tool landing pages (`/tool/codex`, `/gemini`, …)
Net-new SEO surface that only exists because of v2's multi-tool data — server-rendered boards ranking developers per tool, each with:
- unique title/meta ("Codex Usage Leaderboard — …")
- **FAQPage + BreadcrumbList JSON-LD** + a visible FAQ
- cross-links between tools + back to the main board
- ISR `revalidate 3600`, prerendered for the 5 featured tools

Plus: homepage links to the per-tool boards (crawlable internal links) and the sitemap includes them.

Verified locally: homepage HTML contains leaderboard rows + `2.3T` stats; `/tool/codex` renders real filtered rankings (azamara, cjleemesotes, kaitas…) + FAQPage schema. Build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)