### PR TITLE
Env-gated sponsor inventory: leaderboard slot + CLI post-submit notice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,3 +19,9 @@ GITHUB_SECRET=your-github-oauth-app-secret
 #    - Homepage URL: http://localhost:3000
 #    - Authorization callback URL: http://localhost:3000/api/auth/callback/github
 # 4. Copy the Client ID and Client Secret
+
+# Sponsor slot (all optional — leave unset to hide every sponsor surface)
+# NEXT_PUBLIC_SPONSOR_NAME=Acme
+# NEXT_PUBLIC_SPONSOR_TAGLINE=Observability for AI agents
+# NEXT_PUBLIC_SPONSOR_URL=https://acme.dev/?ref=viberank
+# SPONSOR_CLI_NOTICE=viberank is sponsored by Acme — https://acme.dev/?ref=viberank-cli

--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -223,6 +223,9 @@ async function main() {
       if (result.success) {
         submitSpinner.succeed('Successfully submitted to Viberank!');
         console.log(`\nView your profile at: ${chalk.green(result.profileUrl)}\n`);
+        if (result.notice) {
+          console.log(chalk.gray(result.notice) + '\n');
+        }
         break; // Success, exit the retry loop
       } else {
         submitSpinner.fail('Failed to submit to Viberank');

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viberank-cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getServerDataLayer, getDatabaseBackend } from "@/lib/data";
 import { normalizeCcData } from "@/lib/ccusage";
+import { getCliNotice } from "@/lib/sponsor";
 
 export async function POST(request: NextRequest) {
   try {
@@ -225,7 +226,9 @@ export async function POST(request: NextRequest) {
       success: true,
       submissionId,
       message: `Successfully submitted data for ${githubUsername}`,
-      profileUrl: `https://viberank.app/profile/${githubUsername}`
+      profileUrl: `https://viberank.app/profile/${githubUsername}`,
+      // Optional sponsor line the CLI prints after a successful submission.
+      notice: getCliNotice(),
     });
 
   } catch (error) {

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -9,6 +9,7 @@ import dynamic from "next/dynamic";
 
 const ShareCard = dynamic(() => import("./ShareCard"), { ssr: false });
 import Avatar from "./Avatar";
+import SponsorSlot from "./SponsorSlot";
 import TierBadge from "./TierBadge";
 import { TIERS } from "@/lib/tiers";
 import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
@@ -279,6 +280,8 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
           )}
         </AnimatePresence>
       </div>
+
+      <SponsorSlot />
 
       {/* Tier ladder key — desktop gets the sidebar ladder instead */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 mb-5 px-0.5 lg:hidden">

--- a/src/components/SponsorSlot.tsx
+++ b/src/components/SponsorSlot.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import { getSponsor } from "@/lib/sponsor";
+
+// Single tasteful sponsor line above the leaderboard. Renders nothing unless
+// NEXT_PUBLIC_SPONSOR_NAME and NEXT_PUBLIC_SPONSOR_URL are set.
+export default function SponsorSlot() {
+  const sponsor = getSponsor();
+  if (!sponsor) return null;
+
+  return (
+    <a
+      href={sponsor.url}
+      target="_blank"
+      rel="noopener sponsored"
+      onClick={() => track("sponsor_click", { sponsor: sponsor.name, placement: "leaderboard" })}
+      className="flex items-center gap-2 px-4 py-2.5 mb-5 rounded-lg border border-border bg-surface-1 hover:border-accent/40 transition-colors group"
+    >
+      <span className="micro-label flex-shrink-0">Sponsor</span>
+      <span className="text-sm font-medium group-hover:text-accent transition-colors">{sponsor.name}</span>
+      {sponsor.tagline && (
+        <span className="text-sm text-muted truncate hidden sm:inline">— {sponsor.tagline}</span>
+      )}
+    </a>
+  );
+}

--- a/src/lib/sponsor.ts
+++ b/src/lib/sponsor.ts
@@ -1,0 +1,30 @@
+// Sponsor slot configuration. All values come from env vars so a sponsor can
+// be turned on/off with a redeploy and no code change. When NAME or URL is
+// unset, every sponsor surface renders nothing.
+//
+// NEXT_PUBLIC_* vars are inlined at build time and drive the site UI;
+// SPONSOR_CLI_NOTICE is server-only and is returned to the CLI after a
+// successful submission.
+
+export interface Sponsor {
+  name: string;
+  url: string;
+  tagline: string | null;
+}
+
+export function getSponsor(): Sponsor | null {
+  const name = process.env.NEXT_PUBLIC_SPONSOR_NAME;
+  const url = process.env.NEXT_PUBLIC_SPONSOR_URL;
+  if (!name || !url) return null;
+  return {
+    name,
+    url,
+    tagline: process.env.NEXT_PUBLIC_SPONSOR_TAGLINE || null,
+  };
+}
+
+// Server-only: line printed by the CLI after a successful submission,
+// e.g. "viberank is sponsored by Acme — https://acme.dev/viberank".
+export function getCliNotice(): string | null {
+  return process.env.SPONSOR_CLI_NOTICE || null;
+}


### PR DESCRIPTION
## Summary
- `src/lib/sponsor.ts`: sponsor config from env vars — all surfaces render nothing when unset
- `SponsorSlot` above the leaderboard, native styling, clicks tracked via `sponsor_click` Vercel event
- `/api/submit` returns optional `notice` (from `SPONSOR_CLI_NOTICE`); CLI 1.1.1 prints it in gray after a successful submit
- env vars documented in .env.example

To activate a sponsor: set the four env vars in Vercel and redeploy. To deactivate: unset them. No code changes needed.

## Test plan
- next build passes with and without sponsor env vars
- Verified visually at localhost with test vars: slot renders between filter bar and board, hidden when unset

🤖 Generated with [Claude Code](https://claude.com/claude-code)