### PR TITLE
perf: image loading fixes + bundle code-splitting

### DIFF
--- a/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
+++ b/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
@@ -77,10 +77,13 @@ export default function ProfileSheet(props: ProfileSheetProps) {
             {props.avatar ? (
               // eslint-disable-next-line @next/next/no-img-element
               <img
-                src={sizedAvatarUrl(props.avatar, 96)}
+                src={sizedAvatarUrl(props.avatar, 128)}
                 alt={props.displayName}
                 width={48}
                 height={48}
+                loading="eager"
+                fetchPriority="high"
+                decoding="async"
                 className="w-12 h-12 rounded-full ring-2 ring-border/40"
               />
             ) : (

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -4,7 +4,9 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Upload, Merge, X, Terminal, Copy, Check, Github } from "lucide-react";
 import Leaderboard from "@/components/Leaderboard";
-import SubmitModal from "@/components/SubmitModal";
+import dynamic from "next/dynamic";
+
+const SubmitModal = dynamic(() => import("@/components/SubmitModal"), { ssr: false });
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
 import { useSession, signIn } from "next-auth/react";
@@ -289,7 +291,7 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
 
       <Footer />
 
-      <SubmitModal open={showUploadModal} onClose={() => setShowUploadModal(false)} />
+      {showUploadModal && <SubmitModal open onClose={() => setShowUploadModal(false)} />}
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -110,6 +110,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
+        {/* Avatars come from the GitHub CDN on every page — start the TLS
+            handshake before the first <img> is discovered. */}
+        <link rel="preconnect" href="https://avatars.githubusercontent.com" crossOrigin="anonymous" />
+        <link rel="dns-prefetch" href="https://avatars.githubusercontent.com" />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/src/app/profile/[username]/UsageChartLazy.tsx
+++ b/src/app/profile/[username]/UsageChartLazy.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+// recharts is ~100KB gz — keep it out of the profile page's critical bundle
+// and swap in once loaded. The skeleton mirrors the chart card's footprint.
+const UsageChart = dynamic(() => import("./UsageChart"), {
+  ssr: false,
+  loading: () => (
+    <div className="bg-surface-1 border border-border rounded-lg p-5 mb-6 animate-pulse" aria-hidden>
+      <div className="h-5 w-36 rounded bg-surface-3 mb-4" />
+      <div className="h-[260px] rounded bg-surface-2" />
+    </div>
+  ),
+});
+
+export default UsageChart;

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -14,7 +14,7 @@ import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl } from "@/lib/u
 import { getTierProgress } from "@/lib/tiers";
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "./getProfile";
-import UsageChart from "./UsageChart";
+import UsageChart from "./UsageChartLazy";
 import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
 import TierBadge from "@/components/TierBadge";
@@ -122,6 +122,9 @@ export default async function ProfilePage({ params }: ProfileParams) {
                 alt={displayName}
                 width={64}
                 height={64}
+                loading="eager"
+                fetchPriority="high"
+                decoding="async"
                 className="w-16 h-16 rounded-full ring-2 ring-border/40"
               />
             )}

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { User } from "lucide-react";
 import { getGitHubAvatarUrl, sizedAvatarUrl } from "@/lib/utils";
 
@@ -11,6 +11,8 @@ interface AvatarProps {
   size?: "sm" | "md" | "lg";
   className?: string;
   showRing?: boolean;
+  /** Above-the-fold avatars: fetch eagerly at high priority instead of lazy. */
+  priority?: boolean;
 }
 
 const sizeClasses = {
@@ -70,27 +72,47 @@ export default function Avatar({
   size = "md",
   className = "",
   showRing = true,
+  priority = false,
 }: AvatarProps) {
-  const [imageError, setImageError] = useState(false);
+  // Determine the image sources. Request 2x the display size for retina, and
+  // never the full-res original — stored avatar URLs have no size param. If
+  // the stored URL 404s (renamed/deleted account), fall back to the
+  // username-derived CDN URL before giving up and showing initials.
+  const sizePixels = size === "sm" ? 32 : size === "md" ? 40 : 48;
+  const fetchSize = sizePixels * 2;
+  const candidates: string[] = [];
+  if (src) candidates.push(sizedAvatarUrl(src, fetchSize));
+  if (githubUsername) {
+    const fromUsername = getGitHubAvatarUrl(githubUsername, fetchSize);
+    if (!candidates.includes(fromUsername)) candidates.push(fromUsername);
+  }
+
+  const [srcIndex, setSrcIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
+  const imgRef = useRef<HTMLImageElement | null>(null);
 
   const displayName = name || githubUsername || "User";
   const initials = getInitials(displayName);
   const gradient = generateGradient(displayName);
+  const imageSrc = candidates[srcIndex];
 
-  // Determine the image source. Request 2x the display size for retina, and
-  // never the full-res original — stored avatar URLs have no size param.
-  const sizePixels = size === "sm" ? 32 : size === "md" ? 40 : 48;
-  const fetchSize = sizePixels * 2;
-  let imageSrc = src ? sizedAvatarUrl(src, fetchSize) : undefined;
-  if (!imageSrc && githubUsername) {
-    imageSrc = getGitHubAvatarUrl(githubUsername, fetchSize);
-  }
+  // If the image finished (or failed) before React hydrated, the onLoad /
+  // onError handlers never fire and the img would stay at opacity-0 forever.
+  // Re-check the element's actual state after mount.
+  useEffect(() => {
+    const img = imgRef.current;
+    if (!img || !img.complete) return;
+    if (img.naturalWidth > 0) {
+      setIsLoading(false);
+    } else {
+      setSrcIndex((i) => i + 1);
+    }
+  }, [imageSrc]);
 
   const ringClass = showRing ? "ring-2 ring-border/20" : "";
 
-  // Show fallback if no image or image failed to load
-  if (!imageSrc || imageError) {
+  // Show fallback if no image or every candidate failed to load
+  if (!imageSrc) {
     return (
       <div
         className={`${sizeClasses[size]} rounded-full flex items-center justify-center ${ringClass} ${className} ${
@@ -117,20 +139,20 @@ export default function Avatar({
         <div className={`absolute inset-0 rounded-full bg-card ${ringClass} animate-pulse`} />
       )}
       <img
+        ref={imgRef}
+        key={imageSrc}
         src={imageSrc}
         alt={displayName}
         width={sizePixels}
         height={sizePixels}
-        loading="lazy"
+        loading={priority ? "eager" : "lazy"}
+        fetchPriority={priority ? "high" : "auto"}
         decoding="async"
         className={`${sizeClasses[size]} rounded-full ${ringClass} object-cover ${
           isLoading ? "opacity-0" : "opacity-100"
-        } transition-opacity duration-200`}
+        } transition-opacity duration-150`}
         onLoad={() => setIsLoading(false)}
-        onError={() => {
-          setImageError(true);
-          setIsLoading(false);
-        }}
+        onError={() => setSrcIndex((i) => i + 1)}
       />
     </div>
   );

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -5,7 +5,9 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Trophy, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
-import ShareCard from "./ShareCard";
+import dynamic from "next/dynamic";
+
+const ShareCard = dynamic(() => import("./ShareCard"), { ssr: false });
 import Avatar from "./Avatar";
 import TierBadge from "./TierBadge";
 import { TIERS } from "@/lib/tiers";
@@ -318,6 +320,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                           githubUsername={submission.githubUsername}
                           name={submission.githubName || submission.username}
                           size="sm"
+                          priority={rank <= 10}
                         />
                         <div className="min-w-0">
                           <div className="flex items-center gap-1.5">

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -6,9 +6,13 @@ import { Upload, Github, Sparkles, Menu, X } from "lucide-react";
 import { useSession, signIn, signOut } from "next-auth/react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import dynamic from "next/dynamic";
 import Avatar from "./Avatar";
-import SubmitModal from "./SubmitModal";
-import UpdatesModal from "./UpdatesModal";
+
+// Modals only matter on interaction — split them out of the shell bundle
+// (SubmitModal drags in react-dropzone via FileUpload).
+const SubmitModal = dynamic(() => import("./SubmitModal"), { ssr: false });
+const UpdatesModal = dynamic(() => import("./UpdatesModal"), { ssr: false });
 import { isAdmin as checkIsAdmin } from "@/lib/admin";
 
 function Wordmark({ size = 20 }: { size?: number }) {
@@ -217,8 +221,8 @@ export default function NavBar() {
         </AnimatePresence>
       </header>
 
-      <SubmitModal open={showSubmit} onClose={() => setShowSubmit(false)} />
-      <UpdatesModal isOpen={showUpdates} onClose={() => setShowUpdates(false)} />
+      {showSubmit && <SubmitModal open onClose={() => setShowSubmit(false)} />}
+      {showUpdates && <UpdatesModal isOpen onClose={() => setShowUpdates(false)} />}
     </>
   );
 }


### PR DESCRIPTION
## Image fixes
- **Avatars stuck invisible (the "images don't load sometimes" bug):** the img rendered at opacity-0 and waited for React's onLoad — but cached images finish loading before hydration, so onLoad never fired and loaded avatars stayed invisible. Now we re-check `img.complete`/`naturalWidth` after mount. Verified on a warm-cache prod-build reload (all 25 avatars from cache): 25/25 visible.
- Fallback chain: stored avatar URL → username-derived CDN URL → initials (handles renamed/deleted accounts).
- Above-the-fold avatars (top 10 board rows, profile sheet, profile header) now load eagerly with `fetchPriority=high`; the sheet requests the same 128px variant as the profile page so the browser cache entry is shared.
- `preconnect`/`dns-prefetch` to avatars.githubusercontent.com.

## Bundle code-splitting
- recharts `UsageChart` → `next/dynamic` with skeleton (no longer blocks profile first paint)
- `SubmitModal` (drags in react-dropzone), `UpdatesModal`, `ShareCard` → load on demand when opened
- Total static JS: **2192KB → 1704KB (-22%)**

## Verification
- `tsc` clean, `next build` passes
- Prod-build browser checks: home, submit modal lazy-open, profile chart lazy-render, warm-cache avatar visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)