### PR TITLE
feat(ui): spend tiers + full page redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ scripts/
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.playwright-mcp/

--- a/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
+++ b/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { X, Github, ArrowUpRight } from "lucide-react";
+import TierBadge from "@/components/TierBadge";
+import { getTierProgress } from "@/lib/tiers";
+import { formatNumber, toolLabel, sizedAvatarUrl } from "@/lib/utils";
+
+interface ProfileSheetProps {
+  username: string;
+  displayName: string;
+  handle: string;
+  avatar: string | null;
+  totalCost: number;
+  totalTokens: number;
+  daysActive: number;
+  bestCost: number;
+  globalRank: number | null;
+  tools: string[];
+  /** Daily spend, oldest → newest, for the mini bar chart. */
+  spark: number[];
+}
+
+export default function ProfileSheet(props: ProfileSheetProps) {
+  const router = useRouter();
+  const tierInfo = getTierProgress(props.bestCost);
+  const profileUrl = `/profile/${encodeURIComponent(props.username)}`;
+
+  const close = () => router.back();
+
+  // Esc to close + lock body scroll while open.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && close();
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center">
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={close}
+      />
+
+      <motion.div
+        initial={{ y: "100%" }}
+        animate={{ y: 0 }}
+        transition={{ type: "spring", damping: 30, stiffness: 360 }}
+        className="relative w-full max-w-2xl bg-surface-1 border border-border border-b-0 rounded-t-xl shadow-2xl max-h-[85vh] overflow-y-auto"
+      >
+        {/* Grab handle + close */}
+        <div className="sticky top-0 bg-surface-1 pt-3 pb-2 px-5 flex items-center justify-between border-b border-border-subtle">
+          <div className="w-8" />
+          <div className="w-10 h-1 rounded-full bg-surface-4" aria-hidden />
+          <button
+            onClick={close}
+            aria-label="Close"
+            className="w-8 h-8 inline-flex items-center justify-center text-muted hover:text-foreground hover:bg-surface-2 rounded-md transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="px-5 py-5">
+          {/* Identity */}
+          <div className="flex items-center gap-4 mb-5">
+            {props.avatar ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={sizedAvatarUrl(props.avatar, 96)}
+                alt={props.displayName}
+                width={48}
+                height={48}
+                className="w-12 h-12 rounded-full ring-2 ring-border/40"
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-surface-3" />
+            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="text-lg font-bold tracking-tight truncate">{props.displayName}</h2>
+                <TierBadge totalCost={props.bestCost} size="sm" />
+                {props.globalRank && (
+                  <span className="font-mono text-[11px] font-semibold px-1.5 py-0.5 rounded bg-accent/12 text-accent leading-none">
+                    #{props.globalRank}
+                  </span>
+                )}
+              </div>
+              <a
+                href={`https://github.com/${props.handle}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-muted hover:text-accent transition-colors"
+              >
+                <Github className="w-3.5 h-3.5" />@{props.handle}
+              </a>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="grid grid-cols-3 gap-3 mb-4">
+            <div className="rounded-lg bg-background border border-border-subtle p-3">
+              <p className="micro-label mb-1">Spent</p>
+              <p className="font-mono font-bold text-accent">${formatNumber(props.totalCost)}</p>
+            </div>
+            <div className="rounded-lg bg-background border border-border-subtle p-3">
+              <p className="micro-label mb-1">Tokens</p>
+              <p className="font-mono font-bold">{formatNumber(props.totalTokens)}</p>
+            </div>
+            <div className="rounded-lg bg-background border border-border-subtle p-3">
+              <p className="micro-label mb-1">Days</p>
+              <p className="font-mono font-bold">{props.daysActive}</p>
+            </div>
+          </div>
+
+          {/* Daily spend sparkline */}
+          {props.spark.length > 1 && (
+            <div className="rounded-lg bg-background border border-border-subtle p-3 mb-3">
+              <p className="micro-label mb-2">Daily spend · last {props.spark.length} days</p>
+              <div className="flex items-end gap-px h-12">
+                {props.spark.map((v, i) => {
+                  const max = Math.max(...props.spark) || 1;
+                  return (
+                    <div
+                      key={i}
+                      className="flex-1 rounded-sm bg-accent/70 min-h-[2px]"
+                      style={{ height: `${Math.max(4, (v / max) * 100)}%`, opacity: v === 0 ? 0.15 : undefined }}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Tier progress */}
+          <div className="rounded-lg bg-background border border-border-subtle p-3 mb-4">
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <span className="micro-label">Tier progress</span>
+              {tierInfo.next ? (
+                <span className="font-mono text-xs text-muted">
+                  ${formatNumber(Math.ceil(tierInfo.remaining))} to{" "}
+                  <span style={{ color: tierInfo.next.color }}>
+                    {tierInfo.next.glyph} {tierInfo.next.name.toUpperCase()}
+                  </span>
+                </span>
+              ) : (
+                <span className="font-mono text-xs" style={{ color: tierInfo.tier.color }}>
+                  Top tier reached
+                </span>
+              )}
+            </div>
+            <div className="h-1.5 rounded-full bg-surface-3 overflow-hidden">
+              <div
+                className="h-full rounded-full"
+                style={{ width: `${Math.max(2, tierInfo.progress * 100)}%`, background: tierInfo.tier.color }}
+              />
+            </div>
+          </div>
+
+          {/* Tools */}
+          {props.tools.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5 mb-5">
+              {props.tools.map((t) => (
+                <span
+                  key={t}
+                  className="text-xs font-medium px-2 py-1 rounded-md bg-surface-2 text-foreground/80 border border-border"
+                >
+                  {toolLabel(t)}
+                </span>
+              ))}
+            </div>
+          )}
+
+          {/* Full profile is a plain anchor — forces a document load of the
+              SSR page since the soft route is already this sheet. */}
+          <a
+            href={profileUrl}
+            className="w-full h-10 inline-flex items-center justify-center gap-2 rounded-md bg-accent text-white text-sm font-medium hover:bg-accent-hover transition-colors"
+          >
+            View full profile
+            <ArrowUpRight className="w-4 h-4" />
+          </a>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/app/@modal/(.)profile/[username]/page.tsx
+++ b/src/app/@modal/(.)profile/[username]/page.tsx
@@ -1,0 +1,58 @@
+import { getServerDataLayer } from "@/lib/data";
+import { getProfileCached } from "@/app/profile/[username]/getProfile";
+import ProfileSheet from "./ProfileSheet";
+
+interface Params {
+  params: Promise<{ username: string }>;
+}
+
+// Intercepted /profile/[username] — client-side navigations from the board
+// get this pull-up sheet over the leaderboard; direct loads, refreshes and
+// crawlers still get the full SSR profile page (SEO unaffected).
+export default async function InterceptedProfile({ params }: Params) {
+  const { username: raw } = await params;
+  const username = decodeURIComponent(raw);
+  const profileData = await getProfileCached(username);
+
+  if (!profileData) return null;
+
+  const submissions = profileData.submissions ?? [];
+  const totalCost = submissions.reduce((s, sub) => s + sub.totalCost, 0);
+  const totalTokens = submissions.reduce((s, sub) => s + sub.totalTokens, 0);
+  const allDaily = submissions.flatMap((sub) => sub.dailyBreakdown ?? []);
+  const daysActive = new Set(allDaily.map((d) => d.date)).size || 1;
+  const tools = Array.from(new Set(submissions.flatMap((s) => s.tools ?? []))).sort();
+  const bestCost = submissions.length > 0 ? Math.max(...submissions.map((s) => s.totalCost)) : 0;
+
+  // Last 30 calendar days of spend for the sheet's sparkline.
+  const byDate = new Map<string, number>();
+  for (const d of allDaily) byDate.set(d.date, (byDate.get(d.date) ?? 0) + d.totalCost);
+  const days = [...byDate.keys()].sort();
+  const spark = days.slice(-30).map((d) => byDate.get(d) ?? 0);
+
+  let globalRank: number | null = null;
+  try {
+    if (bestCost > 0) {
+      const dataLayer = await getServerDataLayer();
+      globalRank = await dataLayer.submissions.getGlobalRank(bestCost);
+    }
+  } catch {
+    // rank is nice-to-have
+  }
+
+  return (
+    <ProfileSheet
+      username={username}
+      displayName={profileData.githubName || profileData.githubUsername || username}
+      handle={profileData.githubUsername || username}
+      avatar={profileData.avatar ?? null}
+      totalCost={totalCost}
+      totalTokens={totalTokens}
+      daysActive={daysActive}
+      bestCost={bestCost}
+      globalRank={globalRank}
+      tools={tools}
+      spark={spark}
+    />
+  );
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,4 @@
+// The modal slot renders nothing unless the profile route is intercepted.
+export default function Default() {
+  return null;
+}

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -2,16 +2,15 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Upload, Merge, X, Terminal, Copy, Check, Users, DollarSign, Zap, Trophy } from "lucide-react";
-import Link from "next/link";
-import FileUpload from "@/components/FileUpload";
+import { Upload, Merge, X, Terminal, Copy, Check, Github } from "lucide-react";
 import Leaderboard from "@/components/Leaderboard";
-import UpdatesModal from "@/components/UpdatesModal";
+import SubmitModal from "@/components/SubmitModal";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
-import { useSession } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
 import { useCheckClaimableSubmissions, useClaimAndMergeSubmissions } from "@/lib/data/hooks/useSubmissions";
-import { formatNumber, toolLabel, FEATURED_TOOLS } from "@/lib/utils";
+import { formatNumber } from "@/lib/utils";
+import { TIERS } from "@/lib/tiers";
 import { HOME_FAQS } from "@/lib/home-faqs";
 import type { Submission, GlobalStats } from "@/lib/data/types";
 
@@ -21,9 +20,45 @@ interface HomeClientProps {
   initialHasMore?: boolean;
 }
 
+// "$5K+" style tier thresholds (formatNumber gives "5.0K").
+function tierMin(min: number): string {
+  if (min === 0) return "$0+";
+  return `$${formatNumber(min).replace(".0", "")}+`;
+}
+
+function Ticker({ stats }: { stats: GlobalStats }) {
+  const entries = [
+    `${formatNumber(stats.totalUsers)} developers on the board`,
+    `$${formatNumber(stats.totalCost)} tracked`,
+    `${formatNumber(stats.totalTokens)} tokens burned`,
+    stats.topUser ? `${stats.topUser} leads at $${formatNumber(stats.topCost)}` : null,
+    `run npx viberank-cli to join`,
+  ].filter(Boolean) as string[];
+
+  // Track is duplicated so the -50% translate loops seamlessly.
+  const half = (
+    <span className="inline-flex items-center">
+      {entries.map((e, i) => (
+        <span key={i} className="inline-flex items-center">
+          <span className="px-5">{e}</span>
+          <span className="text-accent">·</span>
+        </span>
+      ))}
+    </span>
+  );
+
+  return (
+    <div className="border-b border-border bg-surface-1 overflow-hidden" aria-hidden>
+      <div className="ticker-track font-mono text-[10px] uppercase tracking-[0.14em] text-muted py-1.5">
+        {half}
+        {half}
+      </div>
+    </div>
+  );
+}
+
 export default function HomeClient({ initialItems, initialStats, initialHasMore }: HomeClientProps) {
   const [showUploadModal, setShowUploadModal] = useState(false);
-  const [showUpdatesModal, setShowUpdatesModal] = useState(false);
   const [copiedToClipboard, setCopiedToClipboard] = useState(false);
   const [showMergeBanner, setShowMergeBanner] = useState(true);
   const [merging, setMerging] = useState(false);
@@ -60,10 +95,9 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
-      <NavBar
-        onUploadClick={() => setShowUploadModal(true)}
-        onUpdatesClick={() => setShowUpdatesModal(true)}
-      />
+      {stats && <Ticker stats={stats} />}
+
+      <NavBar />
 
       {/* Claim/Merge Banner */}
       <AnimatePresence>
@@ -97,95 +131,154 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
       </AnimatePresence>
 
       <main className="flex-1">
-        {/* Hero */}
-        <section className="border-b border-border">
-          <div className="max-w-6xl mx-auto px-6 pt-14 pb-10">
-            <h1 className="text-3xl sm:text-5xl font-bold tracking-tight max-w-3xl leading-[1.1]">
-              Claude Code, Codex &amp; AI Coding <span className="text-accent">Leaderboard</span>
-            </h1>
-            <p className="text-muted text-base sm:text-lg mt-4 max-w-2xl">
-              Real usage, real costs. Developers ranked by what they actually spend across AI coding
-              tools — measured from ccusage data, not vibes.
-            </p>
+        {/* Headline + board + sidebar */}
+        <section className="max-w-6xl mx-auto px-6 pt-12 pb-16 w-full lg:grid lg:grid-cols-[minmax(0,1fr)_300px] lg:gap-10 lg:items-start">
+          <div>
+            <div className="pb-8">
+              <p className="micro-label mb-3">The AI coding usage leaderboard</p>
+              <h1 className="font-mono text-2xl sm:text-4xl font-bold tracking-tight max-w-3xl leading-[1.15]">
+                Claude Code &amp; AI coding spend,{" "}
+                <span className="text-accent whitespace-nowrap">
+                  ranked
+                  <span className="cursor-block" aria-hidden />
+                </span>
+              </h1>
+              <p className="text-muted text-base sm:text-lg mt-4 max-w-2xl">
+                Developers ranked by API spend and token usage across Claude Code, OpenAI Codex,
+                Gemini CLI, Copilot and every coding agent ccusage tracks.
+              </p>
 
-            {/* Terminal CTA */}
-            <div className="flex flex-wrap items-center gap-3 mt-7">
+              {/* CTA — mobile/tablet only; the sidebar card covers desktop */}
+              <div className="flex flex-wrap items-center gap-3 mt-6 lg:hidden">
+                <button
+                  onClick={copyCommand}
+                  className="group flex items-center gap-3 rounded-lg bg-surface-1 border border-border hover:border-accent/50 px-4 py-3 transition-colors"
+                >
+                  <Terminal className="w-4 h-4 text-muted" />
+                  <code className="font-mono text-accent font-medium">npx viberank-cli</code>
+                  {copiedToClipboard ? (
+                    <Check className="w-4 h-4 text-success" />
+                  ) : (
+                    <Copy className="w-4 h-4 text-muted group-hover:text-foreground transition-colors" />
+                  )}
+                </button>
+                <button
+                  onClick={() => setShowUploadModal(true)}
+                  className="flex items-center gap-2 px-4 py-3 text-sm text-muted hover:text-foreground transition-colors"
+                >
+                  <Upload className="w-4 h-4" />
+                  or upload cc.json
+                </button>
+              </div>
+            </div>
+
+            <Leaderboard
+              initialItems={initialItems}
+              initialStats={initialStats}
+              initialHasMore={initialHasMore}
+            />
+          </div>
+
+          <aside className="hidden lg:block sticky top-20 space-y-4">
+            {/* Enlist card */}
+            <div className="rounded-lg border border-border bg-surface-1 p-4">
+              <div className="micro-label mb-3">Get on the board</div>
               <button
                 onClick={copyCommand}
-                className="group flex items-center gap-3 rounded-xl bg-surface-1 border border-border hover:border-accent/50 px-4 py-3 transition-colors"
+                className="group w-full flex items-center justify-between gap-2 rounded-md bg-background border border-border hover:border-accent/50 px-3 py-2.5 transition-colors"
               >
-                <Terminal className="w-4 h-4 text-muted" />
-                <code className="font-mono text-accent font-medium">npx viberank-cli</code>
+                <span className="flex items-center gap-2 min-w-0">
+                  <span className="text-accent font-mono text-sm">$</span>
+                  <code className="font-mono text-sm truncate">npx viberank-cli</code>
+                </span>
                 {copiedToClipboard ? (
-                  <Check className="w-4 h-4 text-success" />
+                  <Check className="w-4 h-4 text-success flex-shrink-0" />
                 ) : (
-                  <Copy className="w-4 h-4 text-muted group-hover:text-foreground transition-colors" />
+                  <Copy className="w-4 h-4 text-muted group-hover:text-foreground transition-colors flex-shrink-0" />
                 )}
               </button>
               <button
                 onClick={() => setShowUploadModal(true)}
-                className="flex items-center gap-2 px-4 py-3 text-sm text-muted hover:text-foreground transition-colors"
+                className="w-full flex items-center gap-2 mt-2 px-3 py-2 text-sm text-muted hover:text-foreground transition-colors"
               >
                 <Upload className="w-4 h-4" />
                 or upload cc.json
               </button>
+              {!session && (
+                <button
+                  onClick={() => signIn("github")}
+                  className="w-full flex items-center justify-center gap-2 mt-2 px-3 py-2 text-sm border border-border rounded-md hover:bg-surface-2 transition-colors"
+                >
+                  <Github className="w-4 h-4" />
+                  Sign in to get verified
+                </button>
+              )}
             </div>
 
-            {/* Stat strip */}
-            {stats && (
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-9">
-                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
-                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><Users className="w-3.5 h-3.5" />Developers</div>
-                  <div className="text-xl font-bold font-mono">{formatNumber(stats.totalUsers)}</div>
-                </div>
-                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
-                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><DollarSign className="w-3.5 h-3.5" />Total spent</div>
-                  <div className="text-xl font-bold font-mono text-accent">${formatNumber(stats.totalCost)}</div>
-                </div>
-                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
-                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><Zap className="w-3.5 h-3.5" />Tokens</div>
-                  <div className="text-xl font-bold font-mono">{formatNumber(stats.totalTokens)}</div>
-                </div>
-                <div className="rounded-2xl bg-surface-1 border border-border px-4 py-3.5">
-                  <div className="flex items-center gap-1.5 text-xs text-muted mb-1.5"><Trophy className="w-3.5 h-3.5" />Top spender</div>
-                  <div className="text-xl font-bold font-mono">${formatNumber(stats.topCost)}</div>
-                </div>
+            {/* Tier ladder */}
+            <div className="rounded-lg border border-border bg-surface-1 p-4">
+              <div className="micro-label mb-2">Tier ladder</div>
+              <div className="divide-y divide-border-subtle">
+                {[...TIERS].reverse().map((t) => (
+                  <div key={t.key} className="flex items-center justify-between py-2 font-mono text-xs uppercase tracking-[0.1em]">
+                    <span style={{ color: t.color }}>
+                      {t.glyph} {t.name}
+                    </span>
+                    <span className="text-muted">{tierMin(t.min)}</span>
+                  </div>
+                ))}
               </div>
-            )}
+              <p className="text-[11px] text-muted leading-relaxed mt-3">
+                Based on your best submission&apos;s total cost.
+              </p>
+            </div>
+          </aside>
+        </section>
 
-            {/* Per-tool boards */}
-            <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 mt-6 text-sm text-muted">
-              <span>Per-tool boards:</span>
-              {FEATURED_TOOLS.map((t) => (
-                <Link
-                  key={t.key}
-                  href={`/tool/${t.key}`}
-                  className="px-2.5 py-1 rounded-md bg-surface-1 border border-border hover:text-accent hover:border-accent/40 transition-colors"
-                >
-                  {toolLabel(t.key)}
-                </Link>
+        {/* How it works */}
+        <section className="border-t border-border">
+          <div className="max-w-6xl mx-auto px-6 py-12">
+            <div className="micro-label mb-6">How it works</div>
+            <div className="grid sm:grid-cols-3 gap-x-10 gap-y-6">
+              {[
+                {
+                  title: "Run the CLI",
+                  body: (
+                    <>
+                      <code className="font-mono text-accent">npx viberank-cli</code> reads your local usage
+                      logs with ccusage. Your code and prompts never leave your machine.
+                    </>
+                  ),
+                },
+                {
+                  title: "Every agent counts",
+                  body: "Claude Code, OpenAI Codex, Gemini CLI, Copilot, OpenCode and every other coding agent ccusage tracks — summed into one number.",
+                },
+                {
+                  title: "Climb the tiers",
+                  body: "Your total spend earns a tier, from Spark to Supernova. Sign in with GitHub for a verified badge and a shareable rank card.",
+                },
+              ].map((step, i) => (
+                <div key={step.title} className="flex gap-4">
+                  <span className="font-mono text-sm text-accent pt-0.5">0{i + 1}</span>
+                  <div>
+                    <h3 className="text-sm font-semibold mb-1.5">{step.title}</h3>
+                    <p className="text-sm text-muted leading-relaxed">{step.body}</p>
+                  </div>
+                </div>
               ))}
             </div>
           </div>
         </section>
 
-        {/* Leaderboard */}
-        <section className="max-w-6xl mx-auto px-6 pb-16">
-          <Leaderboard
-            initialItems={initialItems}
-            initialStats={initialStats}
-            initialHasMore={initialHasMore}
-          />
-        </section>
-
         {/* FAQ */}
-        <section className="border-t border-border bg-surface-1/50">
-          <div className="max-w-6xl mx-auto px-6 py-14">
-            <h2 className="text-2xl font-bold tracking-tight mb-6">Frequently asked questions</h2>
-            <div className="grid gap-4 md:grid-cols-2">
+        <section className="border-t border-border">
+          <div className="max-w-6xl mx-auto px-6 py-12">
+            <div className="micro-label mb-6">FAQ</div>
+            <div className="grid md:grid-cols-2 gap-x-12 gap-y-7">
               {HOME_FAQS.map((f) => (
-                <div key={f.q} className="rounded-2xl border border-border bg-surface-1 p-5">
-                  <h3 className="font-semibold mb-2">{f.q}</h3>
+                <div key={f.q} className="border-t border-border-subtle pt-4">
+                  <h3 className="text-sm font-semibold mb-1.5">{f.q}</h3>
                   <p className="text-sm text-muted leading-relaxed">{f.a}</p>
                 </div>
               ))}
@@ -196,73 +289,7 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
 
       <Footer />
 
-      {/* Upload Modal */}
-      <AnimatePresence>
-        {showUploadModal && (
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            className="fixed inset-0 z-50 flex items-center justify-center p-4"
-          >
-            <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setShowUploadModal(false)} />
-            <motion.div
-              initial={{ opacity: 0, scale: 0.95, y: 10 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.95, y: 10 }}
-              className="relative bg-surface-1 border border-border rounded-2xl shadow-xl max-w-sm w-full"
-            >
-              <div className="px-4 py-3 flex items-center justify-between border-b border-border">
-                <h3 className="font-medium">Submit Stats</h3>
-                <button onClick={() => setShowUploadModal(false)} className="p-1 text-muted hover:text-foreground rounded hover:bg-surface-2">
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-              <div className="p-4 space-y-4">
-                {/* CLI option */}
-                <div className="p-3 rounded-lg bg-accent/5 border border-accent/20">
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2 text-sm">
-                      <Terminal className="w-4 h-4 text-accent" />
-                      <span className="font-medium">CLI</span>
-                    </div>
-                    <span className="text-[10px] px-1.5 py-0.5 bg-accent/20 text-accent rounded">Recommended</span>
-                  </div>
-                  <button
-                    onClick={copyCommand}
-                    className="w-full flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border hover:border-accent/50 transition-colors"
-                  >
-                    <code className="text-sm font-mono text-accent">npx viberank-cli</code>
-                    {copiedToClipboard ? (
-                      <Check className="w-4 h-4 text-green-500" />
-                    ) : (
-                      <Copy className="w-4 h-4 text-muted" />
-                    )}
-                  </button>
-                </div>
-
-                {/* Divider */}
-                <div className="flex items-center gap-3">
-                  <div className="flex-1 h-px bg-border" />
-                  <span className="text-xs text-muted">or</span>
-                  <div className="flex-1 h-px bg-border" />
-                </div>
-
-                {/* Upload option */}
-                <div>
-                  <div className="flex items-center gap-2 mb-2 text-sm">
-                    <Upload className="w-4 h-4 text-muted" />
-                    <span className="font-medium">Upload cc.json</span>
-                  </div>
-                  <FileUpload onSuccess={() => setShowUploadModal(false)} />
-                </div>
-              </div>
-            </motion.div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      <UpdatesModal isOpen={showUpdatesModal} onClose={() => setShowUpdatesModal(false)} />
+      <SubmitModal open={showUploadModal} onClose={() => setShowUploadModal(false)} />
     </div>
   );
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -50,10 +50,7 @@ export default function AdminPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <NavBar 
-        onUploadClick={() => {}}
-        onUpdatesClick={() => {}}
-      />
+      <NavBar />
       <div className="max-w-5xl mx-auto px-6 py-8">
         <div className="mb-6">
           <h1 className="text-2xl font-semibold mb-1">Admin Dashboard</h1>

--- a/src/app/blog/claude-code-complete-guide/page.tsx
+++ b/src/app/blog/claude-code-complete-guide/page.tsx
@@ -62,7 +62,7 @@ export default function ClaudeCodeCompleteGuide() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link
           href="/blog"
           className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"

--- a/src/app/blog/codex-vs-claude-code-vs-gemini-cli/page.tsx
+++ b/src/app/blog/codex-vs-claude-code-vs-gemini-cli/page.tsx
@@ -44,7 +44,7 @@ export default function Post() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link href="/blog" className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline">
           <ArrowLeft className="w-4 h-4" />
           Back to Blog

--- a/src/app/blog/cursor-vs-claude-code-vs-copilot/page.tsx
+++ b/src/app/blog/cursor-vs-claude-code-vs-copilot/page.tsx
@@ -62,7 +62,7 @@ export default function CursorVsClaudeCodeVsCopilot() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link
           href="/blog"
           className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"

--- a/src/app/blog/how-much-does-claude-code-cost/page.tsx
+++ b/src/app/blog/how-much-does-claude-code-cost/page.tsx
@@ -44,7 +44,7 @@ export default function Post() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link href="/blog" className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline">
           <ArrowLeft className="w-4 h-4" />
           Back to Blog

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
 
 export const metadata: Metadata = {
   title: {
@@ -14,10 +16,12 @@ export default function BlogLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-background">
-      <div className="max-w-3xl mx-auto px-6 py-12">
+    <div className="min-h-screen bg-background flex flex-col">
+      <NavBar />
+      <main className="flex-1 w-full max-w-6xl mx-auto px-6 py-12">
         {children}
-      </div>
+      </main>
+      <Footer />
     </div>
   );
 }

--- a/src/app/blog/mcp-servers-guide/page.tsx
+++ b/src/app/blog/mcp-servers-guide/page.tsx
@@ -62,7 +62,7 @@ export default function MCPServersGuide() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
 
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link
           href="/blog"
           className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 
 const blogPosts = [
   {
@@ -57,15 +56,8 @@ export default function BlogPage() {
   const [featured, ...rest] = blogPosts;
   return (
     <>
-      <Link
-        href="/"
-        className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8"
-      >
-        <ArrowLeft className="w-4 h-4" />
-        Back to Leaderboard
-      </Link>
-
-      <h1 className="text-3xl font-bold tracking-tight text-foreground mb-3">Blog</h1>
+      <p className="micro-label mb-3">Blog</p>
+      <h1 className="font-mono text-3xl font-bold tracking-tight text-foreground mb-3">Notes from the leaderboard</h1>
       <p className="text-muted mb-10">
         Insights on AI-powered development, Claude Code, and the future of programming.
       </p>
@@ -73,9 +65,9 @@ export default function BlogPage() {
       {/* Featured (latest) post */}
       <Link
         href={`/blog/${featured.slug}`}
-        className="group block rounded-2xl border border-accent/40 bg-surface-1 p-6 mb-6 hover:bg-surface-2 transition-colors"
+        className="group block rounded-lg border border-accent/40 bg-surface-1 p-6 mb-6 hover:bg-surface-2 transition-colors"
       >
-        <span className="inline-block text-[10px] font-semibold uppercase tracking-wider text-accent mb-3">
+        <span className="inline-block font-mono text-[10px] font-medium uppercase tracking-[0.14em] text-accent mb-3">
           Latest
         </span>
         <h2 className="text-2xl font-bold tracking-tight text-foreground group-hover:text-accent transition-colors mb-2">
@@ -89,12 +81,12 @@ export default function BlogPage() {
         </div>
       </Link>
 
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {rest.map((post) => (
           <Link
             key={post.slug}
             href={`/blog/${post.slug}`}
-            className="group flex flex-col rounded-2xl border border-border bg-surface-1 p-5 hover:bg-surface-2 transition-colors"
+            className="group flex flex-col rounded-lg border border-border bg-surface-1 p-5 hover:bg-surface-2 transition-colors"
           >
             <h2 className="text-base font-semibold text-foreground group-hover:text-accent transition-colors mb-2">
               {post.title}

--- a/src/app/blog/reduce-ai-coding-costs/page.tsx
+++ b/src/app/blog/reduce-ai-coding-costs/page.tsx
@@ -44,7 +44,7 @@ export default function Post() {
     <>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
 
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link href="/blog" className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline">
           <ArrowLeft className="w-4 h-4" />
           Back to Blog

--- a/src/app/blog/vibe-coding-revolution/page.tsx
+++ b/src/app/blog/vibe-coding-revolution/page.tsx
@@ -61,7 +61,7 @@ export default function VibeCodingRevolution() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       
-      <article className="prose prose-invert prose-neutral max-w-none">
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
         <Link 
           href="/blog" 
           className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -150,6 +150,48 @@ body {
   outline-offset: 2px;
 }
 
+/* Uppercase mono micro-label — section eyebrows, stat labels, table headers */
+.micro-label {
+  font-family: var(--font-geist-mono), monospace;
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+/* Ticker tape — continuous marquee, pauses on hover */
+@keyframes ticker-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+.ticker-track {
+  display: inline-flex;
+  white-space: nowrap;
+  animation: ticker-scroll 60s linear infinite;
+  will-change: transform;
+}
+
+.ticker-track:hover {
+  animation-play-state: paused;
+}
+
+/* Blinking block cursor used after headings */
+@keyframes cursor-blink {
+  0%, 55% { opacity: 1; }
+  56%, 100% { opacity: 0; }
+}
+
+.cursor-block {
+  display: inline-block;
+  width: 0.45em;
+  height: 0.85em;
+  margin-left: 0.12em;
+  background: var(--accent);
+  animation: cursor-blink 1.1s steps(1) infinite;
+}
+
 /* Simple table row hover */
 .table-row-hover {
   transition: background 0.15s ease;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -68,8 +68,11 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
   children: React.ReactNode;
+  // Parallel slot for the intercepted profile sheet (see app/@modal).
+  modal: React.ReactNode;
 }>) {
   const jsonLd = [
     {
@@ -115,7 +118,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          {modal}
+        </Providers>
         <Analytics />
       </body>
     </html>

--- a/src/app/profile/[username]/UsageChart.tsx
+++ b/src/app/profile/[username]/UsageChart.tsx
@@ -22,7 +22,7 @@ export default function UsageChart({ daily }: { daily: DailyPoint[] }) {
     .slice(range === "7d" ? -7 : range === "30d" ? -30 : 0);
 
   return (
-    <div className="bg-surface-1 border border-border rounded-2xl p-5 mb-6">
+    <div className="bg-surface-1 border border-border rounded-lg p-5 mb-6">
       <div className="flex items-center justify-between mb-4">
         <h2 className="text-base font-medium flex items-center gap-2">
           <TrendingUp className="w-4 h-4 text-accent" />

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -10,11 +10,14 @@ import {
   CalendarDays,
   Trophy,
 } from "lucide-react";
-import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
+import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl } from "@/lib/utils";
+import { getTierProgress } from "@/lib/tiers";
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "./getProfile";
 import UsageChart from "./UsageChart";
 import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import TierBadge from "@/components/TierBadge";
 
 interface ProfileParams {
   params: Promise<{ username: string }>;
@@ -77,11 +80,14 @@ export default async function ProfilePage({ params }: ProfileParams) {
   const displayName = profileData.githubName || profileData.githubUsername || username;
   const handle = profileData.githubUsername || username;
 
+  // Best submission drives both global rank and tier, matching the board.
+  const bestCost = submissions.length > 0 ? Math.max(...submissions.map((s) => s.totalCost)) : 0;
+  const tierInfo = getTierProgress(bestCost);
+
   // Global leaderboard position, based on the profile's best submission.
   let globalRank: number | null = null;
   try {
-    const bestCost = Math.max(...submissions.map((s) => s.totalCost));
-    if (Number.isFinite(bestCost)) {
+    if (Number.isFinite(bestCost) && bestCost > 0) {
       const dataLayer = await getServerDataLayer();
       globalRank = await dataLayer.submissions.getGlobalRank(bestCost);
     }
@@ -98,25 +104,21 @@ export default async function ProfilePage({ params }: ProfileParams) {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-50">
-        <div className="max-w-5xl mx-auto px-6">
-          <div className="flex items-center h-14">
-            <Link href="/" className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors text-sm">
-              <ArrowLeft className="w-4 h-4" />
-              Back to leaderboard
-            </Link>
-          </div>
-        </div>
-      </header>
+      <NavBar />
 
-      <div className="max-w-5xl mx-auto px-6 py-8">
+      <div className="max-w-6xl mx-auto px-6 py-8">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
         {/* Profile header */}
         <div className="mb-8">
           <div className="flex items-start gap-5 mb-6">
             {profileData.avatar && (
               // eslint-disable-next-line @next/next/no-img-element
               <img
-                src={profileData.avatar}
+                src={sizedAvatarUrl(profileData.avatar, 128)}
                 alt={displayName}
                 width={64}
                 height={64}
@@ -124,7 +126,15 @@ export default async function ProfilePage({ params }: ProfileParams) {
               />
             )}
             <div className="flex-1 min-w-0">
-              <h1 className="text-2xl font-bold tracking-tight mb-2">{displayName}</h1>
+              <div className="flex flex-wrap items-center gap-2.5 mb-2">
+                <h1 className="text-2xl font-bold tracking-tight">{displayName}</h1>
+                <TierBadge totalCost={bestCost} size="md" />
+                {globalRank && (
+                  <span className="font-mono text-xs font-semibold px-2 py-1 rounded bg-accent/12 text-accent leading-none">
+                    #{globalRank}
+                  </span>
+                )}
+              </div>
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted">
                 <a
                   href={`https://github.com/${handle}`}
@@ -157,25 +167,58 @@ export default async function ProfilePage({ params }: ProfileParams) {
 
           {/* Key stats */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-            <div className="bg-surface-1 border border-border rounded-2xl p-4">
-              <p className="flex items-center gap-1.5 text-xs text-muted mb-1"><DollarSign className="w-3.5 h-3.5" />Total spent</p>
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1"><DollarSign className="w-3.5 h-3.5" />Total spent</p>
               <p className="text-xl font-bold font-mono text-accent">${formatNumber(totalCost)}</p>
               <p className="text-xs text-muted mt-1">${formatCurrency(avgDailyCost)}/day avg</p>
             </div>
-            <div className="bg-surface-1 border border-border rounded-2xl p-4">
-              <p className="flex items-center gap-1.5 text-xs text-muted mb-1"><Zap className="w-3.5 h-3.5" />Total tokens</p>
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1"><Zap className="w-3.5 h-3.5" />Total tokens</p>
               <p className="text-xl font-bold font-mono">{formatNumber(totalTokens)}</p>
               <p className="text-xs text-muted mt-1">{formatNumber(Math.round(totalTokens / daysActive))}/day</p>
             </div>
-            <div className="bg-surface-1 border border-border rounded-2xl p-4">
-              <p className="flex items-center gap-1.5 text-xs text-muted mb-1"><CalendarDays className="w-3.5 h-3.5" />Days active</p>
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1"><CalendarDays className="w-3.5 h-3.5" />Days active</p>
               <p className="text-xl font-bold">{daysActive}</p>
               <p className="text-xs text-muted mt-1">{profileData.totalSubmissions} submission{profileData.totalSubmissions === 1 ? "" : "s"}</p>
             </div>
-            <div className="bg-surface-1 border border-border rounded-2xl p-4">
-              <p className="flex items-center gap-1.5 text-xs text-muted mb-1"><Trophy className="w-3.5 h-3.5" />Global rank</p>
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1"><Trophy className="w-3.5 h-3.5" />Global rank</p>
               <p className="text-xl font-bold">{globalRank ? `#${globalRank}` : "—"}</p>
               <p className="text-xs text-muted mt-1 truncate">{tools.length ? `${tools.map(toolLabel).slice(0, 2).join(", ")}${tools.length > 2 ? " +" + (tools.length - 2) : ""}` : "by cost"}</p>
+            </div>
+          </div>
+
+          {/* Tier progress */}
+          <div className="bg-surface-1 border border-border rounded-lg p-4 mt-3">
+            <div className="flex flex-wrap items-center justify-between gap-2 mb-2.5">
+              <span className="micro-label">Tier progress</span>
+              {tierInfo.next ? (
+                <span className="font-mono text-xs text-muted">
+                  ${formatNumber(Math.ceil(tierInfo.remaining))} to{" "}
+                  <span style={{ color: tierInfo.next.color }}>
+                    {tierInfo.next.glyph} {tierInfo.next.name.toUpperCase()}
+                  </span>
+                </span>
+              ) : (
+                <span className="font-mono text-xs" style={{ color: tierInfo.tier.color }}>
+                  Top tier reached
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-3">
+              <TierBadge totalCost={bestCost} size="sm" />
+              <div className="flex-1 h-1.5 rounded-full bg-surface-3 overflow-hidden">
+                <div
+                  className="h-full rounded-full"
+                  style={{ width: `${Math.max(2, tierInfo.progress * 100)}%`, background: tierInfo.tier.color }}
+                />
+              </div>
+              {tierInfo.next && (
+                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-muted/70">
+                  {tierInfo.next.glyph} {tierInfo.next.name}
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -185,7 +228,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
 
         {/* Token breakdown + insights */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-          <div className="bg-surface-1 border border-border rounded-2xl p-5">
+          <div className="bg-surface-1 border border-border rounded-lg p-5">
             <h2 className="text-base font-medium mb-4 flex items-center gap-2">
               <Zap className="w-4 h-4 text-accent" />
               Token breakdown
@@ -208,7 +251,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
             </div>
           </div>
 
-          <div className="bg-surface-1 border border-border rounded-2xl p-5">
+          <div className="bg-surface-1 border border-border rounded-lg p-5">
             <h2 className="text-base font-medium mb-4 flex items-center gap-2">
               <Activity className="w-4 h-4 text-accent" />
               Usage insights

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { ArrowLeft, BadgeCheck } from "lucide-react";
 import { getServerDataLayer } from "@/lib/data";
 import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import TierBadge from "@/components/TierBadge";
 import { formatNumber, formatCurrency, toolLabel, toolBlurb, FEATURED_TOOLS } from "@/lib/utils";
 
 interface ToolParams {
@@ -85,19 +87,16 @@ export default async function ToolPage({ params }: ToolParams) {
     <div className="min-h-screen bg-background">
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbLd, faqLd]) }} />
 
-      <header className="border-b border-border bg-background/95 backdrop-blur sticky top-0 z-50">
-        <div className="max-w-4xl mx-auto px-6">
-          <div className="flex items-center h-14">
-            <Link href="/" className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors text-sm">
-              <ArrowLeft className="w-4 h-4" />
-              Back to leaderboard
-            </Link>
-          </div>
-        </div>
-      </header>
+      <NavBar />
 
-      <div className="max-w-4xl mx-auto px-6 py-10">
-        <h1 className="text-3xl font-bold tracking-tight mb-2">{label} Usage Leaderboard</h1>
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
+        <p className="micro-label mb-3">Per-tool leaderboard</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">{label} Usage Leaderboard</h1>
         <p className="text-muted mb-6 max-w-2xl">
           Developers ranked by their {label} usage ({toolBlurb(tool)}) — by cost and tokens, from real{" "}
           <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">ccusage</a>{" "}
@@ -106,7 +105,7 @@ export default async function ToolPage({ params }: ToolParams) {
 
         {/* Browse other tools */}
         <div className="flex flex-wrap items-center gap-2 mb-8 text-sm">
-          <span className="text-muted">Browse:</span>
+          <span className="micro-label">Browse</span>
           {FEATURED_TOOLS.map((t) => (
             <Link
               key={t.key}
@@ -121,10 +120,11 @@ export default async function ToolPage({ params }: ToolParams) {
         </div>
 
         {items.length > 0 ? (
-          <div className="rounded-2xl border border-border overflow-hidden mb-12">
-            <div className="flex items-center gap-3 px-4 py-2.5 text-xs text-muted bg-surface-1 border-b border-border">
+          <div className="rounded-lg border border-border overflow-hidden mb-12">
+            <div className="flex items-center gap-3 px-4 py-2.5 micro-label bg-surface-1 border-b border-border">
               <div className="w-8 text-center">#</div>
               <div className="flex-1">User</div>
+              <div className="hidden sm:block w-24">Tier</div>
               <div className="w-28 text-right">Cost</div>
               <div className="w-24 text-right hidden sm:block">Tokens</div>
             </div>
@@ -135,12 +135,15 @@ export default async function ToolPage({ params }: ToolParams) {
                   href={`/profile/${encodeURIComponent(s.githubUsername || s.username)}`}
                   className="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors group"
                 >
-                  <div className="w-8 text-center text-sm text-muted font-mono">{i + 1}</div>
+                  <div className={`w-8 text-center text-sm font-mono ${i === 0 ? "text-[#f5b008] font-bold" : i === 1 ? "text-[#b8bcc4] font-bold" : i === 2 ? "text-[#c2703f] font-bold" : "text-muted"}`}>{i + 1}</div>
                   <div className="flex-1 min-w-0 flex items-center gap-1.5">
                     <span className="text-sm font-medium truncate group-hover:text-accent transition-colors">
                       {s.githubUsername || s.username}
                     </span>
                     {s.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+                  </div>
+                  <div className="hidden sm:block w-24 flex-shrink-0">
+                    <TierBadge totalCost={s.totalCost} size="xs" bare />
                   </div>
                   <div className="w-28 text-right text-sm font-mono font-semibold text-accent">${formatCurrency(s.totalCost)}</div>
                   <div className="w-24 text-right text-sm font-mono text-muted hidden sm:block">{formatNumber(s.totalTokens)}</div>
@@ -149,7 +152,7 @@ export default async function ToolPage({ params }: ToolParams) {
             </div>
           </div>
         ) : (
-          <div className="rounded-2xl border border-border p-10 text-center mb-12">
+          <div className="rounded-lg border border-border p-10 text-center mb-12">
             <p className="font-medium mb-1">No {label} submissions yet</p>
             <p className="text-sm text-muted">Be the first — run <code className="font-mono text-accent">npx viberank-cli</code></p>
           </div>
@@ -157,10 +160,10 @@ export default async function ToolPage({ params }: ToolParams) {
 
         {/* FAQ */}
         <section>
-          <h2 className="text-xl font-bold tracking-tight mb-4">{label} leaderboard FAQ</h2>
+          <h2 className="font-mono text-xl font-bold tracking-tight mb-4">{label} leaderboard FAQ</h2>
           <div className="space-y-3">
             {faqs.map((f) => (
-              <div key={f.q} className="rounded-xl border border-border bg-surface-1 p-4">
+              <div key={f.q} className="rounded-lg border border-border bg-surface-1 p-4">
                 <h3 className="font-medium mb-1.5">{f.q}</h3>
                 <p className="text-sm text-muted">{f.a}</p>
               </div>

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { User } from "lucide-react";
-import { getGitHubAvatarUrl } from "@/lib/utils";
+import { getGitHubAvatarUrl, sizedAvatarUrl } from "@/lib/utils";
 
 interface AvatarProps {
   src?: string | null;
@@ -78,11 +78,13 @@ export default function Avatar({
   const initials = getInitials(displayName);
   const gradient = generateGradient(displayName);
 
-  // Determine the image source
-  let imageSrc = src;
+  // Determine the image source. Request 2x the display size for retina, and
+  // never the full-res original — stored avatar URLs have no size param.
+  const sizePixels = size === "sm" ? 32 : size === "md" ? 40 : 48;
+  const fetchSize = sizePixels * 2;
+  let imageSrc = src ? sizedAvatarUrl(src, fetchSize) : undefined;
   if (!imageSrc && githubUsername) {
-    const sizePixels = size === "sm" ? 32 : size === "md" ? 40 : 48;
-    imageSrc = getGitHubAvatarUrl(githubUsername, sizePixels);
+    imageSrc = getGitHubAvatarUrl(githubUsername, fetchSize);
   }
 
   const ringClass = showRing ? "ring-2 ring-border/20" : "";
@@ -117,6 +119,10 @@ export default function Avatar({
       <img
         src={imageSrc}
         alt={displayName}
+        width={sizePixels}
+        height={sizePixels}
+        loading="lazy"
+        decoding="async"
         className={`${sizeClasses[size]} rounded-full ${ringClass} object-cover ${
           isLoading ? "opacity-0" : "opacity-100"
         } transition-opacity duration-200`}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,7 @@ const RESOURCES = [
 
 export default function Footer() {
   return (
-    <footer className="border-t border-border bg-surface-1">
+    <footer className="border-t border-border">
       <div className="max-w-6xl mx-auto px-6 py-12">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
           <div className="col-span-2 md:col-span-1">
@@ -20,7 +20,7 @@ export default function Footer() {
                 <rect x="9.5" y="8" width="5" height="13" rx="1" fill="currentColor" opacity="0.75" />
                 <rect x="16" y="3" width="5" height="18" rx="1" fill="currentColor" />
               </svg>
-              <span className="font-semibold">viberank</span>
+              <span className="font-mono font-semibold tracking-tight">viberank</span>
             </Link>
             <p className="text-sm text-muted leading-relaxed">
               The leaderboard for AI coding usage. Real costs, real tokens, from real ccusage data.
@@ -28,7 +28,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Leaderboards</h3>
+            <h3 className="micro-label mb-3">Leaderboards</h3>
             <ul className="space-y-2 text-sm">
               <li><Link href="/" className="text-foreground/80 hover:text-accent transition-colors">All tools</Link></li>
               {FEATURED_TOOLS.map((t) => (
@@ -42,7 +42,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Resources</h3>
+            <h3 className="micro-label mb-3">Resources</h3>
             <ul className="space-y-2 text-sm">
               {RESOURCES.map((r) => (
                 <li key={r.href}>
@@ -55,7 +55,7 @@ export default function Footer() {
           </div>
 
           <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-muted mb-3">Community</h3>
+            <h3 className="micro-label mb-3">Community</h3>
             <ul className="space-y-2 text-sm">
               <li>
                 <a href="https://github.com/sculptdotfun/viberank" target="_blank" rel="noopener noreferrer" className="text-foreground/80 hover:text-accent transition-colors">

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -2,11 +2,13 @@
 
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Trophy, Medal, Award, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2 } from "lucide-react";
+import { Trophy, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import ShareCard from "./ShareCard";
 import Avatar from "./Avatar";
+import TierBadge from "./TierBadge";
+import { TIERS } from "@/lib/tiers";
 import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
 import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useSubmissions";
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
@@ -21,90 +23,12 @@ interface LeaderboardProps {
   initialHasMore?: boolean;
 }
 
-// Small flat pills showing which tools a submission used.
-function ToolChips({ tools, max = 3, className = "" }: { tools?: string[]; max?: number; className?: string }) {
-  if (!tools || tools.length === 0) return null;
-  const shown = tools.slice(0, max);
-  const extra = tools.length - shown.length;
-  return (
-    <div className={`flex items-center gap-1 flex-wrap ${className}`}>
-      {shown.map((t) => (
-        <span
-          key={t}
-          className="text-[10px] font-medium leading-none px-1.5 py-1 rounded-md bg-surface-3 text-muted border border-border-subtle"
-        >
-          {toolLabel(t)}
-        </span>
-      ))}
-      {extra > 0 && <span className="text-[10px] text-muted leading-none">+{extra}</span>}
-    </div>
-  );
-}
-
-const RANK_META = [
-  { label: "1st", Icon: Trophy, color: "text-[#f5b008]" },
-  { label: "2nd", Icon: Medal, color: "text-[#b8bcc4]" },
-  { label: "3rd", Icon: Award, color: "text-[#c2703f]" },
-];
-
-function PodiumCard({
-  submission,
-  rank,
-  isCurrentUser,
-}: {
-  submission: Submission;
-  rank: number;
-  isCurrentUser: boolean;
-}) {
-  const meta = RANK_META[rank - 1];
-  const { Icon } = meta;
-  const featured = rank === 1;
-  return (
-    <Link
-      href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
-      className={`group flex flex-col rounded-2xl border bg-surface-1 p-4 transition-colors hover:bg-surface-2 ${
-        featured ? "border-accent/40 sm:p-5" : "border-border"
-      } ${isCurrentUser ? "ring-1 ring-accent" : ""}`}
-    >
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-1.5">
-          <Icon className={`w-4 h-4 ${meta.color}`} />
-          <span className="text-xs font-semibold text-muted">{meta.label}</span>
-        </div>
-        {submission.verified ? (
-          <BadgeCheck className="w-4 h-4 text-blue-500" />
-        ) : (
-          <span className="text-[9px] font-mono uppercase tracking-wider px-1 py-px rounded bg-muted/15 text-muted">cli</span>
-        )}
-      </div>
-
-      <div className="flex items-center gap-3 mb-4">
-        <Avatar
-          src={submission.githubAvatar}
-          githubUsername={submission.githubUsername}
-          name={submission.githubName || submission.username}
-          size={featured ? "lg" : "md"}
-        />
-        <div className="min-w-0">
-          <div className="font-semibold truncate group-hover:text-accent transition-colors">
-            {submission.githubUsername || submission.username}
-          </div>
-          {submission.githubName && submission.githubName !== submission.githubUsername && (
-            <div className="text-xs text-muted truncate">{submission.githubName}</div>
-          )}
-        </div>
-      </div>
-
-      <div className="mt-auto">
-        <div className={`font-mono font-bold text-accent ${featured ? "text-2xl" : "text-xl"}`}>
-          ${formatCurrency(submission.totalCost)}
-        </div>
-        <div className="text-xs text-muted font-mono mt-0.5">{formatNumber(submission.totalTokens)} tokens</div>
-        <ToolChips tools={submission.tools} className="mt-3" />
-      </div>
-    </Link>
-  );
-}
+// Medal colors for the top three rank numbers.
+const RANK_COLORS: Record<number, string> = {
+  1: "text-[#f5b008]",
+  2: "text-[#b8bcc4]",
+  3: "text-[#c2703f]",
+};
 
 // Flat placeholder rows shown while a filter/sort change is fetching.
 function SkeletonRows({ count = 8 }: { count?: number }) {
@@ -234,16 +158,13 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
     return diff === days;
   };
 
-  const podiumCount = Math.min(3, allItems.length);
-  const podium = allItems.slice(0, podiumCount);
-  const rest = allItems.slice(podiumCount);
-
   return (
     <div>
       {/* Filter bar — sticky under the nav while scrolling the board */}
-      <div className="sticky top-14 z-40 -mx-6 px-6 py-3 bg-background/95 backdrop-blur border-y border-border mb-6">
+      <div className="sticky top-14 z-40 py-2.5 bg-background/95 backdrop-blur border-b border-border mb-5">
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-1.5">
+            <span className="micro-label mr-2 hidden lg:block">Leaderboard</span>
             {[
               { label: "All", days: null },
               { label: "7d", days: 7 },
@@ -252,7 +173,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
               <button
                 key={label}
                 onClick={() => setQuickFilter(days)}
-                className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+                className={`px-2.5 py-1 text-xs font-mono font-medium rounded transition-colors ${
                   days === null
                     ? (!dateFrom && !dateTo ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2")
                     : (isQuickFilterActive(days) ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2")
@@ -263,9 +184,10 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
             ))}
             <button
               onClick={() => setShowFilters(!showFilters)}
-              className={`p-1.5 rounded-md transition-colors ${showFilters ? "text-accent" : "text-muted hover:text-foreground"}`}
+              aria-label="Custom date range"
+              className={`p-1.5 rounded transition-colors ${showFilters ? "text-accent" : "text-muted hover:text-foreground"}`}
             >
-              <Calendar className="w-4 h-4" />
+              <Calendar className="w-3.5 h-3.5" />
             </button>
 
             {availableTools.length > 1 && (
@@ -273,7 +195,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                 value={tool ?? ""}
                 onChange={(e) => setTool(e.target.value || null)}
                 aria-label="Filter by tool"
-                className={`px-2.5 py-1.5 text-sm font-medium rounded-md bg-surface-2 border border-border transition-colors focus:outline-none focus:ring-1 focus:ring-accent ${
+                className={`px-2 py-1 text-xs font-mono font-medium rounded bg-surface-2 border border-border transition-colors focus:outline-none focus:ring-1 focus:ring-accent ${
                   tool ? "text-accent" : "text-muted hover:text-foreground"
                 }`}
               >
@@ -287,23 +209,23 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
             )}
           </div>
 
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1">
             <button
               onClick={() => setSortBy("cost")}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md flex items-center gap-1.5 transition-colors ${
+              className={`px-2.5 py-1 text-xs font-mono font-medium rounded flex items-center gap-1 transition-colors ${
                 sortBy === "cost" ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2"
               }`}
             >
-              <DollarSign className="w-4 h-4" />
+              <DollarSign className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">Cost</span>
             </button>
             <button
               onClick={() => setSortBy("tokens")}
-              className={`px-3 py-1.5 text-sm font-medium rounded-md flex items-center gap-1.5 transition-colors ${
+              className={`px-2.5 py-1 text-xs font-mono font-medium rounded flex items-center gap-1 transition-colors ${
                 sortBy === "tokens" ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2"
               }`}
             >
-              <Zap className="w-4 h-4" />
+              <Zap className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">Tokens</span>
             </button>
           </div>
@@ -342,41 +264,39 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
         </AnimatePresence>
       </div>
 
+      {/* Tier ladder key — desktop gets the sidebar ladder instead */}
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 mb-5 px-0.5 lg:hidden">
+        <span className="micro-label">Tiers</span>
+        {TIERS.map((t) => (
+          <span key={t.key} className="inline-flex items-baseline gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em]">
+            <span style={{ color: t.color }}>
+              {t.glyph} {t.name}
+            </span>
+            <span className="text-muted/70 normal-case tracking-normal">
+              {t.min === 0 ? "$0" : `$${formatNumber(t.min).replace(".0", "")}`}+
+            </span>
+          </span>
+        ))}
+      </div>
+
       {/* Board */}
       {allItems.length > 0 ? (
         <div>
-          {/* Podium */}
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:items-end mb-6">
-            {podium.map((submission, i) => {
-              const rank = i + 1;
-              const order = rank === 1 ? "order-1 sm:order-2" : rank === 2 ? "order-2 sm:order-1" : "order-3";
-              return (
-                <div key={submission.id} className={order}>
-                  <PodiumCard
-                    submission={submission}
-                    rank={rank}
-                    isCurrentUser={session?.user?.username === submission.githubUsername}
-                  />
-                </div>
-              );
-            })}
-          </div>
-
           {/* Full table */}
-          {rest.length > 0 && (
-            <div className="rounded-2xl border border-border overflow-hidden">
-              <div className="flex items-center gap-3 px-4 py-2.5 text-xs text-muted bg-surface-1 border-b border-border">
+          {allItems.length > 0 && (
+            <div className="rounded-lg border border-border overflow-hidden">
+              <div className="flex items-center gap-3 px-4 py-2.5 micro-label bg-surface-1 border-b border-border">
                 <div className="w-8 text-center">#</div>
                 <div className="flex-1">User</div>
-                <div className="hidden md:block w-44">Tools</div>
+                <div className="hidden sm:block w-28">Tier</div>
                 <div className="w-28 text-right">Cost</div>
                 <div className="w-24 text-right hidden sm:block">Tokens</div>
                 <div className="w-8" />
               </div>
 
               <div className="divide-y divide-border-subtle">
-                {rest.map((submission, i) => {
-                  const rank = podiumCount + i + 1;
+                {allItems.map((submission, i) => {
+                  const rank = i + 1;
                   const isCurrentUser = session?.user?.username === submission.githubUsername;
                   return (
                     <Link
@@ -384,7 +304,13 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                       href={`/profile/${encodeURIComponent(submission.githubUsername || submission.username)}`}
                       className={`flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors cursor-pointer group ${isCurrentUser ? "bg-accent/10 border-l-2 border-l-accent" : ""}`}
                     >
-                      <div className="w-8 flex-shrink-0 text-center text-sm text-muted font-mono">{rank}</div>
+                      <div
+                        className={`w-8 flex-shrink-0 text-center text-sm font-mono ${
+                          RANK_COLORS[rank] ? `${RANK_COLORS[rank]} font-bold` : "text-muted"
+                        }`}
+                      >
+                        {rank}
+                      </div>
 
                       <div className="flex items-center gap-3 flex-1 min-w-0">
                         <Avatar
@@ -410,11 +336,11 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                         </div>
                       </div>
 
-                      <div className="hidden md:block w-44">
-                        <ToolChips tools={submission.tools} max={3} />
+                      <div className="hidden sm:block w-28 flex-shrink-0">
+                        <TierBadge totalCost={submission.totalCost} size="xs" bare />
                       </div>
 
-                      <div className="w-28 text-right flex-shrink-0">
+                      <div className="w-24 sm:w-28 text-right flex-shrink-0">
                         <div className="text-sm font-mono font-semibold text-accent">${formatCurrency(submission.totalCost)}</div>
                       </div>
 
@@ -422,7 +348,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                         <div className="text-sm font-mono text-muted">{formatNumber(submission.totalTokens)}</div>
                       </div>
 
-                      <div className="w-8 flex-shrink-0 flex justify-end">
+                      <div className="w-8 flex-shrink-0 justify-end hidden sm:flex">
                         {isCurrentUser && (
                           <button
                             onClick={(e) => { e.preventDefault(); setShowShareCard(submission.id); }}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,28 +2,42 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Upload, Github, Sparkles, Menu, X, Shield, BookOpen } from "lucide-react";
+import { Upload, Github, Sparkles, Menu, X } from "lucide-react";
 import { useSession, signIn, signOut } from "next-auth/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import Avatar from "./Avatar";
+import SubmitModal from "./SubmitModal";
+import UpdatesModal from "./UpdatesModal";
 import { isAdmin as checkIsAdmin } from "@/lib/admin";
 
-interface NavBarProps {
-  onUploadClick: () => void;
-  onUpdatesClick: () => void;
+function Wordmark({ size = 20 }: { size?: number }) {
+  return (
+    <>
+      <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className="text-accent">
+        <rect x="3" y="14" width="5" height="7" rx="1" fill="currentColor" opacity="0.5" />
+        <rect x="9.5" y="8" width="5" height="13" rx="1" fill="currentColor" opacity="0.75" />
+        <rect x="16" y="3" width="5" height="18" rx="1" fill="currentColor" />
+      </svg>
+      <span className="font-mono font-semibold tracking-tight">viberank</span>
+    </>
+  );
 }
 
-export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
+// Site-wide nav. Owns the submit + updates modals so any page can mount it
+// with no props.
+export default function NavBar() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [showSubmit, setShowSubmit] = useState(false);
+  const [showUpdates, setShowUpdates] = useState(false);
   const { data: session } = useSession();
   const pathname = usePathname();
 
   const isAdmin = checkIsAdmin(session?.user?.username);
 
   const navItems = [
-    { name: "Blog", href: "/blog", icon: BookOpen },
-    ...(isAdmin ? [{ name: "Admin", href: "/admin", icon: Shield }] : []),
+    { name: "Blog", href: "/blog" },
+    ...(isAdmin ? [{ name: "Admin", href: "/admin" }] : []),
   ];
 
   return (
@@ -32,29 +46,22 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
       <header className="sticky top-0 z-50 h-14 bg-background/95 backdrop-blur border-b border-border hidden md:flex items-center">
         <div className="w-full max-w-6xl mx-auto px-6 flex items-center justify-between">
           {/* Left: Logo + Nav Items */}
-          <div className="flex items-center gap-6">
-            <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition-opacity">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" className="text-accent">
-                <rect x="3" y="14" width="5" height="7" rx="1" fill="currentColor" opacity="0.5"/>
-                <rect x="9.5" y="8" width="5" height="13" rx="1" fill="currentColor" opacity="0.75"/>
-                <rect x="16" y="3" width="5" height="18" rx="1" fill="currentColor"/>
-              </svg>
-              <span className="font-semibold text-lg">viberank</span>
+          <div className="flex items-center gap-5">
+            <Link href="/" className="flex items-center gap-2 text-lg hover:opacity-80 transition-opacity">
+              <Wordmark />
             </Link>
 
-            <div className="flex items-center gap-1">
+            <div className="flex items-center gap-0.5">
               {navItems.map((item) => {
-                const Icon = item.icon;
-                const isActive = pathname === item.href;
+                const isActive = pathname.startsWith(item.href);
                 return (
                   <Link
                     key={item.name}
                     href={item.href}
-                    className={`px-3 py-1.5 text-sm rounded flex items-center gap-1.5 transition-colors ${
-                      isActive ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2"
+                    className={`px-3 h-8 inline-flex items-center text-sm rounded-md transition-colors ${
+                      isActive ? "text-foreground bg-surface-2" : "text-muted hover:text-foreground hover:bg-surface-2"
                     }`}
                   >
-                    <Icon className="w-4 h-4" />
                     {item.name}
                   </Link>
                 );
@@ -63,36 +70,30 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
           </div>
 
           {/* Right: Actions */}
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             <button
-              onClick={onUploadClick}
-              className="px-4 py-2 bg-accent text-white text-sm rounded-md font-medium hover:bg-accent-hover transition-colors flex items-center gap-2"
+              onClick={() => setShowUpdates(true)}
+              aria-label="What's new"
+              className="relative h-9 w-9 inline-flex items-center justify-center text-muted hover:text-foreground hover:bg-surface-2 rounded-md transition-colors"
             >
-              <Upload className="w-4 h-4" />
-              Submit
-            </button>
-
-            <button
-              onClick={onUpdatesClick}
-              className="p-2 text-muted hover:text-foreground hover:bg-surface-2 rounded-md transition-colors relative"
-            >
-              <Sparkles className="w-5 h-5" />
-              <span className="absolute top-1 right-1 w-2 h-2 bg-accent rounded-full" />
+              <Sparkles className="w-[18px] h-[18px]" />
+              <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 bg-accent rounded-full" />
             </button>
 
             <a
               href="https://github.com/sculptdotfun/viberank"
               target="_blank"
               rel="noopener noreferrer"
-              className="p-2 text-muted hover:text-foreground hover:bg-surface-2 rounded-md transition-colors"
+              aria-label="GitHub repository"
+              className="h-9 w-9 inline-flex items-center justify-center text-muted hover:text-foreground hover:bg-surface-2 rounded-md transition-colors"
             >
-              <Github className="w-5 h-5" />
+              <Github className="w-[18px] h-[18px]" />
             </a>
 
             {session ? (
               <button
                 onClick={() => signOut()}
-                className="flex items-center gap-2 px-3 py-1.5 text-sm border border-border rounded-md hover:bg-surface-2 transition-colors"
+                className="h-9 inline-flex items-center gap-2 px-2.5 text-sm border border-border rounded-md hover:bg-surface-2 transition-colors"
               >
                 <Avatar
                   src={session.user?.image}
@@ -106,12 +107,20 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
             ) : (
               <button
                 onClick={() => signIn("github")}
-                className="px-4 py-2 text-sm border border-border rounded-md hover:bg-surface-2 transition-colors flex items-center gap-2"
+                className="h-9 inline-flex items-center gap-2 px-3.5 text-sm font-medium border border-border rounded-md hover:bg-surface-2 transition-colors"
               >
                 <Github className="w-4 h-4" />
                 Sign in
               </button>
             )}
+
+            <button
+              onClick={() => setShowSubmit(true)}
+              className="h-9 inline-flex items-center gap-2 px-3.5 bg-accent text-white text-sm rounded-md font-medium hover:bg-accent-hover transition-colors btn-glow"
+            >
+              <Upload className="w-4 h-4" />
+              Submit
+            </button>
           </div>
         </div>
       </header>
@@ -120,25 +129,21 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
       <header className="md:hidden sticky top-0 z-50 h-14 bg-background/95 backdrop-blur border-b border-border">
         <div className="h-full px-4 flex items-center justify-between">
           <Link href="/" className="flex items-center gap-2">
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" className="text-accent">
-              <rect x="3" y="14" width="5" height="7" rx="1" fill="currentColor" opacity="0.5"/>
-              <rect x="9.5" y="8" width="5" height="13" rx="1" fill="currentColor" opacity="0.75"/>
-              <rect x="16" y="3" width="5" height="18" rx="1" fill="currentColor"/>
-            </svg>
-            <span className="font-semibold">viberank</span>
+            <Wordmark size={18} />
           </Link>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5">
             <button
-              onClick={onUploadClick}
-              className="px-3 py-1.5 bg-accent text-white text-sm rounded-md font-medium flex items-center gap-1.5"
+              onClick={() => setShowSubmit(true)}
+              className="h-8 inline-flex items-center gap-1.5 px-3 bg-accent text-white text-sm rounded-md font-medium"
             >
-              <Upload className="w-4 h-4" />
+              <Upload className="w-3.5 h-3.5" />
               Submit
             </button>
             <button
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="p-2 text-muted hover:text-foreground"
+              aria-label="Menu"
+              className="h-8 w-8 inline-flex items-center justify-center text-muted hover:text-foreground rounded-md"
             >
               {mobileMenuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
             </button>
@@ -153,44 +158,39 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
               exit={{ opacity: 0, height: 0 }}
               className="bg-background border-b border-border"
             >
-              <div className="px-4 py-3 space-y-2">
-                {navItems.map((item) => {
-                  const Icon = item.icon;
-                  return (
-                    <Link
-                      key={item.name}
-                      href={item.href}
-                      onClick={() => setMobileMenuOpen(false)}
-                      className="flex items-center gap-2 px-3 py-2 text-sm rounded hover:bg-surface-2"
-                    >
-                      <Icon className="w-4 h-4" />
-                      {item.name}
-                    </Link>
-                  );
-                })}
-
-                <div className="flex items-center gap-2 pt-2 border-t border-border">
-                  <button
-                    onClick={() => { onUpdatesClick(); setMobileMenuOpen(false); }}
-                    className="p-2 text-muted hover:text-foreground"
+              <div className="px-4 py-3 space-y-1">
+                {navItems.map((item) => (
+                  <Link
+                    key={item.name}
+                    href={item.href}
+                    onClick={() => setMobileMenuOpen(false)}
+                    className="block px-3 py-2 text-sm rounded-md hover:bg-surface-2"
                   >
-                    <Sparkles className="w-4 h-4" />
-                  </button>
-                  <a
-                    href="https://github.com/sculptdotfun/viberank"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="p-2 text-muted hover:text-foreground"
-                  >
-                    <Github className="w-4 h-4" />
-                  </a>
-                </div>
+                    {item.name}
+                  </Link>
+                ))}
+                <button
+                  onClick={() => { setShowUpdates(true); setMobileMenuOpen(false); }}
+                  className="w-full text-left flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-surface-2"
+                >
+                  <Sparkles className="w-4 h-4 text-muted" />
+                  What&apos;s new
+                </button>
+                <a
+                  href="https://github.com/sculptdotfun/viberank"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-surface-2"
+                >
+                  <Github className="w-4 h-4 text-muted" />
+                  GitHub
+                </a>
 
                 <div className="pt-2 border-t border-border">
                   {session ? (
                     <button
                       onClick={() => { signOut(); setMobileMenuOpen(false); }}
-                      className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded hover:bg-surface-2"
+                      className="w-full flex items-center gap-2 px-3 py-2 text-sm rounded-md hover:bg-surface-2"
                     >
                       <Avatar
                         src={session.user?.image}
@@ -204,7 +204,7 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
                   ) : (
                     <button
                       onClick={() => { signIn("github"); setMobileMenuOpen(false); }}
-                      className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm border border-border rounded"
+                      className="w-full flex items-center justify-center gap-2 px-3 py-2 text-sm font-medium border border-border rounded-md hover:bg-surface-2"
                     >
                       <Github className="w-4 h-4" />
                       Sign in with GitHub
@@ -216,6 +216,9 @@ export default function NavBar({ onUploadClick, onUpdatesClick }: NavBarProps) {
           )}
         </AnimatePresence>
       </header>
+
+      <SubmitModal open={showSubmit} onClose={() => setShowSubmit(false)} />
+      <UpdatesModal isOpen={showUpdates} onClose={() => setShowUpdates(false)} />
     </>
   );
 }

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -4,6 +4,8 @@ import { motion } from "framer-motion";
 import { Copy, X, Trophy, Check } from "lucide-react";
 import { useState } from "react";
 import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
+import { getTier } from "@/lib/tiers";
+import TierBadge from "./TierBadge";
 
 interface ShareCardProps {
   rank: number;
@@ -19,8 +21,9 @@ export default function ShareCard({ rank, username, totalCost, totalTokens, date
   const [copied, setCopied] = useState(false);
 
   const shareUrl = `https://viberank.app/profile/${encodeURIComponent(username)}`;
+  const tier = getTier(totalCost);
   const toolsLine = tools && tools.length > 0 ? `\n🧰 ${tools.map(toolLabel).join(" · ")}` : "";
-  const shareText = `I'm ranked #${rank} on viberank 🏆\n\n💰 $${formatCurrency(totalCost)} spent\n📊 ${formatNumber(totalTokens)} tokens${toolsLine}\n\nJoin the AI coding leaderboard:`;
+  const shareText = `I'm ranked #${rank} on viberank 🏆\n\n${tier.glyph} ${tier.name.toUpperCase()} tier\n💰 $${formatCurrency(totalCost)} spent\n📊 ${formatNumber(totalTokens)} tokens${toolsLine}\n\nJoin the AI coding leaderboard:`;
 
   const handleCopyLink = () => {
     navigator.clipboard.writeText(shareUrl);
@@ -52,8 +55,11 @@ export default function ShareCard({ rank, username, totalCost, totalTokens, date
       <div className="bg-background border border-border rounded-xl p-5 mb-4">
         <div className="flex items-start justify-between mb-4">
           <div>
-            <p className="text-xs text-muted font-mono mb-1">viberank.app</p>
-            <h4 className="text-lg font-bold">{username}</h4>
+            <p className="micro-label mb-1">viberank.app</p>
+            <div className="flex items-center gap-2">
+              <h4 className="text-lg font-bold">{username}</h4>
+              <TierBadge totalCost={totalCost} size="xs" />
+            </div>
           </div>
           <div className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg bg-accent text-white">
             <Trophy className="w-4 h-4" />

--- a/src/components/SubmitModal.tsx
+++ b/src/components/SubmitModal.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Upload, X, Terminal, Copy, Check } from "lucide-react";
+import FileUpload from "./FileUpload";
+
+interface SubmitModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function SubmitModal({ open, onClose }: SubmitModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  const copyCommand = () => {
+    navigator.clipboard.writeText("npx viberank-cli");
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        >
+          <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 10 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 10 }}
+            className="relative bg-surface-1 border border-border rounded-lg shadow-xl max-w-sm w-full"
+          >
+            <div className="px-4 py-3 flex items-center justify-between border-b border-border">
+              <h3 className="font-medium">Submit Stats</h3>
+              <button onClick={onClose} className="p-1 text-muted hover:text-foreground rounded hover:bg-surface-2">
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+            <div className="p-4 space-y-4">
+              {/* CLI option */}
+              <div className="p-3 rounded-lg bg-accent/5 border border-accent/20">
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2 text-sm">
+                    <Terminal className="w-4 h-4 text-accent" />
+                    <span className="font-medium">CLI</span>
+                  </div>
+                  <span className="text-[10px] px-1.5 py-0.5 bg-accent/20 text-accent rounded">Recommended</span>
+                </div>
+                <button
+                  onClick={copyCommand}
+                  className="w-full flex items-center justify-between gap-2 bg-background rounded-md px-3 py-2 border border-border hover:border-accent/50 transition-colors"
+                >
+                  <code className="text-sm font-mono text-accent">npx viberank-cli</code>
+                  {copied ? <Check className="w-4 h-4 text-success" /> : <Copy className="w-4 h-4 text-muted" />}
+                </button>
+              </div>
+
+              {/* Divider */}
+              <div className="flex items-center gap-3">
+                <div className="flex-1 h-px bg-border" />
+                <span className="text-xs text-muted">or</span>
+                <div className="flex-1 h-px bg-border" />
+              </div>
+
+              {/* Upload option */}
+              <div>
+                <div className="flex items-center gap-2 mb-2 text-sm">
+                  <Upload className="w-4 h-4 text-muted" />
+                  <span className="font-medium">Upload cc.json</span>
+                </div>
+                <FileUpload onSuccess={onClose} />
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/TierBadge.tsx
+++ b/src/components/TierBadge.tsx
@@ -1,0 +1,50 @@
+import { getTier } from "@/lib/tiers";
+import { cn } from "@/lib/utils";
+
+interface TierBadgeProps {
+  totalCost: number;
+  size?: "xs" | "sm" | "md";
+  /** Glyph-only, no pill background — for tight spots like table cells. */
+  bare?: boolean;
+  className?: string;
+}
+
+const SIZE_CLASSES = {
+  xs: "text-[9px] px-1 py-px gap-0.5",
+  sm: "text-[10px] px-1.5 py-0.5 gap-1",
+  md: "text-xs px-2 py-1 gap-1.5",
+};
+
+export default function TierBadge({ totalCost, size = "sm", bare = false, className }: TierBadgeProps) {
+  const tier = getTier(totalCost);
+  // White-hot top tier gets a faint glow.
+  const glow = tier.key === "supernova" ? { textShadow: "0 0 10px rgba(191, 219, 254, 0.5)" } : undefined;
+
+  if (bare) {
+    return (
+      <span
+        className={cn("inline-flex items-center gap-1 font-mono uppercase tracking-[0.12em]", SIZE_CLASSES[size].split(" ")[0], className)}
+        style={{ color: tier.color, ...glow }}
+        title={`${tier.name} tier — $${tier.min.toLocaleString()}+ spent`}
+      >
+        <span aria-hidden>{tier.glyph}</span>
+        {tier.name}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded font-mono font-medium uppercase tracking-[0.12em] leading-none",
+        SIZE_CLASSES[size],
+        className
+      )}
+      style={{ color: tier.color, background: tier.soft, ...glow }}
+      title={`${tier.name} tier — $${tier.min.toLocaleString()}+ spent`}
+    >
+      <span aria-hidden>{tier.glyph}</span>
+      {tier.name}
+    </span>
+  );
+}

--- a/src/lib/home-faqs.ts
+++ b/src/lib/home-faqs.ts
@@ -17,4 +17,8 @@ export const HOME_FAQS = [
     q: "Is the data verified?",
     a: "Submissions are validated server-side (token math, cost/token ratio, date sanity). Signing in with GitHub marks your submission verified with a blue check; unverified CLI rows show a 'cli' badge.",
   },
+  {
+    q: "What are viberank tiers?",
+    a: "Every developer holds a spend tier based on their best submission: Spark ($0+), Ember ($100+), Flame ($1K+), Blaze ($5K+), Inferno ($15K+) and Supernova ($50K+). Tier badges appear on the leaderboard, your profile and your share card — and your profile shows exactly how far you are from the next tier.",
+  },
 ];

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -1,0 +1,56 @@
+// Fire-themed spend tiers, inspired by ranked ladders (and viberank's flame
+// accent). Thresholds are calibrated against the live cost distribution as of
+// June 2026 (797 users): median best-submission ≈ $1.25k, p90 ≈ $6.3k,
+// top ≈ $57k. Roughly: Ember = active, Flame = top half, Blaze = top 15%,
+// Inferno = top 3%, Supernova = top 0.5%.
+export interface Tier {
+  key: "spark" | "ember" | "flame" | "blaze" | "inferno" | "supernova";
+  name: string;
+  glyph: string;
+  /** Minimum total cost (USD) to hold this tier. */
+  min: number;
+  /** Text color on dark surfaces. */
+  color: string;
+  /** Translucent badge background. */
+  soft: string;
+}
+
+// Ascending order — getTier walks this from the top down.
+export const TIERS: Tier[] = [
+  { key: "spark", name: "Spark", glyph: "✧", min: 0, color: "#9aa0a8", soft: "rgba(154, 160, 168, 0.12)" },
+  { key: "ember", name: "Ember", glyph: "✦", min: 100, color: "#c2703f", soft: "rgba(194, 112, 63, 0.14)" },
+  { key: "flame", name: "Flame", glyph: "◆", min: 1_000, color: "#f97316", soft: "rgba(249, 115, 22, 0.14)" },
+  { key: "blaze", name: "Blaze", glyph: "❖", min: 5_000, color: "#fbbf24", soft: "rgba(251, 191, 36, 0.13)" },
+  { key: "inferno", name: "Inferno", glyph: "✶", min: 15_000, color: "#f87171", soft: "rgba(248, 113, 113, 0.13)" },
+  { key: "supernova", name: "Supernova", glyph: "✺", min: 50_000, color: "#dbeafe", soft: "rgba(191, 219, 254, 0.14)" },
+];
+
+export function getTier(totalCost: number): Tier {
+  for (let i = TIERS.length - 1; i >= 0; i--) {
+    if (totalCost >= TIERS[i].min) return TIERS[i];
+  }
+  return TIERS[0];
+}
+
+export function getNextTier(totalCost: number): Tier | null {
+  const current = getTier(totalCost);
+  const idx = TIERS.findIndex((t) => t.key === current.key);
+  return TIERS[idx + 1] ?? null;
+}
+
+/** Progress within the current tier band, for "$X to Blaze" UI. */
+export function getTierProgress(totalCost: number): {
+  tier: Tier;
+  next: Tier | null;
+  /** 0–1 within the current band; 1 when at the top tier. */
+  progress: number;
+  /** Dollars left to the next tier; 0 at the top tier. */
+  remaining: number;
+} {
+  const tier = getTier(totalCost);
+  const next = getNextTier(totalCost);
+  if (!next) return { tier, next: null, progress: 1, remaining: 0 };
+  const span = next.min - tier.min;
+  const progress = Math.min(1, Math.max(0, (totalCost - tier.min) / span));
+  return { tier, next, progress, remaining: Math.max(0, next.min - totalCost) };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -75,5 +75,13 @@ export function formatDateRange(start: string, end: string): string {
 }
 
 export function getGitHubAvatarUrl(username: string, size: number = 40): string {
-  return `https://github.com/${username}.png?size=${size}`;
+  // Hit the avatar CDN directly — github.com/<user>.png 302s to it, which
+  // costs an extra round trip per avatar.
+  return `https://avatars.githubusercontent.com/${username}?s=${size}`;
+}
+
+/** Append a size param to a GitHub avatar URL so we don't download full-res images. */
+export function sizedAvatarUrl(url: string, size: number): string {
+  if (!/githubusercontent\.com/.test(url) || /[?&]s=/.test(url)) return url;
+  return `${url}${url.includes("?") ? "&" : "?"}s=${size}`;
 }


### PR DESCRIPTION
## What's in here

### Gamification — fire-themed spend tiers
- Six tiers calibrated against the live cost distribution (797 users): ✧ Spark $0+ · ✦ Ember $100+ · ◆ Flame $1K+ · ❖ Blaze $5K+ · ✶ Inferno $15K+ · ✺ Supernova $50K+
- Tier badges on the leaderboard, tool pages, profiles and share cards; profiles get a "tier progress" bar showing dollars to the next tier
- New `src/lib/tiers.ts` + `TierBadge` component

### Full page redesign
- Scrolling stats ticker tape above the nav
- Mono editorial hero with blinking cursor; stat cards and per-tool chip rows removed
- Two-column command-center layout: board left, sticky sidebar right (enlist card + tier ladder)
- Podium removed — unified table from #1 with gold/silver/bronze rank numbers
- How-it-works strip and borderless editorial FAQ (new tiers entry feeds FAQPage JSON-LD)

### Profile pull-up sheet (SEO-safe)
- Intercepting route at `app/@modal/(.)profile/[username]` — board clicks open a bottom sheet (stats, 30-day spend sparkline, tier progress); direct loads and crawlers still get the full SSR profile page

### Consistency + performance
- One shell (nav/footer, `max-w-6xl`) across home, profile, tool, blog, admin; NavBar self-contained with its own submit/updates modals
- Avatars hit the GitHub CDN directly with size params + lazy loading (no more 302 per avatar, no full-res downloads)
- Sharpened type system: mono headings, uppercase micro-labels, tighter radii

## Verification
- `tsc --noEmit` clean (pre-existing errors in next.config/scripts untouched)
- `next build` passes incl. parallel/intercepting routes
- Verified in-browser at 1440px and 390px: home, profile sheet, full profile, blog

🤖 Generated with [Claude Code](https://claude.com/claude-code)