### PR TITLE
Full redesign: editorial layout, hero, homepage FAQ + footer (SEO verified)

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -2,13 +2,17 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Upload, Merge, X, Terminal, Copy, Check } from "lucide-react";
+import { Upload, Merge, X, Terminal, Copy, Check, Users, DollarSign, Zap, Trophy } from "lucide-react";
+import Link from "next/link";
 import FileUpload from "@/components/FileUpload";
 import Leaderboard from "@/components/Leaderboard";
 import UpdatesModal from "@/components/UpdatesModal";
 import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
 import { useSession } from "next-auth/react";
 import { useCheckClaimableSubmissions, useClaimAndMergeSubmissions } from "@/lib/data/hooks/useSubmissions";
+import { formatNumber, toolLabel, FEATURED_TOOLS } from "@/lib/utils";
+import { HOME_FAQS } from "@/lib/home-faqs";
 import type { Submission, GlobalStats } from "@/lib/data/types";
 
 interface HomeClientProps {
@@ -52,9 +56,10 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
     }
   };
 
+  const stats = initialStats;
+
   return (
-    <div className="h-screen flex flex-col overflow-hidden bg-background">
-      {/* Navigation */}
+    <div className="min-h-screen bg-background flex flex-col">
       <NavBar
         onUploadClick={() => setShowUploadModal(true)}
         onUpdatesClick={() => setShowUpdatesModal(true)}
@@ -67,7 +72,7 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
-            className="flex-shrink-0 bg-accent/10 border-b border-accent/20 px-4 py-2 mt-14 md:mt-16"
+            className="bg-accent/10 border-b border-accent/20 px-4 py-2"
           >
             <div className="max-w-6xl mx-auto flex items-center justify-between gap-3">
               <div className="flex items-center gap-2 text-sm">
@@ -91,18 +96,105 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
         )}
       </AnimatePresence>
 
-      {/* Main Content */}
-      <main className={`flex-1 flex flex-col min-h-0 ${!(showMergeBanner && claimStatus?.actionNeeded) ? 'pt-14' : ''}`}>
-        <div className="flex-1 min-h-0">
+      <main className="flex-1">
+        {/* Hero */}
+        <section className="border-b border-border">
+          <div className="max-w-6xl mx-auto px-6 pt-14 pb-10">
+            <h1 className="text-3xl sm:text-5xl font-bold tracking-tight max-w-3xl leading-[1.1]">
+              Claude Code, Codex &amp; AI Coding <span className="text-accent">Leaderboard</span>
+            </h1>
+            <p className="text-muted text-base sm:text-lg mt-4 max-w-2xl">
+              Real usage, real costs. Developers ranked by what they actually spend across AI coding
+              tools — measured from ccusage data, not vibes.
+            </p>
+
+            {/* Terminal CTA */}
+            <div className="flex flex-wrap items-center gap-3 mt-7">
+              <button
+                onClick={copyCommand}
+                className="group flex items-center gap-3 rounded-xl bg-surface-1 border border-border hover:border-accent/50 px-4 py-3 transition-colors"
+              >
+                <Terminal className="w-4 h-4 text-muted" />
+                <code className="font-mono text-accent font-medium">npx viberank-cli</code>
+                {copiedToClipboard ? (
+                  <Check className="w-4 h-4 text-success" />
+                ) : (
+                  <Copy className="w-4 h-4 text-muted group-hover:text-foreground transition-colors" />
+                )}
+              </button>
+              <button
+                onClick={() => setShowUploadModal(true)}
+                className="flex items-center gap-2 px-4 py-3 text-sm text-muted hover:text-foreground transition-colors"
+              >
+                <Upload className="w-4 h-4" />
+                or upload cc.json
+              </button>
+            </div>
+
+            {/* Stat strip */}
+            {stats && (
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-9">
+                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
+                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><Users className="w-3.5 h-3.5" />Developers</div>
+                  <div className="text-xl font-bold font-mono">{formatNumber(stats.totalUsers)}</div>
+                </div>
+                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
+                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><DollarSign className="w-3.5 h-3.5" />Total spent</div>
+                  <div className="text-xl font-bold font-mono text-accent">${formatNumber(stats.totalCost)}</div>
+                </div>
+                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
+                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><Zap className="w-3.5 h-3.5" />Tokens</div>
+                  <div className="text-xl font-bold font-mono">{formatNumber(stats.totalTokens)}</div>
+                </div>
+                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
+                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><Trophy className="w-3.5 h-3.5" />Top spender</div>
+                  <div className="text-xl font-bold font-mono">${formatNumber(stats.topCost)}</div>
+                </div>
+              </div>
+            )}
+
+            {/* Per-tool boards */}
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 mt-6 text-sm text-muted">
+              <span>Per-tool boards:</span>
+              {FEATURED_TOOLS.map((t) => (
+                <Link
+                  key={t.key}
+                  href={`/tool/${t.key}`}
+                  className="px-2.5 py-1 rounded-md bg-surface-1 border border-border hover:text-accent hover:border-accent/40 transition-colors"
+                >
+                  {toolLabel(t.key)}
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Leaderboard */}
+        <section className="max-w-6xl mx-auto px-6 pb-16">
           <Leaderboard
-            onCopyCommand={copyCommand}
-            copiedToClipboard={copiedToClipboard}
             initialItems={initialItems}
             initialStats={initialStats}
             initialHasMore={initialHasMore}
           />
-        </div>
+        </section>
+
+        {/* FAQ */}
+        <section className="border-t border-border bg-surface-1/50">
+          <div className="max-w-6xl mx-auto px-6 py-14">
+            <h2 className="text-2xl font-bold tracking-tight mb-6">Frequently asked questions</h2>
+            <div className="grid gap-4 md:grid-cols-2">
+              {HOME_FAQS.map((f) => (
+                <div key={f.q} className="rounded-2xl border border-border bg-surface-1 p-5">
+                  <h3 className="font-semibold mb-2">{f.q}</h3>
+                  <p className="text-sm text-muted leading-relaxed">{f.a}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
       </main>
+
+      <Footer />
 
       {/* Upload Modal */}
       <AnimatePresence>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -54,7 +54,7 @@ export default function AdminPage() {
         onUploadClick={() => {}}
         onUpdatesClick={() => {}}
       />
-      <div className="max-w-5xl mx-auto px-6 py-8 pt-20">
+      <div className="max-w-5xl mx-auto px-6 py-8">
         <div className="mb-6">
           <h1 className="text-2xl font-semibold mb-1">Admin Dashboard</h1>
           <p className="text-sm text-muted">Review and manage flagged submissions</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { getServerDataLayer } from "@/lib/data";
 import HomeClient from "./HomeClient";
+import { HOME_FAQS } from "@/lib/home-faqs";
 import type { Submission, GlobalStats } from "@/lib/data/types";
 
 // Refresh the server-rendered snapshot every 5 min; the client hooks fetch
@@ -27,5 +28,21 @@ export default async function Home() {
     // Fall back to client-side fetch if the server read fails.
   }
 
-  return <HomeClient initialItems={initialItems} initialStats={initialStats} initialHasMore={initialHasMore} />;
+  // FAQPage schema for the homepage FAQ section (content shared via lib/home-faqs).
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: HOME_FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+      <HomeClient initialItems={initialItems} initialStats={initialStats} initialHasMore={initialHasMore} />
+    </>
+  );
 }

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -14,6 +14,7 @@ import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "./getProfile";
 import UsageChart from "./UsageChart";
+import Footer from "@/components/Footer";
 
 interface ProfileParams {
   params: Promise<{ username: string }>;
@@ -237,6 +238,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
           </div>
         </div>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft, BadgeCheck } from "lucide-react";
 import { getServerDataLayer } from "@/lib/data";
+import Footer from "@/components/Footer";
 import { formatNumber, formatCurrency, toolLabel, toolBlurb, FEATURED_TOOLS } from "@/lib/utils";
 
 interface ToolParams {
@@ -167,6 +168,7 @@ export default async function ToolPage({ params }: ToolParams) {
           </div>
         </section>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link";
+import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
+
+const RESOURCES = [
+  { name: "Blog", href: "/blog" },
+  { name: "Codex vs Claude Code vs Gemini", href: "/blog/codex-vs-claude-code-vs-gemini-cli" },
+  { name: "What Claude Code costs", href: "/blog/how-much-does-claude-code-cost" },
+  { name: "Cut your AI coding bill", href: "/blog/reduce-ai-coding-costs" },
+];
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-border bg-surface-1">
+      <div className="max-w-6xl mx-auto px-6 py-12">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
+          <div className="col-span-2 md:col-span-1">
+            <Link href="/" className="flex items-center gap-2 mb-3">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="text-accent">
+                <rect x="3" y="14" width="5" height="7" rx="1" fill="currentColor" opacity="0.5" />
+                <rect x="9.5" y="8" width="5" height="13" rx="1" fill="currentColor" opacity="0.75" />
+                <rect x="16" y="3" width="5" height="18" rx="1" fill="currentColor" />
+              </svg>
+              <span className="font-semibold">viberank</span>
+            </Link>
+            <p className="text-sm text-muted leading-relaxed">
+              The leaderboard for AI coding usage. Real costs, real tokens, from real ccusage data.
+            </p>
+          </div>
+
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Leaderboards</h3>
+            <ul className="space-y-2 text-sm">
+              <li><Link href="/" className="text-foreground/80 hover:text-accent transition-colors">All tools</Link></li>
+              {FEATURED_TOOLS.map((t) => (
+                <li key={t.key}>
+                  <Link href={`/tool/${t.key}`} className="text-foreground/80 hover:text-accent transition-colors">
+                    {toolLabel(t.key)}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Resources</h3>
+            <ul className="space-y-2 text-sm">
+              {RESOURCES.map((r) => (
+                <li key={r.href}>
+                  <Link href={r.href} className="text-foreground/80 hover:text-accent transition-colors">
+                    {r.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Community</h3>
+            <ul className="space-y-2 text-sm">
+              <li>
+                <a href="https://github.com/sculptdotfun/viberank" target="_blank" rel="noopener noreferrer" className="text-foreground/80 hover:text-accent transition-colors">
+                  GitHub
+                </a>
+              </li>
+              <li>
+                <a href="https://www.npmjs.com/package/viberank-cli" target="_blank" rel="noopener noreferrer" className="text-foreground/80 hover:text-accent transition-colors">
+                  viberank-cli on npm
+                </a>
+              </li>
+              <li>
+                <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer" className="text-foreground/80 hover:text-accent transition-colors">
+                  ccusage
+                </a>
+              </li>
+              <li>
+                <a href="https://github.com/sculptdotfun/viberank/issues" target="_blank" rel="noopener noreferrer" className="text-foreground/80 hover:text-accent transition-colors">
+                  Report an issue
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+
+        <div className="flex flex-col sm:flex-row items-center justify-between gap-3 mt-10 pt-6 border-t border-border-subtle text-xs text-muted">
+          <span>© {new Date().getFullYear()} viberank · MIT licensed</span>
+          <code className="font-mono text-accent">npx viberank-cli</code>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Trophy, Medal, Award, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2, Terminal, Copy, Check, Users } from "lucide-react";
+import { Trophy, Medal, Award, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import ShareCard from "./ShareCard";
 import Avatar from "./Avatar";
-import { formatNumber, formatCurrency, toolLabel, FEATURED_TOOLS } from "@/lib/utils";
+import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
 import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useSubmissions";
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
 import type { Submission, GlobalStats } from "@/lib/data/types";
@@ -15,30 +15,10 @@ import type { Submission, GlobalStats } from "@/lib/data/types";
 type SortBy = "cost" | "tokens";
 
 interface LeaderboardProps {
-  onCopyCommand?: () => void;
-  copiedToClipboard?: boolean;
-  // Server-fetched first page + stats, so the leaderboard renders in the SSR
-  // HTML (SEO + no first-paint spinner) before the client hooks take over.
+  // Server-fetched first page + stats so the board renders in the SSR HTML.
   initialItems?: Submission[];
   initialStats?: GlobalStats;
   initialHasMore?: boolean;
-}
-
-// Flat placeholder rows shown while a filter/sort change is fetching.
-function SkeletonRows({ count = 8 }: { count?: number }) {
-  return (
-    <div className="px-6 py-5 space-y-3" aria-hidden>
-      {Array.from({ length: count }).map((_, i) => (
-        <div key={i} className="flex items-center gap-3 rounded-xl border border-border-subtle bg-surface-1 px-4 py-3 animate-pulse">
-          <div className="w-8 h-4 rounded bg-surface-3" />
-          <div className="w-8 h-8 rounded-full bg-surface-3" />
-          <div className="flex-1 h-4 rounded bg-surface-3 max-w-[180px]" />
-          <div className="w-24 h-4 rounded bg-surface-3" />
-          <div className="w-20 h-4 rounded bg-surface-3 hidden sm:block" />
-        </div>
-      ))}
-    </div>
-  );
 }
 
 // Small flat pills showing which tools a submission used.
@@ -126,19 +106,24 @@ function PodiumCard({
   );
 }
 
-function StatCard({ icon: Icon, label, value, accent = false }: { icon: typeof Users; label: string; value: string; accent?: boolean }) {
+// Flat placeholder rows shown while a filter/sort change is fetching.
+function SkeletonRows({ count = 8 }: { count?: number }) {
   return (
-    <div className="bg-surface-1 rounded-xl px-4 py-3.5 border border-border">
-      <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5">
-        <Icon className="w-3.5 h-3.5" />
-        {label}
-      </div>
-      <div className={`text-xl font-bold font-mono truncate ${accent ? "text-accent" : ""}`}>{value}</div>
+    <div className="py-5 space-y-3" aria-hidden>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3 rounded-xl border border-border-subtle bg-surface-1 px-4 py-3 animate-pulse">
+          <div className="w-8 h-4 rounded bg-surface-3" />
+          <div className="w-8 h-8 rounded-full bg-surface-3" />
+          <div className="flex-1 h-4 rounded bg-surface-3 max-w-[180px]" />
+          <div className="w-24 h-4 rounded bg-surface-3" />
+          <div className="w-20 h-4 rounded bg-surface-3 hidden sm:block" />
+        </div>
+      ))}
     </div>
   );
 }
 
-export default function Leaderboard({ onCopyCommand, copiedToClipboard, initialItems, initialStats, initialHasMore }: LeaderboardProps) {
+export default function Leaderboard({ initialItems, initialStats, initialHasMore }: LeaderboardProps) {
   const [sortBy, setSortBy] = useState<SortBy>("cost");
   const [tool, setTool] = useState<string | null>(null);
   const [showShareCard, setShowShareCard] = useState<string | null>(null);
@@ -254,52 +239,9 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard, initialI
   const rest = allItems.slice(podiumCount);
 
   return (
-    <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="flex-shrink-0 px-6 py-5 border-b border-border">
-        <div className="flex items-center justify-between gap-4 mb-5">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">Claude Code, Codex &amp; AI Coding Leaderboard</h1>
-            <p className="text-sm text-muted mt-1">Who's spending the most across AI coding tools?</p>
-            <div className="hidden sm:flex flex-wrap items-center gap-x-2 gap-y-1 mt-2 text-xs text-muted">
-              <span>Per-tool boards:</span>
-              {FEATURED_TOOLS.map((t, i) => (
-                <span key={t.key} className="flex items-center gap-2">
-                  <Link href={`/tool/${t.key}`} className="hover:text-accent transition-colors">{toolLabel(t.key)}</Link>
-                  {i < FEATURED_TOOLS.length - 1 && <span className="text-border">·</span>}
-                </span>
-              ))}
-            </div>
-          </div>
-          {onCopyCommand && (
-            <button
-              onClick={onCopyCommand}
-              className="hidden sm:flex items-center gap-2 px-4 py-2.5 text-sm bg-surface-1 hover:bg-surface-2 border border-border rounded-lg transition-colors"
-            >
-              <Terminal className="w-4 h-4 text-muted" />
-              <code className="font-mono text-accent font-medium">npx viberank-cli</code>
-              {copiedToClipboard ? (
-                <Check className="w-4 h-4 text-green-500" />
-              ) : (
-                <Copy className="w-4 h-4 text-muted" />
-              )}
-            </button>
-          )}
-        </div>
-
-        {/* Aggregated Stats */}
-        {globalStats && (
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            <StatCard icon={Users} label="Users" value={formatNumber(globalStats.totalUsers)} />
-            <StatCard icon={DollarSign} label="Total Spent" value={`$${formatNumber(globalStats.totalCost)}`} accent />
-            <StatCard icon={Zap} label="Total Tokens" value={formatNumber(globalStats.totalTokens)} />
-            <StatCard icon={Trophy} label="Top Spender" value={`$${formatNumber(globalStats.topCost)}`} />
-          </div>
-        )}
-      </div>
-
-      {/* Filters */}
-      <div className="flex-shrink-0 px-6 py-3 border-b border-border bg-surface-1">
+    <div>
+      {/* Filter bar — sticky under the nav while scrolling the board */}
+      <div className="sticky top-14 z-40 -mx-6 px-6 py-3 bg-background/95 backdrop-blur border-y border-border mb-6">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-1.5">
             {[
@@ -400,121 +342,119 @@ export default function Leaderboard({ onCopyCommand, copiedToClipboard, initialI
         </AnimatePresence>
       </div>
 
-      {/* Body */}
-      <div className="flex-1 overflow-auto">
-        {allItems.length > 0 ? (
-          <div className="px-6 py-5">
-            {/* Podium */}
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:items-end mb-6">
-              {podium.map((submission, i) => {
-                const rank = i + 1;
-                const order = rank === 1 ? "order-1 sm:order-2" : rank === 2 ? "order-2 sm:order-1" : "order-3";
-                return (
-                  <div key={submission.id} className={order}>
-                    <PodiumCard
-                      submission={submission}
-                      rank={rank}
-                      isCurrentUser={session?.user?.username === submission.githubUsername}
-                    />
-                  </div>
-                );
-              })}
-            </div>
-
-            {/* Full table */}
-            {rest.length > 0 && (
-              <div className="rounded-2xl border border-border overflow-hidden">
-                <div className="flex items-center gap-3 px-4 py-2.5 text-xs text-muted bg-surface-1 border-b border-border">
-                  <div className="w-8 text-center">#</div>
-                  <div className="flex-1">User</div>
-                  <div className="hidden md:block w-44">Tools</div>
-                  <div className="w-28 text-right">Cost</div>
-                  <div className="w-24 text-right hidden sm:block">Tokens</div>
-                  <div className="w-8" />
+      {/* Board */}
+      {allItems.length > 0 ? (
+        <div>
+          {/* Podium */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:items-end mb-6">
+            {podium.map((submission, i) => {
+              const rank = i + 1;
+              const order = rank === 1 ? "order-1 sm:order-2" : rank === 2 ? "order-2 sm:order-1" : "order-3";
+              return (
+                <div key={submission.id} className={order}>
+                  <PodiumCard
+                    submission={submission}
+                    rank={rank}
+                    isCurrentUser={session?.user?.username === submission.githubUsername}
+                  />
                 </div>
+              );
+            })}
+          </div>
 
-                <div className="divide-y divide-border-subtle">
-                  {rest.map((submission, i) => {
-                    const rank = podiumCount + i + 1;
-                    const isCurrentUser = session?.user?.username === submission.githubUsername;
-                    return (
-                      <Link
-                        key={submission.id}
-                        href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
-                        className={`flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors cursor-pointer group ${isCurrentUser ? "bg-accent/10 border-l-2 border-l-accent" : ""}`}
-                      >
-                        <div className="w-8 flex-shrink-0 text-center text-sm text-muted font-mono">{rank}</div>
+          {/* Full table */}
+          {rest.length > 0 && (
+            <div className="rounded-2xl border border-border overflow-hidden">
+              <div className="flex items-center gap-3 px-4 py-2.5 text-xs text-muted bg-surface-1 border-b border-border">
+                <div className="w-8 text-center">#</div>
+                <div className="flex-1">User</div>
+                <div className="hidden md:block w-44">Tools</div>
+                <div className="w-28 text-right">Cost</div>
+                <div className="w-24 text-right hidden sm:block">Tokens</div>
+                <div className="w-8" />
+              </div>
 
-                        <div className="flex items-center gap-3 flex-1 min-w-0">
-                          <Avatar
-                            src={submission.githubAvatar}
-                            githubUsername={submission.githubUsername}
-                            name={submission.githubName || submission.username}
-                            size="sm"
-                          />
-                          <div className="min-w-0">
-                            <div className="flex items-center gap-1.5">
-                              <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
-                                {submission.githubUsername || submission.username}
-                              </span>
-                              {submission.verified ? (
-                                <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />
-                              ) : (
-                                <span className="text-[9px] font-mono uppercase tracking-wider px-1 py-px rounded bg-muted/15 text-muted flex-shrink-0">cli</span>
-                              )}
-                            </div>
-                            {submission.githubName && submission.githubName !== submission.githubUsername && (
-                              <div className="text-xs text-muted truncate">{submission.githubName}</div>
+              <div className="divide-y divide-border-subtle">
+                {rest.map((submission, i) => {
+                  const rank = podiumCount + i + 1;
+                  const isCurrentUser = session?.user?.username === submission.githubUsername;
+                  return (
+                    <Link
+                      key={submission.id}
+                      href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
+                      className={`flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors cursor-pointer group ${isCurrentUser ? "bg-accent/10 border-l-2 border-l-accent" : ""}`}
+                    >
+                      <div className="w-8 flex-shrink-0 text-center text-sm text-muted font-mono">{rank}</div>
+
+                      <div className="flex items-center gap-3 flex-1 min-w-0">
+                        <Avatar
+                          src={submission.githubAvatar}
+                          githubUsername={submission.githubUsername}
+                          name={submission.githubName || submission.username}
+                          size="sm"
+                        />
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-1.5">
+                            <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
+                              {submission.githubUsername || submission.username}
+                            </span>
+                            {submission.verified ? (
+                              <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />
+                            ) : (
+                              <span className="text-[9px] font-mono uppercase tracking-wider px-1 py-px rounded bg-muted/15 text-muted flex-shrink-0">cli</span>
                             )}
                           </div>
-                        </div>
-
-                        <div className="hidden md:block w-44">
-                          <ToolChips tools={submission.tools} max={3} />
-                        </div>
-
-                        <div className="w-28 text-right flex-shrink-0">
-                          <div className="text-sm font-mono font-semibold text-accent">${formatCurrency(submission.totalCost)}</div>
-                        </div>
-
-                        <div className="w-24 text-right flex-shrink-0 hidden sm:block">
-                          <div className="text-sm font-mono text-muted">{formatNumber(submission.totalTokens)}</div>
-                        </div>
-
-                        <div className="w-8 flex-shrink-0 flex justify-end">
-                          {isCurrentUser && (
-                            <button
-                              onClick={(e) => { e.preventDefault(); setShowShareCard(submission.id); }}
-                              className="p-1.5 text-muted hover:text-foreground hover:bg-surface-2 rounded transition-colors"
-                            >
-                              <Share2 className="w-4 h-4" />
-                            </button>
+                          {submission.githubName && submission.githubName !== submission.githubUsername && (
+                            <div className="text-xs text-muted truncate">{submission.githubName}</div>
                           )}
                         </div>
-                      </Link>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
+                      </div>
 
-            {!isDateFiltered && hasMore && (
-              <div ref={loadMoreRef} className="py-6 text-center">
-                <Loader2 className="w-4 h-4 animate-spin mx-auto text-muted" />
+                      <div className="hidden md:block w-44">
+                        <ToolChips tools={submission.tools} max={3} />
+                      </div>
+
+                      <div className="w-28 text-right flex-shrink-0">
+                        <div className="text-sm font-mono font-semibold text-accent">${formatCurrency(submission.totalCost)}</div>
+                      </div>
+
+                      <div className="w-24 text-right flex-shrink-0 hidden sm:block">
+                        <div className="text-sm font-mono text-muted">{formatNumber(submission.totalTokens)}</div>
+                      </div>
+
+                      <div className="w-8 flex-shrink-0 flex justify-end">
+                        {isCurrentUser && (
+                          <button
+                            onClick={(e) => { e.preventDefault(); setShowShareCard(submission.id); }}
+                            className="p-1.5 text-muted hover:text-foreground hover:bg-surface-2 rounded transition-colors"
+                          >
+                            <Share2 className="w-4 h-4" />
+                          </button>
+                        )}
+                      </div>
+                    </Link>
+                  );
+                })}
               </div>
-            )}
-          </div>
-        ) : isLoading ? (
-          <SkeletonRows />
-        ) : (
-          <div className="text-center py-16">
-            <Trophy className="w-10 h-10 text-muted mx-auto mb-3" />
-            <p className="text-base font-medium mb-1">No submissions yet</p>
-            <p className="text-sm text-muted mb-4">Be the first on the leaderboard</p>
-            <code className="text-sm font-mono text-accent">npx viberank-cli</code>
-          </div>
-        )}
-      </div>
+            </div>
+          )}
+
+          {!isDateFiltered && hasMore && (
+            <div ref={loadMoreRef} className="py-6 text-center">
+              <Loader2 className="w-4 h-4 animate-spin mx-auto text-muted" />
+            </div>
+          )}
+        </div>
+      ) : isLoading ? (
+        <SkeletonRows />
+      ) : (
+        <div className="text-center py-16">
+          <Trophy className="w-10 h-10 text-muted mx-auto mb-3" />
+          <p className="text-base font-medium mb-1">No submissions yet</p>
+          <p className="text-sm text-muted mb-4">Be the first on the leaderboard</p>
+          <code className="text-sm font-mono text-accent">npx viberank-cli</code>
+        </div>
+      )}
 
       {/* Share Modal */}
       {showShareCard && allItems.find(s => s.id === showShareCard) && (

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -29,8 +29,8 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
   return (
     <>
       {/* Desktop Nav */}
-      <header className="fixed top-0 left-0 right-0 z-50 h-14 bg-background/95 backdrop-blur border-b border-border hidden md:flex items-center">
-        <div className="w-full px-6 flex items-center justify-between">
+      <header className="sticky top-0 z-50 h-14 bg-background/95 backdrop-blur border-b border-border hidden md:flex items-center">
+        <div className="w-full max-w-6xl mx-auto px-6 flex items-center justify-between">
           {/* Left: Logo + Nav Items */}
           <div className="flex items-center gap-6">
             <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
@@ -117,7 +117,7 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
       </header>
 
       {/* Mobile Nav */}
-      <header className="md:hidden fixed top-0 left-0 right-0 z-50 h-14 bg-background/95 backdrop-blur border-b border-border">
+      <header className="md:hidden sticky top-0 z-50 h-14 bg-background/95 backdrop-blur border-b border-border">
         <div className="h-full px-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="text-accent">

--- a/src/lib/home-faqs.ts
+++ b/src/lib/home-faqs.ts
@@ -1,0 +1,20 @@
+// Homepage FAQ content — shared by the visible FAQ section (client) and the
+// FAQPage JSON-LD emitted by the server page, so they can never drift.
+export const HOME_FAQS = [
+  {
+    q: "What is viberank?",
+    a: "viberank is a community leaderboard for AI coding usage. Developers submit their real usage data — exported by ccusage from Claude Code, Codex, Gemini CLI and other tools — and get ranked by cost and tokens.",
+  },
+  {
+    q: "How do I get on the leaderboard?",
+    a: "Run npx viberank-cli in your terminal. It reads your local ccusage data across all supported tools and submits it. Sign in with GitHub to get a verified badge.",
+  },
+  {
+    q: "Which AI coding tools are supported?",
+    a: "Everything ccusage tracks: Claude Code, OpenAI Codex, Gemini CLI, GitHub Copilot CLI, OpenCode, and more. Each submission records which tools contributed, and you can filter the board per tool.",
+  },
+  {
+    q: "Is the data verified?",
+    a: "Submissions are validated server-side (token math, cost/token ratio, date sanity). Signing in with GitHub marks your submission verified with a blue check; unverified CLI rows show a 'cli' badge.",
+  },
+];


### PR DESCRIPTION
The full redesign — structural, not just polish.

### Layout
- **App-shell → editorial scrolling page.** The cramped fixed-height dashboard becomes a real site: hero → board → FAQ → footer.
- **Hero**: display-scale H1 (text unchanged — SEO keyword preserved) with accent "Leaderboard", tagline, the `npx viberank-cli` terminal CTA, stat strip, and per-tool pills.
- **Sticky filter bar** under the nav while scrolling the board; Leaderboard is now a pure board component (page owns the hero).
- **NavBar**: fixed → sticky in document flow, contained to `max-w-6xl` (kills the `pt-14` clearance hacks).

### New SEO surface
- **Homepage FAQ section + FAQPage JSON-LD** (content shared via `lib/home-faqs` so visible copy and schema can't drift)
- **Site footer** on home, tool pages, and profiles — crawlable internal links to every per-tool board + blog post

### SEO verification (run against SSR HTML)
✓ H1 keyword + title tag intact · ✓ exactly one `<h1>` · ✓ 26 profile links SSR'd · ✓ FAQPage schema · ✓ tool links · ✓ footer present

Desktop + mobile screenshots verified locally. Build green, 19 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)