### PR TITLE
Fix empty leaderboard state after resetting filters

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -72,6 +72,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   // The server already rendered page 0 of the default view — don't re-fetch
   // it on mount. The hook only runs for non-default filters or later pages.
   const isSeededDefaultView =
+    firstRender.current &&
     (initialItems?.length ?? 0) > 0 &&
     page === 0 &&
     sortBy === "cost" &&


### PR DESCRIPTION
## What changed
- make the homepage reuse the server-seeded leaderboard rows only on the first render
- allow the default cost view to refetch after a user changes filters and returns to the default state

## Why
The homepage can fall into an empty-table state after users switch away from the default leaderboard view and then reset back to it.

## Root cause
The default view was treated as "seeded" any time the filter state returned to the original cost/no-filter combination, even after hydration. Once the filter-reset effect cleared the current rows, the board skipped fetching because it incorrectly assumed the server-seeded rows were still active.

## Impact
Returning to the default homepage leaderboard view now restores rows correctly instead of showing an empty table.

## Validation
- [x] `pnpm build`
- [ ] `pnpm exec tsc --noEmit`  
  Fails in the current repo due to pre-existing type/config issues unrelated to this change.
- [ ] `pnpm lint`  
  Fails in the current repo because the script still uses `next lint`, which is invalid under the current Next.js setup.
- [ ] `pnpm test`  
  Fails in the current repo because the script runs `node` directly on `test/ccusage.test.mts`.
