### PR TITLE
/hire MVP: open-to-work opt-in + hiring page + company CTA

### DIFF
--- a/src/app/api/profile/open-to-work/route.ts
+++ b/src/app/api/profile/open-to-work/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+
+// Toggle the signed-in user's own open-to-work flag. Identity comes from the
+// GitHub OAuth session only — there is no way to set this for someone else.
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.username) {
+    return NextResponse.json({ error: "Sign in with GitHub first." }, { status: 401 });
+  }
+
+  let open: boolean;
+  try {
+    const body = await request.json();
+    if (typeof body.open !== "boolean") throw new Error("bad payload");
+    open = body.open;
+  } catch {
+    return NextResponse.json({ error: "Expected JSON body: { open: boolean }" }, { status: 400 });
+  }
+
+  const dataLayer = await getServerDataLayer();
+  const result = await dataLayer.profiles.setOpenToWork(session.user.username, open);
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.error || "Update failed" }, { status: 400 });
+  }
+  return NextResponse.json({ success: true, open });
+}

--- a/src/app/hire/HireCta.tsx
+++ b/src/app/hire/HireCta.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { track } from "@vercel/analytics";
+import { Mail } from "lucide-react";
+
+const MAILTO =
+  "mailto:nikshepsvn@gmail.com?subject=" +
+  encodeURIComponent("Job post on viberank /hire") +
+  "&body=" +
+  encodeURIComponent(
+    "Company:\nRole + link:\nRemote/location:\nComp range:\n\nWe'll get back within 24h with details."
+  );
+
+// Company-facing CTA. Mailto for the MVP — swap for a form/Stripe once
+// there's demand worth automating.
+export default function HireCta() {
+  return (
+    <a
+      href={MAILTO}
+      onClick={() => track("hire_cta_click")}
+      className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg bg-accent text-white text-sm font-medium hover:bg-accent-hover transition-colors"
+    >
+      <Mail className="w-4 h-4" />
+      Post a job — reach these engineers
+    </a>
+  );
+}

--- a/src/app/hire/page.tsx
+++ b/src/app/hire/page.tsx
@@ -1,0 +1,148 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Github, BadgeCheck, BriefcaseBusiness } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl } from "@/lib/utils";
+import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
+import TierBadge from "@/components/TierBadge";
+import HireCta from "./HireCta";
+
+export const revalidate = 300;
+
+const TITLE = "Hire AI-native engineers | Viberank";
+const DESC =
+  "Engineers from the viberank leaderboard who are open to work — ranked by real, measured AI coding usage, not claims on a resume.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: "https://www.viberank.app/hire" },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: "https://www.viberank.app/hire",
+    images: [
+      {
+        url: "/api/og?title=Hire%20AI-native%20engineers&description=Ranked%20by%20real%2C%20measured%20AI%20coding%20usage",
+        width: 1200,
+        height: 630,
+      },
+    ],
+  },
+};
+
+export default async function HirePage() {
+  const dataLayer = await getServerDataLayer();
+  let listings: Awaited<ReturnType<typeof dataLayer.profiles.getHireListings>> = [];
+  try {
+    listings = await dataLayer.profiles.getHireListings();
+  } catch {
+    // render the page shell even if the query hiccups
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+
+      <div className="max-w-4xl mx-auto px-6 py-12">
+        <p className="micro-label mb-3">Hire</p>
+        <h1 className="font-mono text-3xl font-bold tracking-tight text-foreground mb-3">
+          AI-native engineers, proven by usage
+        </h1>
+        <p className="text-muted max-w-2xl mb-6">
+          Everyone below is on the <Link href="/" className="text-accent hover:underline">viberank leaderboard</Link>{" "}
+          with real, locally-measured AI coding usage — and has explicitly opted in to being contacted.
+          No resumes, no claims: the rank <em>is</em> the proof of work.
+        </p>
+        <div className="flex flex-wrap items-center gap-4 mb-12">
+          <HireCta />
+          <span className="text-xs text-muted">
+            Hiring? Your role goes in front of the most agentic engineers anywhere.
+          </span>
+        </div>
+
+        {listings.length > 0 ? (
+          <div className="rounded-lg border border-border overflow-hidden">
+            <div className="flex items-center gap-3 px-4 py-2.5 micro-label bg-surface-1 border-b border-border">
+              <div className="flex-1">Engineer</div>
+              <div className="hidden sm:block w-28">Tier</div>
+              <div className="w-24 text-right">Usage</div>
+              <div className="w-20 text-right hidden sm:block">Rank</div>
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {listings.map((l) => (
+                <Link
+                  key={l.githubUsername}
+                  href={`/profile/${encodeURIComponent(l.githubUsername)}`}
+                  className="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors group"
+                >
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    {l.avatar ? (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        src={sizedAvatarUrl(l.avatar, 80)}
+                        alt=""
+                        width={40}
+                        height={40}
+                        className="w-10 h-10 rounded-full ring-2 ring-emerald-500/40"
+                      />
+                    ) : (
+                      <div className="w-10 h-10 rounded-full bg-surface-2 flex items-center justify-center">
+                        <BriefcaseBusiness className="w-4 h-4 text-muted" />
+                      </div>
+                    )}
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5">
+                        <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
+                          {l.githubUsername}
+                        </span>
+                        {l.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+                        <Github className="w-3.5 h-3.5 text-muted flex-shrink-0" />
+                      </div>
+                      <div className="flex flex-wrap gap-1 mt-0.5">
+                        {l.tools.map((t) => (
+                          <span key={t} className="text-[10px] font-mono text-muted">
+                            {toolLabel(t)}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="hidden sm:block w-28 flex-shrink-0">
+                    <TierBadge totalCost={l.bestCost} size="xs" bare />
+                  </div>
+                  <div className="w-24 text-right flex-shrink-0">
+                    <span className="text-sm font-mono font-semibold text-accent">
+                      ${formatCurrency(l.bestCost)}
+                    </span>
+                    <div className="text-[10px] font-mono text-muted">{formatNumber(l.totalTokens)} tok</div>
+                  </div>
+                  <div className="w-20 text-right flex-shrink-0 hidden sm:block">
+                    {l.rank && <span className="text-sm font-mono text-muted">#{l.rank}</span>}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border bg-surface-1 px-6 py-12 text-center">
+            <BriefcaseBusiness className="w-8 h-8 text-muted mx-auto mb-3" />
+            <p className="text-sm text-muted max-w-md mx-auto">
+              No one has opted in yet — the feature just launched. On the board?{" "}
+              Flip on <span className="text-emerald-400 font-mono">Open to work</span> from your own
+              profile page and you&apos;ll show up here.
+            </p>
+          </div>
+        )}
+
+        <p className="text-xs text-muted mt-8">
+          For engineers: opt in or out anytime from your profile — it&apos;s a single toggle, visible only
+          as this list and a badge. We never share emails; companies reach you via your GitHub.
+        </p>
+      </div>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -18,6 +18,7 @@ import UsageChart from "./UsageChartLazy";
 import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
 import TierBadge from "@/components/TierBadge";
+import OpenToWorkToggle from "@/components/OpenToWorkToggle";
 
 // ISR the full profile page too — direct loads and sheet "view full profile"
 // both get cached HTML; data is at most 2 minutes stale.
@@ -147,6 +148,10 @@ export default async function ProfilePage({ params }: ProfileParams) {
                     #{globalRank}
                   </span>
                 )}
+                <OpenToWorkToggle
+                  profileGithubUsername={profileData.githubUsername}
+                  initialOpen={profileData.openToWork ?? false}
+                />
               </div>
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted">
                 <a

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -14,6 +14,7 @@ const toolEntries: MetadataRoute.Sitemap = FEATURED_TOOLS.map((t) => ({
 const staticEntries: MetadataRoute.Sitemap = [
   { url: SITE, lastModified: new Date(), changeFrequency: "daily", priority: 1 },
   ...toolEntries,
+  { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
   { url: `${SITE}/blog/state-of-ai-coding-2026`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
   { url: `${SITE}/blog/codex-vs-claude-code-vs-gemini-cli`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,6 +3,7 @@ import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
 
 const RESOURCES = [
   { name: "Blog", href: "/blog" },
+  { name: "Hire AI-native engineers", href: "/hire" },
   { name: "Codex vs Claude Code vs Gemini", href: "/blog/codex-vs-claude-code-vs-gemini-cli" },
   { name: "What Claude Code costs", href: "/blog/how-much-does-claude-code-cost" },
   { name: "Cut your AI coding bill", href: "/blog/reduce-ai-coding-costs" },

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -41,6 +41,7 @@ export default function NavBar() {
 
   const navItems = [
     { name: "Blog", href: "/blog" },
+    { name: "Hire", href: "/hire" },
     ...(isAdmin ? [{ name: "Admin", href: "/admin" }] : []),
   ];
 

--- a/src/components/OpenToWorkToggle.tsx
+++ b/src/components/OpenToWorkToggle.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+import { useSession } from "next-auth/react";
+import { BriefcaseBusiness, Loader2 } from "lucide-react";
+import { track } from "@vercel/analytics";
+
+interface OpenToWorkToggleProps {
+  profileGithubUsername?: string;
+  initialOpen: boolean;
+}
+
+// Shown only to the profile's owner. Toggles the opt-in flag that puts them
+// on /hire and adds the badge to their public profile.
+export default function OpenToWorkToggle({ profileGithubUsername, initialOpen }: OpenToWorkToggleProps) {
+  const { data: session } = useSession();
+  const [open, setOpen] = useState(initialOpen);
+  const [busy, setBusy] = useState(false);
+
+  const isOwner =
+    !!session?.user?.username &&
+    !!profileGithubUsername &&
+    session.user.username.toLowerCase() === profileGithubUsername.toLowerCase();
+
+  // Visitors see a static badge when the profile has opted in; only the
+  // owner gets the interactive toggle.
+  if (!isOwner) {
+    if (!initialOpen) return null;
+    return (
+      <a
+        href="/hire"
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono font-medium rounded-full border border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
+      >
+        <BriefcaseBusiness className="w-3.5 h-3.5" />
+        Open to work
+      </a>
+    );
+  }
+
+  const toggle = async () => {
+    if (busy) return;
+    setBusy(true);
+    const next = !open;
+    try {
+      const res = await fetch("/api/profile/open-to-work", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ open: next }),
+      });
+      if (res.ok) {
+        setOpen(next);
+        track("open_to_work_toggled", { open: next });
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={busy}
+      title={open ? "Shown on viberank.app/hire — click to opt out" : "List yourself on viberank.app/hire"}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono font-medium rounded-full border transition-colors ${
+        open
+          ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
+          : "border-border text-muted hover:text-foreground hover:bg-surface-2"
+      }`}
+    >
+      {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <BriefcaseBusiness className="w-3.5 h-3.5" />}
+      {open ? "Open to work" : "Set open to work"}
+    </button>
+  );
+}

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -25,6 +25,7 @@ import type {
   DeleteResult,
   FindProfilesResult,
   PatternSearchOptions,
+  HireListing,
 } from "../types";
 import { SupabaseRateLimiter } from "./rate-limiter";
 import { validateCcData, inferToolFromModel } from "@/lib/ccusage";
@@ -84,6 +85,7 @@ interface DbProfile {
   avatar: string | null;
   total_submissions: number;
   best_submission_id: string | null;
+  open_to_work: boolean | null;
   created_at: string;
   updated_at: string;
 }
@@ -980,11 +982,75 @@ class SupabaseProfilesService implements ProfilesService {
       avatar: profile.avatar || undefined,
       totalSubmissions: profile.total_submissions,
       bestSubmission: profile.best_submission_id || undefined,
+      openToWork: profile.open_to_work || false,
       createdAt: new Date(profile.created_at).getTime(),
       submissions: (submissions || []).map((s) =>
         convertDbSubmissionToSubmission(s, dailyBySubmission.get(s.id) || [])
       ),
     };
+  }
+
+  async setOpenToWork(
+    githubUsername: string,
+    open: boolean
+  ): Promise<{ success: boolean; error?: string }> {
+    const { data, error } = await this.client
+      .from("profiles")
+      .update({ open_to_work: open })
+      .ilike("github_username", githubUsername)
+      .select("id");
+
+    if (error) return { success: false, error: error.message };
+    if (!data || data.length === 0) {
+      return { success: false, error: "No profile found — submit your stats first." };
+    }
+    return { success: true };
+  }
+
+  async getHireListings(): Promise<HireListing[]> {
+    const { data: profiles } = await this.client
+      .from("profiles")
+      .select("*")
+      .eq("open_to_work", true);
+
+    if (!profiles || profiles.length === 0) return [];
+
+    // Best submission per opted-in profile, plus the full cost ladder so we
+    // can attach the same global rank the leaderboard would show.
+    const usernames = profiles.map((p) => p.username);
+    const [{ data: subs }, { data: ladder }] = await Promise.all([
+      this.client.from("submissions").select("*").in("username", usernames),
+      this.client
+        .from("submissions")
+        .select("total_cost")
+        .order("total_cost", { ascending: false }),
+    ]);
+
+    const costs = (ladder || []).map((r) => Number(r.total_cost));
+    const bestByUser = new Map<string, DbSubmission>();
+    (subs || []).forEach((s) => {
+      const cur = bestByUser.get(s.username);
+      if (!cur || Number(s.total_cost) > Number(cur.total_cost)) bestByUser.set(s.username, s);
+    });
+
+    return profiles
+      .filter((p) => p.github_username && bestByUser.has(p.username))
+      .map((p) => {
+        const best = bestByUser.get(p.username)!;
+        const bestCost = Number(best.total_cost);
+        return {
+          username: p.username,
+          githubUsername: p.github_username!,
+          githubName: p.github_name || best.github_name || undefined,
+          avatar: p.avatar || best.github_avatar || undefined,
+          bestCost,
+          totalTokens: Number(best.total_tokens),
+          tools: best.tools && best.tools.length > 0 ? best.tools : ["claude"],
+          rank: costs.length > 0 ? costs.filter((c) => c > bestCost).length + 1 : null,
+          verified: best.verified,
+        };
+      })
+      .sort((a, b) => b.bestCost - a.bestCost);
   }
 
   async deleteByPattern(

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -55,7 +55,22 @@ export interface Profile {
   avatar?: string;
   totalSubmissions: number;
   bestSubmission?: string;
+  /** Explicit opt-in flag shown on the profile and the /hire page. */
+  openToWork?: boolean;
   createdAt: number; // Unix timestamp in ms
+}
+
+/** Row on the /hire page: an opted-in profile with its board stats. */
+export interface HireListing {
+  username: string;
+  githubUsername: string;
+  githubName?: string;
+  avatar?: string;
+  bestCost: number;
+  totalTokens: number;
+  tools: string[];
+  rank: number | null;
+  verified: boolean;
 }
 
 export interface ProfileWithSubmissions extends Profile {
@@ -244,6 +259,13 @@ export interface ProfilesService {
     username: string,
     submissionLimit?: number
   ): Promise<ProfileWithSubmissions | null>;
+  /** Set the open-to-work flag for a GitHub-verified profile. */
+  setOpenToWork(
+    githubUsername: string,
+    open: boolean
+  ): Promise<{ success: boolean; error?: string }>;
+  /** All opted-in profiles with board stats, sorted by best cost. */
+  getHireListings(): Promise<HireListing[]>;
   deleteByPattern(
     patterns: string[],
     options: PatternSearchOptions & { dryRun?: boolean }

--- a/supabase/migrations/003_open_to_work.sql
+++ b/supabase/migrations/003_open_to_work.sql
@@ -1,0 +1,12 @@
+-- Migration 003: opt-in "open to work" flag for the /hire page.
+--
+-- Explicit opt-in only — never inferred from GitHub's hireable flag. The
+-- column is additive with a default, so existing rows and deployed code keep
+-- working. Apply BEFORE deploying the matching app code.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS open_to_work BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- The /hire page only ever reads the opted-in slice.
+CREATE INDEX IF NOT EXISTS idx_profiles_open_to_work
+  ON profiles(open_to_work) WHERE open_to_work;


### PR DESCRIPTION
## Summary
- **Migration 003** (`open_to_work` boolean on profiles, partial index) — **already applied to prod** via the management API; column is additive and defaults false
- **Profile toggle**: owners (GitHub-OAuth session must match the profile) flip "Open to work" from their own profile page via `POST /api/profile/open-to-work`; explicit opt-in only, never inferred from GitHub's hireable flag
- **Badge**: opted-in profiles show a green Open to work pill linking to /hire
- **/hire page** (ISR 5m): opted-in engineers with avatar, verified check, tools, tier, usage, global rank, sorted by usage; empty state explains how to opt in; privacy note (no emails shared, contact via GitHub)
- **Company CTA**: "Post a job — reach these engineers" mailto with `hire_cta_click` tracking — Stripe/form later if there's demand
- Nav + footer + sitemap links

## Test plan
- next build passes; verified in dev and clean prod build that an opted-in profile renders on /hire (tested with my own profile, flag reverted after)
- Toggle round-trip exercised via the API route logic; events fire client-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)