### PR TITLE
docs: polish all docs for v2 + CHANGELOG

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # NextAuth
-NEXTAUTH_URL=http://localhost:3001
+NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your-secret-here # Generate with: openssl rand -base64 32
 
 # GitHub OAuth
@@ -16,6 +16,6 @@ GITHUB_SECRET=your-github-oauth-app-secret
 # 2. Click "New OAuth App"
 # 3. Fill in:
 #    - Application name: viberank (local)
-#    - Homepage URL: http://localhost:3001
-#    - Authorization callback URL: http://localhost:3001/api/auth/callback/github
+#    - Homepage URL: http://localhost:3000
+#    - Authorization callback URL: http://localhost:3000/api/auth/callback/github
 # 4. Copy the Client ID and Client Secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## v2.0 — Multi-tool leaderboard (June 2026)
+
+viberank evolved from a Claude Code leaderboard into the leaderboard for **all AI coding usage** — Claude Code, Codex, Gemini CLI, Copilot, OpenCode and every other tool [ccusage](https://github.com/ryoppippi/ccusage) tracks.
+
+### Fixed
+- **Submissions were failing** with `Invalid date format: undefined` — ccusage v20's default report keys daily rows by `period` (not `date`). All ccusage report shapes are now normalized server-side at a single chokepoint (`src/lib/ccusage.ts`), so old and new output both work. (#49)
+- **"Token totals don't match" rejections** for Gemini/Codex users — reasoning/thinking tokens are counted in `totalTokens` but not broken out by ccusage. The token check is now one-sided (`total >= components`) with a cost/token ratio guard as the anti-inflation defense. (#48)
+- Merge button / web upload RLS failures: all writes (claim/merge, upload, admin flag) now run through authenticated server routes with the service-role client. (#42, #47)
+- Token stats now roll over to trillions (`2.3T`, previously `2305.1B`).
+
+### Added
+- **Multi-tool support** (#45): submissions record which tools contributed (`submissions.tools[]`, `daily_breakdowns.agents[]`, migration `002`); tool chips on every row; an "All tools / Claude / Codex / …" filter.
+- **Per-tool leaderboards** at `/tool/claude`, `/tool/codex`, `/tool/gemini`, `/tool/copilot`, `/tool/opencode` — server-rendered with FAQ + structured data.
+- **Server rendering everywhere**: homepage (first page + stats, ISR 5 min), profiles (single cached DB read shared with metadata), tool boards (ISR hourly). Structured data: FAQPage, ProfilePage, BreadcrumbList, BlogPosting.
+- **Global rank** on profile pages.
+- **Full redesign**: editorial scrolling layout with hero, top-3 podium, sticky filter bar, homepage FAQ, site footer; flat dark theme (no gradients).
+- **Blog**: three data-backed posts (tool cost comparison, what Claude Code costs, cutting your AI coding bill) + Tailwind Typography (post formatting was previously broken).
+- `pnpm test`: zero-dependency test harness for ccusage normalization/validation (`test/ccusage.test.mts`).
+
+### Changed
+- npm packages renamed (the old names belong to the original author): CLI is now [`viberank-cli`](https://www.npmjs.com/package/viberank-cli) (v1.1.0, pinned to `ccusage daily --json`), MCP server is [`viberank-mcp`](https://www.npmjs.com/package/viberank-mcp).
+- Branding broadened additively: "Claude Code, Codex & AI Coding Leaderboard" (the Claude Code keyword is preserved everywhere for SEO; no URL changes).
+- Historical submissions backfilled with tools derived from their `models_used`.
+
+### Removed
+- The dormant Convex backend — viberank is Supabase-only. The Vercel build no longer wraps `convex deploy`.
+
+### Known limitations
+- Multi-machine submissions with overlapping dates overwrite rather than sum daily data (#43) — ccusage exposes no machine identifier; a CLI-supplied machine ID is the planned fix.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ File a GitHub issue with the motivation, the proposed behavior, and any alternat
 ### Prerequisites
 
 - Node.js 18+ and pnpm 10+
-- A Supabase project (free tier is fine) — the schema lives in `supabase/migrations/001_initial_schema.sql`
-- A GitHub OAuth app for local sign-in (callback URL: `http://localhost:3001/api/auth/callback/github`)
+- A Supabase project (free tier is fine) — the schema lives in `supabase/migrations/` (apply in order)
+- A GitHub OAuth app for local sign-in (callback URL: `http://localhost:3000/api/auth/callback/github`)
 
 ### Install
 
@@ -45,7 +45,7 @@ Fill in `.env.local` with your Supabase project URL, anon key, service role key,
 
 ### Apply the database schema
 
-Run the SQL in `supabase/migrations/001_initial_schema.sql` against your Supabase project, either via the SQL editor in the dashboard or the `supabase` CLI.
+Run the SQL files in `supabase/migrations/` (in order: `001_initial_schema.sql`, then `002_multi_tool.sql`) against your Supabase project, either via the SQL editor in the dashboard or the `supabase` CLI.
 
 ### Run the dev server
 
@@ -53,7 +53,7 @@ Run the SQL in `supabase/migrations/001_initial_schema.sql` against your Supabas
 pnpm dev
 ```
 
-Opens on <http://localhost:3001>.
+Opens on <http://localhost:3000>.
 
 ## Project structure
 
@@ -62,34 +62,41 @@ viberank/
 ├── src/
 │   ├── app/                  # Next.js App Router
 │   │   ├── api/
-│   │   │   ├── submit/       # POST /api/submit
+│   │   │   ├── submit/       # POST /api/submit (normalize + validate + store)
 │   │   │   ├── claim/        # POST /api/claim (authenticated merge)
+│   │   │   ├── admin/flag/   # POST /api/admin/flag (admin-only)
 │   │   │   ├── auth/         # NextAuth handlers
 │   │   │   └── health/       # GET /api/health
-│   │   ├── profile/[username]/
-│   │   ├── admin/
-│   │   └── page.tsx          # Home / leaderboard
-│   ├── components/           # React components
+│   │   ├── page.tsx          # Home (server: SSR first page + FAQ schema)
+│   │   ├── HomeClient.tsx    # Home interactivity (hero, board, modals)
+│   │   ├── tool/[tool]/      # Per-tool leaderboards (SSR, ISR hourly)
+│   │   ├── profile/[username]/ # SSR profile (+ getProfile cache, UsageChart)
+│   │   ├── blog/             # Blog posts (static)
+│   │   └── admin/            # Flag-review dashboard
+│   ├── components/           # Leaderboard, NavBar, Footer, ShareCard, …
 │   ├── lib/
+│   │   ├── ccusage.ts        # ccusage normalization + validation (unit-tested)
+│   │   ├── admin.ts          # Admin allowlist (client gate + server enforcement)
+│   │   ├── home-faqs.ts      # Homepage FAQ content (visible copy + JSON-LD)
 │   │   ├── auth.ts           # Shared NextAuth options
 │   │   ├── env.ts            # Server env validation
-│   │   ├── utils.ts
+│   │   ├── utils.ts          # Formatters, tool labels, FEATURED_TOOLS
 │   │   └── data/             # Data layer (Supabase)
 │   │       ├── index.ts      # Data-layer factory
 │   │       ├── types.ts
 │   │       ├── hooks/        # React hooks (client)
 │   │       └── supabase/     # Supabase client + services
-│   │   └── ccusage.ts        # ccusage normalization + validation
 │   └── types/                # Shared TS types
 ├── supabase/
-│   └── migrations/           # SQL migrations
+│   └── migrations/           # SQL migrations (apply in order)
+├── test/                     # ccusage tests (`pnpm test`)
 ├── packages/
-│   ├── viberank-cli/         # `npx viberank-cli` CLI
-│   └── viberank-mcp-server/  # MCP server (currently unmaintained)
+│   ├── viberank-cli/         # `npx viberank-cli` (npm: viberank-cli)
+│   └── viberank-mcp-server/  # MCP server (npm: viberank-mcp)
 └── public/                   # Static assets
 ```
 
-The data layer (`src/lib/data/`) is backed by Supabase (Postgres). ccusage input is normalized and validated in `src/lib/data/../ccusage.ts` before it reaches the data layer.
+The data layer (`src/lib/data/`) is backed by Supabase (Postgres). ccusage input is normalized and validated in `src/lib/ccusage.ts` before it reaches the data layer — run `pnpm test` after touching it.
 
 ## Conventions
 
@@ -127,6 +134,7 @@ Keep the subject under ~72 characters. Use the body for the *why*.
 ```bash
 pnpm exec tsc --noEmit   # type-check
 pnpm lint                # next lint
+pnpm test                # ccusage normalization/validation tests
 pnpm build               # full production build
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,20 @@ A community-driven leaderboard for AI coding usage — [Claude Code](https://cla
 
 Live at **[viberank.app](https://www.viberank.app)**.
 
-> **v2 — multi-tool support.** viberank started as a Claude Code leaderboard. As `ccusage` grew to track Codex, Gemini CLI, Copilot, OpenCode and more, viberank evolved with it: submissions from any supported tool are now accepted, recorded per tool, and filterable on the leaderboard. Claude Code remains a first-class citizen — you can now just see how it stacks up against the rest of your stack.
+> **v2 — multi-tool support.** viberank started as a Claude Code leaderboard. As `ccusage` grew to track Codex, Gemini CLI, Copilot, OpenCode and more, viberank evolved with it: submissions from any supported tool are now accepted, recorded per tool, and filterable on the leaderboard. Claude Code remains a first-class citizen — you can now just see how it stacks up against the rest of your stack. Full details in the [CHANGELOG](./CHANGELOG.md).
 
 ## Features
 
-- 🏆 **Global leaderboard** by cost or tokens, with 7d / 30d / custom date filters
-- 🧰 **Multi-tool** — usage from Claude Code, Codex, Gemini CLI, Copilot, OpenCode and other `ccusage`-supported agents, with an **"All tools / Claude / Codex / …" filter**
-- 📊 **Profile pages** at `viberank.app/profile/{username}` with daily charts and model breakdown
-- 🚀 **Three ways to submit**: `npx viberank-cli` CLI, plain `curl`, or signed-in web upload
+- 🏆 **Global leaderboard** — top-3 podium + full table, sorted by cost or tokens, with 7d / 30d / custom date filters
+- 🧰 **Multi-tool** — usage from Claude Code, Codex, Gemini CLI, Copilot, OpenCode and other `ccusage`-supported agents; every row shows **tool chips** and the board filters per tool
+- 🎯 **Per-tool boards** — dedicated leaderboards at [`/tool/claude`](https://www.viberank.app/tool/claude), [`/tool/codex`](https://www.viberank.app/tool/codex), [`/tool/gemini`](https://www.viberank.app/tool/gemini), [`/tool/copilot`](https://www.viberank.app/tool/copilot), [`/tool/opencode`](https://www.viberank.app/tool/opencode)
+- 📊 **Profile pages** at `viberank.app/profile/{username}` — global rank, daily charts, token breakdown, tools used
+- ⚡ **Server-rendered** — homepage, profiles, and tool boards are SSR'd with structured data (FAQPage, ProfilePage, BreadcrumbList) for fast paint and full crawlability
+- 🚀 **Three ways to submit**: `npx viberank-cli`, plain `curl`, or signed-in web upload
 - 🔐 **GitHub OAuth** — verified submissions show a blue check; unverified CLI submissions show a `cli` pill
-- 🛡️ **Input validation** — token math, date sanity, daily-cost ceilings, cost/token ratio
+- 🛡️ **Input validation** — one-sided token math (reasoning-token aware), cost/token ratio guard, date sanity, realistic-range ceilings
 - 🔄 **Merge flow** — re-submitting the same range overwrites prior daily entries; merging combines unverified CLI rows into your verified profile
+- ✍️ **Blog** — data-backed posts on AI coding costs at [viberank.app/blog](https://www.viberank.app/blog)
 
 ## Submitting your usage data
 
@@ -53,7 +56,11 @@ Web uploads come back with a verified badge automatically. CLI submissions show 
 
 ### Option 4: MCP server
 
-If you use a Claude Code MCP-compatible client, the [`viberank-mcp-server`](./packages/viberank-mcp-server) exposes submit and lookup tools. (Note: this package is currently unmaintained — see [issue tracker](https://github.com/sculptdotfun/viberank/issues) for status.)
+If you use an MCP-compatible client, [`viberank-mcp`](https://www.npmjs.com/package/viberank-mcp) ([source](./packages/viberank-mcp-server)) exposes submit and lookup tools:
+
+```bash
+npx viberank-mcp
+```
 
 ## Data validation
 
@@ -105,7 +112,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://<project-ref>.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 
-NEXTAUTH_URL=http://localhost:3001
+NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=<openssl rand -base64 32>
 
 GITHUB_ID=<github-oauth-client-id>
@@ -129,13 +136,13 @@ Run the dev server:
 pnpm dev
 ```
 
-Open <http://localhost:3001>.
+Open <http://localhost:3000>.
 
 ### Useful scripts
 
 | Command | What it does |
 |---|---|
-| `pnpm dev` | Start Next dev server (Turbopack) on port 3001 |
+| `pnpm dev` | Start Next dev server (Turbopack) on port 3000 |
 | `pnpm build` | Production build |
 | `pnpm start` | Serve the production build |
 | `pnpm lint` | Run `next lint` |
@@ -157,7 +164,7 @@ Open <http://localhost:3001>.
 
 Submit usage data. Authenticated submissions (with a NextAuth session cookie) are marked `verified: true`; otherwise the request must include an `X-GitHub-User` header.
 
-**Body**: contents of `cc.json` (output of `npx ccusage --json`).
+**Body**: contents of `cc.json` (output of `npx ccusage@latest daily --json`).
 
 **Response**:
 
@@ -173,6 +180,10 @@ Submit usage data. Authenticated submissions (with a NextAuth session cookie) ar
 ### `POST /api/claim`
 
 Authenticated — merges unverified CLI submissions into the caller's verified profile. Username is taken from the session, not the request body. Returns 401 without a session.
+
+### `POST /api/admin/flag`
+
+Admin-only (allowlist in `src/lib/admin.ts`) — flags or unflags a submission for review. Runs server-side with the service-role client; returns 403 for non-admins.
 
 ### `GET /api/health`
 
@@ -206,4 +217,5 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 - [Website](https://www.viberank.app)
 - [GitHub](https://github.com/sculptdotfun/viberank)
 - [Report issues](https://github.com/sculptdotfun/viberank/issues)
-- [`viberank` on npm](https://www.npmjs.com/package/viberank)
+- [`viberank-cli` on npm](https://www.npmjs.com/package/viberank-cli)
+- [`viberank-mcp` on npm](https://www.npmjs.com/package/viberank-mcp)

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -2,6 +2,8 @@
 
 How submissions are validated. Implemented in `src/lib/ccusage.ts` (`normalizeCcData` + `validateCcData`) and called from `POST /api/submit`. ccusage output is normalized first (period→date, the aggregate `agent:"all"` rows deduped, per-day tools resolved) and then validated.
 
+Normalization also records **which tools contributed** — `submissions.tools[]` (e.g. `{claude, codex, gemini}`) and `daily_breakdowns.agents[]` — derived from ccusage's `metadata.agents` (with a conservative model-name fallback for older single-source reports). This powers the leaderboard's tool filter and the per-tool boards.
+
 ## Hard rejection
 
 If any of these fail, the API responds with `400` and the submission is not stored.

--- a/packages/viberank-cli/README.md
+++ b/packages/viberank-cli/README.md
@@ -1,85 +1,79 @@
-# viberank
+# viberank-cli
 
-CLI tool to submit your Claude usage stats to the [Viberank](https://viberank.app) leaderboard.
+Submit your AI coding usage stats — **Claude Code, Codex, Gemini CLI, Copilot, OpenCode and more** — to the [viberank](https://viberank.app) leaderboard.
 
-## Installation & Usage
+## Usage
 
-You don't need to install anything! Simply run:
+No install needed:
 
 ```bash
 npx viberank-cli
 ```
 
 This will:
-1. Generate your usage data using `ccusage`
-2. Submit it to the Viberank leaderboard
-3. Give you a link to view your profile
+1. Generate your usage data with `ccusage daily --json` (aggregated across **all** AI coding tools detected on your machine)
+2. Submit it to the viberank leaderboard
+3. Give you a link to your profile
 
-### Alternative Installation
-
-If you prefer to install globally:
+### Global install (optional)
 
 ```bash
-npm install -g viberank
+npm install -g viberank-cli
 viberank
 ```
 
 ## Prerequisites
 
 - Node.js 14 or higher
-- You need to have used Claude Code at least once
-- Git should be configured with your GitHub username
+- You've used at least one supported AI coding tool (Claude Code, Codex, Gemini CLI, …)
+- Git configured with your GitHub username (used to attribute your submission)
 
-## Manual Usage
+## Manual usage
 
-If you prefer to generate the data separately:
+Generate the data yourself first if you prefer:
 
 ```bash
-# Generate usage data
-npx ccusage@latest --json > cc.json
+# Generate usage data across all detected tools
+npx ccusage@latest daily --json > cc.json
 
-# Submit to Viberank
+# Submit it
 npx viberank-cli
 ```
 
-The CLI will detect the existing `cc.json` file and ask if you want to use it.
+The CLI detects the existing `cc.json` and asks whether to use it.
 
-## Direct API Usage
-
-You can also submit directly using curl:
+## Direct API usage
 
 ```bash
-# Get your GitHub username
 GITHUB_USER=$(git config user.name)
 
-# Submit with curl
 curl -X POST https://www.viberank.app/api/submit \
   -H "Content-Type: application/json" \
   -H "X-GitHub-User: $GITHUB_USER" \
   -d @cc.json
 ```
 
+## Verification
+
+CLI submissions appear on the leaderboard with a `cli` badge (unverified). Sign in to [viberank.app](https://viberank.app) with the same GitHub account and the site will offer to verify or merge — verified submissions get a blue check.
+
 ## Troubleshooting
 
-### Common Issues
+- **"npx viberank-cli" not found** — try `npx viberank-cli@latest` or clear the npx cache with `npx clear-npx-cache`
+- **"Failed to submit data"** — regenerate with `npx ccusage@latest daily --json > cc.json` and retry
+- **"GitHub username not found"** — run `git config --global user.name "YourGitHubUsername"`
+- **"No usage data"** — make sure you've used a supported AI coding tool at least once on this machine
 
-- **"npx viberank-cli" not found**: Try `npx viberank-cli@latest` or clear npx cache with `npx clear-npx-cache`
-- **"Failed to submit data"**: Ensure your cc.json is valid JSON format
-- **"GitHub username not found"**: Run `git config --global user.name "YourGitHubUsername"`
-- **"No usage data"**: Make sure you've used Claude Code at least once
+## Data validation
 
-## Data Validation
+Submissions are validated server-side:
+- **Token math** — `totalTokens >= input + output + cache_creation + cache_read`. The total may exceed the components because reasoning/thinking tokens (Gemini, Codex, Claude extended thinking) are counted in the total but not broken out by `ccusage`
+- **Cost/token ratio** must fall in a realistic band (the anti-inflation guard)
+- No negative values; dates must be valid `YYYY-MM-DD` and not past end-of-tomorrow UTC
+- Implausibly high totals are rejected; unusually high daily usage may be flagged for review
 
-Your submissions are automatically validated to ensure data integrity:
-- Token calculations must add up correctly (`input + output + cache_creation + cache_read = total`)
-- No negative values allowed
-- Dates must be valid `YYYY-MM-DD` and not far in the future (the server allows up to end-of-tomorrow UTC to cover all timezones)
-- Submissions with implausibly high total cost are rejected; high daily usage may be flagged for review
-
-For full details see [VALIDATION.md](https://github.com/sculptdotfun/viberank/blob/main/VALIDATION.md).
+Full ruleset: [VALIDATION.md](https://github.com/sculptdotfun/viberank/blob/main/VALIDATION.md).
 
 ## About
 
-Viberank is a community leaderboard for Claude Code usage. Join us to see how you stack up against other developers!
-
-Visit [viberank.app](https://viberank.app) to view the leaderboard.
+viberank is a community leaderboard for AI coding usage — real costs and tokens measured by [ccusage](https://github.com/ryoppippi/ccusage), not self-reported numbers. See how you stack up at [viberank.app](https://viberank.app), or browse the per-tool boards: [Claude](https://www.viberank.app/tool/claude) · [Codex](https://www.viberank.app/tool/codex) · [Gemini](https://www.viberank.app/tool/gemini).

--- a/packages/viberank-mcp-server/README.md
+++ b/packages/viberank-mcp-server/README.md
@@ -1,6 +1,6 @@
 # Viberank MCP Server
 
-Submit your Claude Code usage stats to [Viberank](https://viberank.app) directly from your MCP-compatible AI assistant!
+Submit your AI coding usage stats (Claude Code, Codex, Gemini CLI and more) to [viberank](https://viberank.app) directly from your MCP-compatible AI assistant!
 
 ## Features
 
@@ -79,7 +79,7 @@ Fetches your current Claude Code usage statistics.
 
 **Example:**
 ```
-Use the get_usage tool to check my Claude usage stats
+Use the get_usage tool to check my AI coding usage stats
 ```
 
 ### 2. `submit_to_viberank`
@@ -157,7 +157,7 @@ Show me the top 20 users on Viberank
 ## Troubleshooting
 
 ### "Failed to get usage data"
-- Make sure you've used Claude Code at least once
+- Make sure you've used a supported AI coding tool (Claude Code, Codex, Gemini CLI, …) at least once
 - Ensure `ccusage` is accessible (it's automatically installed via npx)
 
 ### "GitHub username is required"


### PR DESCRIPTION
Full docs refresh: README (features, npm links, ports, API), CONTRIBUTING (accurate tree, test in checklist), VALIDATION (tools recording), CLI/MCP READMEs (multi-tool copy), and a new CHANGELOG.md telling the v2 story. Verified no stale claims remain (old npx name, Claude-only copy, Convex, wrong ports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)