### PR TITLE
[codex] Fix leaderboard sorting, timelines, and duplicate claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts"
+    "test": "node test/ccusage.test.mts && for f in test/*.test.mts; do [ \"$f\" = \"test/ccusage.test.mts\" ] || node \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
+++ b/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
@@ -7,6 +7,7 @@ import { X, Github, ArrowUpRight } from "lucide-react";
 import TierBadge from "@/components/TierBadge";
 import { getTierProgress } from "@/lib/tiers";
 import { formatNumber, toolLabel, sizedAvatarUrl } from "@/lib/utils";
+import { formatCompactDate, type DailyFreshness } from "@/lib/profile-timeline";
 
 interface ProfileSheetProps {
   username: string;
@@ -21,6 +22,9 @@ interface ProfileSheetProps {
   tools: string[];
   /** Daily spend, oldest → newest, for the mini bar chart. */
   spark: number[];
+  sparkStartDate: string | null;
+  sparkEndDate: string | null;
+  dailyFreshness: DailyFreshness;
 }
 
 export default function ProfileSheet(props: ProfileSheetProps) {
@@ -126,7 +130,12 @@ export default function ProfileSheet(props: ProfileSheetProps) {
           {/* Daily spend sparkline */}
           {props.spark.length > 1 && (
             <div className="rounded-lg bg-background border border-border-subtle p-3 mb-3">
-              <p className="micro-label mb-2">Daily spend · last {props.spark.length} days</p>
+              <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
+                <p className="micro-label">Daily spend · last {props.spark.length} calendar days</p>
+                <span className="text-[10px] font-mono text-muted">
+                  {formatCompactDate(props.sparkStartDate)} - {formatCompactDate(props.sparkEndDate)}
+                </span>
+              </div>
               <div className="flex items-end gap-px h-12">
                 {props.spark.map((v, i) => {
                   const max = Math.max(...props.spark) || 1;
@@ -139,6 +148,11 @@ export default function ProfileSheet(props: ProfileSheetProps) {
                   );
                 })}
               </div>
+              {props.dailyFreshness.isStale && (
+                <p className="mt-2 text-[11px] text-muted">
+                  Data ends {formatCompactDate(props.dailyFreshness.lastRecordedDate)}. Run <code className="font-mono text-accent">npx viberank-cli</code> to update recent days.
+                </p>
+              )}
             </div>
           )}
 

--- a/src/app/@modal/(.)profile/[username]/page.tsx
+++ b/src/app/@modal/(.)profile/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "@/app/profile/[username]/getProfile";
+import { buildRecentSpendSpark, getDailyFreshness, todayIso } from "@/lib/profile-timeline";
 import ProfileSheet from "./ProfileSheet";
 
 interface Params {
@@ -32,11 +33,14 @@ export default async function InterceptedProfile({ params }: Params) {
   const tools = Array.from(new Set(submissions.flatMap((s) => s.tools ?? []))).sort();
   const bestCost = submissions.length > 0 ? Math.max(...submissions.map((s) => s.totalCost)) : 0;
 
-  // Last 30 calendar days of spend for the sheet's sparkline.
-  const byDate = new Map<string, number>();
-  for (const d of allDaily) byDate.set(d.date, (byDate.get(d.date) ?? 0) + d.totalCost);
-  const days = [...byDate.keys()].sort();
-  const spark = days.slice(-30).map((d) => byDate.get(d) ?? 0);
+  const today = todayIso();
+  const dailyPoints = allDaily.map((d) => ({
+    date: d.date,
+    cost: d.totalCost,
+    tokens: d.totalTokens,
+  }));
+  const spark = buildRecentSpendSpark(dailyPoints, { days: 30, today });
+  const dailyFreshness = getDailyFreshness(dailyPoints, today);
 
   let globalRank: number | null = null;
   try {
@@ -60,7 +64,10 @@ export default async function InterceptedProfile({ params }: Params) {
       bestCost={bestCost}
       globalRank={globalRank}
       tools={tools}
-      spark={spark}
+      spark={spark.values}
+      sparkStartDate={spark.startDate}
+      sparkEndDate={spark.endDate}
+      dailyFreshness={dailyFreshness}
     />
   );
 }

--- a/src/app/profile/[username]/UsageChart.tsx
+++ b/src/app/profile/[username]/UsageChart.tsx
@@ -11,10 +11,11 @@ import {
   Tooltip,
   ResponsiveContainer,
 } from "recharts";
+import { formatCompactDate, type DailyFreshness } from "@/lib/profile-timeline";
 
 type DailyPoint = { date: string; cost: number; tokens: number };
 
-export default function UsageChart({ daily }: { daily: DailyPoint[] }) {
+export default function UsageChart({ daily, freshness }: { daily: DailyPoint[]; freshness?: DailyFreshness }) {
   const [range, setRange] = useState<"7d" | "30d" | "all">("30d");
 
   const data = [...daily]
@@ -24,10 +25,17 @@ export default function UsageChart({ daily }: { daily: DailyPoint[] }) {
   return (
     <div className="bg-surface-1 border border-border rounded-lg p-5 mb-6">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-base font-medium flex items-center gap-2">
-          <TrendingUp className="w-4 h-4 text-accent" />
-          Usage over time
-        </h2>
+        <div>
+          <h2 className="text-base font-medium flex items-center gap-2">
+            <TrendingUp className="w-4 h-4 text-accent" />
+            Usage over time
+          </h2>
+          {freshness?.isStale && (
+            <p className="text-xs text-muted mt-1">
+              Data ends {formatCompactDate(freshness.lastRecordedDate)}. Run <code className="font-mono text-accent">npx viberank-cli</code> to update recent days.
+            </p>
+          )}
+        </div>
         <div className="flex gap-1">
           {(["7d", "30d", "all"] as const).map((r) => (
             <button

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl } from "@/lib/utils";
 import { getTierProgress } from "@/lib/tiers";
 import { getServerDataLayer } from "@/lib/data";
+import { buildCalendarDailySeries, getDailyFreshness, todayIso } from "@/lib/profile-timeline";
 import { getProfileCached } from "./getProfile";
 import UsageChart from "./UsageChartLazy";
 import Footer from "@/components/Footer";
@@ -66,14 +67,22 @@ export default async function ProfilePage({ params }: ProfileParams) {
   const daysActive = new Set(allDaily.map((d) => d.date)).size || 1;
   const avgDailyCost = totalCost / daysActive;
 
-  // Per-day chart series (summed across submissions).
-  const dailyMap = allDaily.reduce((acc, d) => {
-    if (!acc[d.date]) acc[d.date] = { date: d.date, cost: 0, tokens: 0 };
-    acc[d.date].cost += d.totalCost;
-    acc[d.date].tokens += d.totalTokens;
-    return acc;
-  }, {} as Record<string, { date: string; cost: number; tokens: number }>);
-  const dailySeries = Object.values(dailyMap);
+  const today = todayIso();
+  const dailyPoints = allDaily.map((d) => ({
+    date: d.date,
+    cost: d.totalCost,
+    tokens: d.totalTokens,
+  }));
+  const firstTrackedDate = submissions
+    .map((s) => s.dateRange.start)
+    .filter(Boolean)
+    .sort()[0];
+  const dailySeries = buildCalendarDailySeries(dailyPoints, {
+    range: "all",
+    today,
+    startDate: firstTrackedDate,
+  });
+  const dailyFreshness = getDailyFreshness(dailyPoints, today);
 
   // Tools used across the profile (Claude sorts first).
   const tools = Array.from(new Set(submissions.flatMap((s) => s.tools ?? []))).sort();
@@ -296,7 +305,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
         </div>
 
         {/* Usage chart (client island) */}
-        <UsageChart daily={dailySeries} />
+        <UsageChart daily={dailySeries} freshness={dailyFreshness} />
 
         {/* Token breakdown + insights */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Trophy, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
@@ -13,6 +13,7 @@ import SponsorSlot from "./SponsorSlot";
 import TierBadge from "./TierBadge";
 import { TIERS } from "@/lib/tiers";
 import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
+import { isLeaderboardResultForRequest, shouldUseServerSeededLeaderboard } from "@/lib/leaderboard-view";
 import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useSubmissions";
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
 import type { Submission, GlobalStats } from "@/lib/data/types";
@@ -60,9 +61,9 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   const [verifiedOnly, setVerifiedOnly] = useState(false);
   const [page, setPage] = useState(0);
   const [allItems, setAllItems] = useState<Submission[]>(initialItems ?? []);
+  const [hasUserInteracted, setHasUserInteracted] = useState(false);
   const { data: session } = useSession();
   const loadMoreRef = useRef<HTMLDivElement>(null);
-  const firstRender = useRef(true);
   const { data: liveStats } = useGlobalStats();
   const globalStats = liveStats ?? initialStats;
 
@@ -70,27 +71,51 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   const isDateFiltered = dateFrom && dateTo;
 
   // The server already rendered page 0 of the default view — don't re-fetch
-  // it on mount. The hook only runs for non-default filters or later pages.
-  const isSeededDefaultView =
-    (initialItems?.length ?? 0) > 0 &&
-    page === 0 &&
-    sortBy === "cost" &&
-    !tool &&
-    !verifiedOnly &&
-    !isDateFiltered;
+  // it on mount. After any user sort/filter click, page 0 must be fetched
+  // fresh; otherwise stale seeded or later-page results can masquerade as top.
+  const isSeededDefaultView = shouldUseServerSeededLeaderboard({
+    hasInitialItems: (initialItems?.length ?? 0) > 0,
+    hasUserInteracted,
+    page,
+    sortBy,
+    hasToolFilter: !!tool,
+    verifiedOnly,
+    isDateFiltered: !!isDateFiltered,
+  });
+
+  const regularParams = useMemo(() => ({
+    sortBy,
+    page,
+    pageSize: ITEMS_PER_PAGE,
+    tool: tool ?? undefined,
+    verifiedOnly: verifiedOnly || undefined,
+  }), [sortBy, page, tool, verifiedOnly]);
+  const dateRangeParams = useMemo(() => ({
+    dateFrom,
+    dateTo,
+    sortBy,
+    limit: 100,
+    tool: tool ?? undefined,
+    verifiedOnly: verifiedOnly || undefined,
+  }), [dateFrom, dateTo, sortBy, tool, verifiedOnly]);
+  const dateRangeRequestKey = useMemo(() => JSON.stringify({
+    dateFrom,
+    dateTo,
+    sortBy,
+    limit: 100,
+    cursor: null,
+    tool: tool ?? null,
+    verifiedOnly: Boolean(verifiedOnly),
+  }), [dateFrom, dateTo, sortBy, tool, verifiedOnly]);
 
   const { data: regularResult, isLoading } = useLeaderboard(
-    !isDateFiltered && !isSeededDefaultView
-      ? { sortBy, page, pageSize: ITEMS_PER_PAGE, tool: tool ?? undefined, verifiedOnly: verifiedOnly || undefined }
-      : "skip"
+    !isDateFiltered && !isSeededDefaultView ? regularParams : "skip"
   );
 
   const hasMore = regularResult?.hasMore ?? (isSeededDefaultView ? initialHasMore ?? false : false);
 
   const { data: dateFilteredResult } = useLeaderboardByDateRange(
-    isDateFiltered
-      ? { dateFrom, dateTo, sortBy, limit: 100, tool: tool ?? undefined, verifiedOnly: verifiedOnly || undefined }
-      : "skip"
+    isDateFiltered ? dateRangeParams : "skip"
   );
 
   // Tools available to filter by, sourced from the global per-tool stats.
@@ -98,21 +123,21 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
     ? Object.keys(globalStats.modelUsage).sort()
     : [];
 
-  useEffect(() => {
-    // Keep the server-seeded items on first render; only reset when a filter
-    // actually changes (avoids clearing the SSR'd rows during hydration).
-    if (firstRender.current) {
-      firstRender.current = false;
-      return;
-    }
+  const resetBoardForUserChange = () => {
+    setHasUserInteracted(true);
     setAllItems([]);
     setPage(0);
-  }, [sortBy, dateFrom, dateTo, tool, verifiedOnly]);
+  };
+
+  const updateSort = (nextSort: SortBy) => {
+    if (nextSort !== sortBy) resetBoardForUserChange();
+    setSortBy(nextSort);
+  };
 
   useEffect(() => {
-    if (isDateFiltered && dateFilteredResult?.items) {
+    if (isDateFiltered && dateFilteredResult?.items && dateFilteredResult.requestKey === dateRangeRequestKey) {
       setAllItems(dateFilteredResult.items);
-    } else if (!isDateFiltered && regularResult?.items) {
+    } else if (!isDateFiltered && regularResult?.items && isLeaderboardResultForRequest(regularResult, regularParams)) {
       if (page === 0) {
         setAllItems(regularResult.items);
       } else {
@@ -123,7 +148,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
         });
       }
     }
-  }, [regularResult, dateFilteredResult, page, isDateFiltered]);
+  }, [regularResult, regularParams, dateFilteredResult, dateRangeRequestKey, page, isDateFiltered]);
 
   useEffect(() => {
     if (isDateFiltered || !hasMore) return;
@@ -145,6 +170,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   }, [hasMore, isLoading, isDateFiltered, allItems.length]);
 
   const setQuickFilter = (days: number | null) => {
+    resetBoardForUserChange();
     if (days === null) {
       setDateFrom("");
       setDateTo("");
@@ -196,7 +222,10 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
             </button>
 
             <button
-              onClick={() => setVerifiedOnly(v => !v)}
+              onClick={() => {
+                resetBoardForUserChange();
+                setVerifiedOnly(v => !v);
+              }}
               aria-pressed={verifiedOnly}
               title="Only show GitHub-verified submissions"
               className={`px-2 py-1 text-xs font-mono font-medium rounded flex items-center gap-1 transition-colors ${
@@ -210,7 +239,10 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
             {availableTools.length > 1 && (
               <select
                 value={tool ?? ""}
-                onChange={(e) => setTool(e.target.value || null)}
+                onChange={(e) => {
+                  resetBoardForUserChange();
+                  setTool(e.target.value || null);
+                }}
                 aria-label="Filter by tool"
                 className={`px-2 py-1 text-xs font-mono font-medium rounded bg-surface-2 border border-border transition-colors focus:outline-none focus:ring-1 focus:ring-accent ${
                   tool ? "text-accent" : "text-muted hover:text-foreground"
@@ -228,7 +260,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
 
           <div className="flex items-center gap-1">
             <button
-              onClick={() => setSortBy("cost")}
+              onClick={() => updateSort("cost")}
               className={`px-2.5 py-1 text-xs font-mono font-medium rounded flex items-center gap-1 transition-colors ${
                 sortBy === "cost" ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2"
               }`}
@@ -237,7 +269,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
               <span className="hidden sm:inline">Cost</span>
             </button>
             <button
-              onClick={() => setSortBy("tokens")}
+              onClick={() => updateSort("tokens")}
               className={`px-2.5 py-1 text-xs font-mono font-medium rounded flex items-center gap-1 transition-colors ${
                 sortBy === "tokens" ? "bg-accent text-white" : "text-muted hover:text-foreground hover:bg-surface-2"
               }`}
@@ -260,18 +292,31 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                 <input
                   type="date"
                   value={dateFrom}
-                  onChange={(e) => setDateFrom(e.target.value)}
+                  onChange={(e) => {
+                    resetBoardForUserChange();
+                    setDateFrom(e.target.value);
+                  }}
                   className="px-3 py-1.5 bg-background border border-border rounded-md"
                 />
                 <span className="text-muted">→</span>
                 <input
                   type="date"
                   value={dateTo}
-                  onChange={(e) => setDateTo(e.target.value)}
+                  onChange={(e) => {
+                    resetBoardForUserChange();
+                    setDateTo(e.target.value);
+                  }}
                   className="px-3 py-1.5 bg-background border border-border rounded-md"
                 />
                 {(dateFrom || dateTo) && (
-                  <button onClick={() => { setDateFrom(""); setDateTo(""); }} className="text-muted hover:text-foreground">
+                  <button
+                    onClick={() => {
+                      resetBoardForUserChange();
+                      setDateFrom("");
+                      setDateTo("");
+                    }}
+                    className="text-muted hover:text-foreground"
+                  >
                     <X className="w-4 h-4" />
                   </button>
                 )}

--- a/src/lib/claim-handles.ts
+++ b/src/lib/claim-handles.ts
@@ -1,0 +1,24 @@
+export interface ClaimableSubmissionIdentity {
+  username?: string | null;
+  githubUsername?: string | null;
+  source?: "cli" | "oauth" | null;
+  verified?: boolean | null;
+}
+
+export function normalizeClaimHandle(value: string | null | undefined): string {
+  return (value ?? "").toLowerCase().replace(/[^a-z0-9-]/g, "");
+}
+
+export function isClaimableCliAlias(
+  signedInGithubUsername: string,
+  submission: ClaimableSubmissionIdentity
+): boolean {
+  if (submission.source !== "cli" || submission.verified) return false;
+
+  const signed = normalizeClaimHandle(signedInGithubUsername);
+  if (!signed) return false;
+
+  return [submission.username, submission.githubUsername].some(
+    (value) => normalizeClaimHandle(value) === signed
+  );
+}

--- a/src/lib/data/hooks/useSubmissions.ts
+++ b/src/lib/data/hooks/useSubmissions.ts
@@ -17,6 +17,10 @@ import type {
   ClaimStatus,
   ClaimResult,
 } from "../types";
+import { getLeaderboardRequestKey } from "@/lib/leaderboard-view";
+
+type KeyedLeaderboardResult = LeaderboardResult & { requestKey: string };
+type KeyedDateRangeLeaderboardResult = DateRangeLeaderboardResult & { requestKey: string };
 
 // ============================================================================
 // LEADERBOARD HOOKS
@@ -26,16 +30,21 @@ import type {
  * Hook for fetching the leaderboard (regular, paginated)
  */
 export function useLeaderboard(params: LeaderboardParams | "skip") {
-  const [supabaseData, setSupabaseData] = useState<LeaderboardResult | undefined>();
+  const [supabaseData, setSupabaseData] = useState<KeyedLeaderboardResult | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
   const [supabaseError, setSupabaseError] = useState<Error | null>(null);
+  const paramsKey = params === "skip" ? "skip" : getLeaderboardRequestKey(params);
 
   useEffect(() => {
+    let active = true;
+
     if (params === "skip") {
       setSupabaseData(undefined);
+      setSupabaseLoading(false);
       return;
     }
 
+    setSupabaseData(undefined);
     setSupabaseLoading(true);
     setSupabaseError(null);
 
@@ -44,10 +53,20 @@ export function useLeaderboard(params: LeaderboardParams | "skip") {
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.getLeaderboard(params);
       })
-      .then(setSupabaseData)
-      .catch(setSupabaseError)
-      .finally(() => setSupabaseLoading(false));
-  }, [JSON.stringify(params)]);
+      .then((data) => {
+        if (active) setSupabaseData({ ...data, requestKey: paramsKey });
+      })
+      .catch((error) => {
+        if (active) setSupabaseError(error);
+      })
+      .finally(() => {
+        if (active) setSupabaseLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [paramsKey]);
 
   return {
     data: supabaseData,
@@ -60,16 +79,31 @@ export function useLeaderboard(params: LeaderboardParams | "skip") {
  * Hook for fetching date-filtered leaderboard
  */
 export function useLeaderboardByDateRange(params: DateRangeLeaderboardParams | "skip") {
-  const [supabaseData, setSupabaseData] = useState<DateRangeLeaderboardResult | undefined>();
+  const [supabaseData, setSupabaseData] = useState<KeyedDateRangeLeaderboardResult | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
   const [supabaseError, setSupabaseError] = useState<Error | null>(null);
+  const paramsKey = params === "skip"
+    ? "skip"
+    : JSON.stringify({
+        dateFrom: params.dateFrom,
+        dateTo: params.dateTo,
+        sortBy: params.sortBy ?? "cost",
+        limit: params.limit ?? null,
+        cursor: params.cursor ?? null,
+        tool: params.tool ?? null,
+        verifiedOnly: Boolean(params.verifiedOnly),
+      });
 
   useEffect(() => {
+    let active = true;
+
     if (params === "skip") {
       setSupabaseData(undefined);
+      setSupabaseLoading(false);
       return;
     }
 
+    setSupabaseData(undefined);
     setSupabaseLoading(true);
     setSupabaseError(null);
 
@@ -78,10 +112,20 @@ export function useLeaderboardByDateRange(params: DateRangeLeaderboardParams | "
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.getLeaderboardByDateRange(params);
       })
-      .then(setSupabaseData)
-      .catch(setSupabaseError)
-      .finally(() => setSupabaseLoading(false));
-  }, [JSON.stringify(params)]);
+      .then((data) => {
+        if (active) setSupabaseData({ ...data, requestKey: paramsKey });
+      })
+      .catch((error) => {
+        if (active) setSupabaseError(error);
+      })
+      .finally(() => {
+        if (active) setSupabaseLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [paramsKey]);
 
   return {
     data: supabaseData,

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -30,6 +30,7 @@ import type {
 } from "../types";
 import { SupabaseRateLimiter } from "./rate-limiter";
 import { validateCcData, inferToolFromModel } from "@/lib/ccusage";
+import { isClaimableCliAlias, normalizeClaimHandle } from "@/lib/claim-handles";
 
 // ============================================================================
 // DATABASE TYPES (matching Supabase schema)
@@ -670,11 +671,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
   }
 
   async claimAndMergeSubmissions(githubUsername: string): Promise<ClaimResult> {
-    const { data: submissions } = await this.client
-      .from("submissions")
-      .select("*")
-      .eq("github_username", githubUsername)
-      .limit(100);
+    const submissions = await this.getClaimCandidateSubmissions(githubUsername);
 
     if (!submissions || submissions.length === 0) {
       throw new Error("No submissions found");
@@ -695,8 +692,14 @@ class SupabaseSubmissionsService implements SubmissionsService {
     if (oauthSubmissions.length === 0 && cliSubmissions.length === 1) {
       await this.client
         .from("submissions")
-        .update({ verified: true })
+        .update({
+          username: githubUsername,
+          github_username: githubUsername,
+          verified: true,
+        })
         .eq("id", cliSubmissions[0].id);
+
+      await this.repairClaimedProfile(githubUsername, cliSubmissions[0].id);
 
       return {
         success: true,
@@ -788,6 +791,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
         cache_read_tokens: totals.cacheReadTokens,
         date_range_start: dateRange.start,
         date_range_end: dateRange.end,
+        username: githubUsername,
+        github_username: githubUsername,
         models_used: allModels,
         tools: allTools,
         submitted_at: new Date().toISOString(),
@@ -840,29 +845,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
       }
     }
 
-    // Recompute total_submissions from the source of truth (a count of rows
-    // post-delete), and always repoint best_submission_id at the surviving
-    // base — even if no rows were deleted, this self-heals stale FK state.
-    const { data: profile } = await this.client
-      .from("profiles")
-      .select("id")
-      .eq("github_username", githubUsername)
-      .single();
-
-    if (profile) {
-      const { count: liveCount } = await this.client
-        .from("submissions")
-        .select("id", { count: "exact", head: true })
-        .eq("github_username", githubUsername);
-
-      await this.client
-        .from("profiles")
-        .update({
-          total_submissions: Math.max(1, liveCount ?? 1),
-          best_submission_id: baseSubmission.id,
-        })
-        .eq("id", profile.id);
-    }
+    await this.repairClaimedProfile(githubUsername, baseSubmission.id);
 
     return {
       success: true,
@@ -873,11 +856,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
   }
 
   async checkClaimableSubmissions(githubUsername: string): Promise<ClaimStatus> {
-    const { data: submissions } = await this.client
-      .from("submissions")
-      .select("*")
-      .eq("github_username", githubUsername)
-      .limit(100);
+    const submissions = await this.getClaimCandidateSubmissions(githubUsername);
 
     if (!submissions || submissions.length === 0) {
       return {
@@ -915,6 +894,79 @@ class SupabaseSubmissionsService implements SubmissionsService {
       totalSubmissions: submissions.length,
       unverifiedCount,
     };
+  }
+
+  private async getClaimCandidateSubmissions(githubUsername: string): Promise<DbSubmission[]> {
+    const [{ data: exactMatches }, { data: cliCandidates }] = await Promise.all([
+      this.client
+        .from("submissions")
+        .select("*")
+        .ilike("github_username", githubUsername)
+        .limit(100),
+      this.client
+        .from("submissions")
+        .select("*")
+        .eq("source", "cli")
+        .eq("verified", false)
+        .limit(1000),
+    ]);
+
+    const byId = new Map<string, DbSubmission>();
+    for (const submission of exactMatches || []) byId.set(submission.id, submission);
+    for (const submission of cliCandidates || []) {
+      if (
+        isClaimableCliAlias(githubUsername, {
+          username: submission.username,
+          githubUsername: submission.github_username,
+          source: submission.source,
+          verified: submission.verified,
+        })
+      ) {
+        byId.set(submission.id, submission);
+      }
+    }
+
+    return [...byId.values()].slice(0, 100);
+  }
+
+  private async repairClaimedProfile(githubUsername: string, bestSubmissionId: string): Promise<void> {
+    const { count: liveCount } = await this.client
+      .from("submissions")
+      .select("id", { count: "exact", head: true })
+      .ilike("github_username", githubUsername);
+
+    const { data: profile } = await this.client
+      .from("profiles")
+      .select("id,username,github_username")
+      .ilike("github_username", githubUsername)
+      .maybeSingle();
+
+    let profileId = profile?.id;
+
+    if (!profileId) {
+      const signed = normalizeClaimHandle(githubUsername);
+      const { data: aliasProfiles } = await this.client
+        .from("profiles")
+        .select("id,username,github_username")
+        .limit(1000);
+
+      profileId = (aliasProfiles || []).find((candidate) =>
+        normalizeClaimHandle(candidate.username) === signed ||
+        normalizeClaimHandle(candidate.github_username) === signed
+      )?.id;
+    }
+
+    if (profileId) {
+      await this.client
+        .from("profiles")
+        .update({
+          username: githubUsername,
+          github_username: githubUsername,
+          total_submissions: Math.max(1, liveCount ?? 1),
+          best_submission_id: bestSubmissionId,
+        })
+        .eq("id", profileId);
+    }
   }
 
   async getGlobalRank(totalCost: number): Promise<number> {

--- a/src/lib/leaderboard-view.ts
+++ b/src/lib/leaderboard-view.ts
@@ -1,0 +1,61 @@
+export type LeaderboardSort = "cost" | "tokens";
+
+export interface ServerSeededLeaderboardInput {
+  hasInitialItems: boolean;
+  hasUserInteracted: boolean;
+  page: number;
+  sortBy: LeaderboardSort;
+  hasToolFilter: boolean;
+  verifiedOnly: boolean;
+  isDateFiltered: boolean;
+}
+
+export interface LeaderboardRequestParams {
+  sortBy?: LeaderboardSort;
+  page?: number;
+  pageSize?: number;
+  tool?: string;
+  verifiedOnly?: boolean;
+}
+
+export interface KeyedLeaderboardResult {
+  requestKey?: string;
+  page: number;
+}
+
+export function shouldUseServerSeededLeaderboard({
+  hasInitialItems,
+  hasUserInteracted,
+  page,
+  sortBy,
+  hasToolFilter,
+  verifiedOnly,
+  isDateFiltered,
+}: ServerSeededLeaderboardInput): boolean {
+  return (
+    hasInitialItems &&
+    !hasUserInteracted &&
+    page === 0 &&
+    sortBy === "cost" &&
+    !hasToolFilter &&
+    !verifiedOnly &&
+    !isDateFiltered
+  );
+}
+
+export function getLeaderboardRequestKey(params: LeaderboardRequestParams): string {
+  return JSON.stringify({
+    sortBy: params.sortBy ?? "cost",
+    page: params.page ?? 0,
+    pageSize: params.pageSize ?? 25,
+    tool: params.tool ?? null,
+    verifiedOnly: Boolean(params.verifiedOnly),
+  });
+}
+
+export function isLeaderboardResultForRequest(
+  result: KeyedLeaderboardResult | undefined,
+  params: LeaderboardRequestParams
+): boolean {
+  return !!result?.requestKey && result.requestKey === getLeaderboardRequestKey(params);
+}

--- a/src/lib/profile-timeline.ts
+++ b/src/lib/profile-timeline.ts
@@ -1,0 +1,115 @@
+export interface DailyUsagePoint {
+  date: string;
+  cost: number;
+  tokens: number;
+}
+
+export interface CalendarSeriesOptions {
+  range: number | "all";
+  today: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface RecentSpendSpark {
+  values: number[];
+  startDate: string | null;
+  endDate: string | null;
+}
+
+export interface DailyFreshness {
+  lastRecordedDate: string | null;
+  isStale: boolean;
+  missingDays: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function parseIsoDay(date: string): Date {
+  return new Date(`${date}T00:00:00.000Z`);
+}
+
+function toIsoDay(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function addDays(date: string, days: number): string {
+  return toIsoDay(new Date(parseIsoDay(date).getTime() + days * DAY_MS));
+}
+
+function diffDays(from: string, to: string): number {
+  return Math.max(0, Math.round((parseIsoDay(to).getTime() - parseIsoDay(from).getTime()) / DAY_MS));
+}
+
+export function todayIso(): string {
+  return toIsoDay(new Date());
+}
+
+export function formatCompactDate(date: string | null): string {
+  if (!date) return "N/A";
+  return parseIsoDay(date).toLocaleDateString("en", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
+}
+
+function aggregateDaily(daily: DailyUsagePoint[]): Map<string, DailyUsagePoint> {
+  const byDate = new Map<string, DailyUsagePoint>();
+  for (const point of daily) {
+    const current = byDate.get(point.date) ?? { date: point.date, cost: 0, tokens: 0 };
+    current.cost += point.cost;
+    current.tokens += point.tokens;
+    byDate.set(point.date, current);
+  }
+  return byDate;
+}
+
+export function getDailyFreshness(daily: DailyUsagePoint[], today: string = todayIso()): DailyFreshness {
+  if (daily.length === 0) {
+    return { lastRecordedDate: null, isStale: false, missingDays: 0 };
+  }
+
+  const lastRecordedDate = daily.reduce((latest, point) => point.date > latest ? point.date : latest, daily[0]!.date);
+  const missingDays = diffDays(lastRecordedDate, today);
+  return {
+    lastRecordedDate,
+    isStale: missingDays > 0,
+    missingDays,
+  };
+}
+
+export function buildCalendarDailySeries(
+  daily: DailyUsagePoint[],
+  options: CalendarSeriesOptions
+): DailyUsagePoint[] {
+  if (daily.length === 0) return [];
+
+  const byDate = aggregateDaily(daily);
+  const sortedDates = [...byDate.keys()].sort();
+  const firstRecorded = sortedDates[0]!;
+  const lastRecorded = sortedDates[sortedDates.length - 1]!;
+  const endDate = options.endDate ?? (lastRecorded > options.today ? lastRecorded : options.today);
+  const startDate = options.range === "all"
+    ? options.startDate ?? firstRecorded
+    : addDays(endDate, -(options.range - 1));
+
+  const result: DailyUsagePoint[] = [];
+  for (let cursor = startDate; cursor <= endDate; cursor = addDays(cursor, 1)) {
+    result.push(byDate.get(cursor) ?? { date: cursor, cost: 0, tokens: 0 });
+  }
+  return result;
+}
+
+export function buildRecentSpendSpark(
+  daily: DailyUsagePoint[],
+  options: { days: number; today: string }
+): RecentSpendSpark {
+  const series = buildCalendarDailySeries(daily, {
+    range: options.days,
+    today: options.today,
+    endDate: options.today,
+  });
+
+  return {
+    values: series.map((point) => point.cost),
+    startDate: series[0]?.date ?? null,
+    endDate: series[series.length - 1]?.date ?? null,
+  };
+}

--- a/test/site-bugs.test.mts
+++ b/test/site-bugs.test.mts
@@ -1,0 +1,160 @@
+/**
+ * Focused regression tests for leaderboard/profile display bugs.
+ * Run: node test/site-bugs.test.mts
+ */
+
+const {
+  shouldUseServerSeededLeaderboard,
+  getLeaderboardRequestKey,
+  isLeaderboardResultForRequest,
+} = await import("../src/lib/leaderboard-view.ts");
+const {
+  buildCalendarDailySeries,
+  buildRecentSpendSpark,
+  getDailyFreshness,
+} = await import("../src/lib/profile-timeline.ts");
+const {
+  normalizeClaimHandle,
+  isClaimableCliAlias,
+} = await import("../src/lib/claim-handles.ts");
+
+let passed = 0;
+let failed = 0;
+
+function ok(name: string, cond: boolean, detail = "") {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${name} ${detail}`);
+  }
+}
+
+console.log("\n[1] Leaderboard server seed only applies before user interaction");
+{
+  const base = {
+    hasInitialItems: true,
+    hasUserInteracted: false,
+    page: 0,
+    sortBy: "cost" as const,
+    hasToolFilter: false,
+    verifiedOnly: false,
+    isDateFiltered: false,
+  };
+
+  ok("initial default view can use server seed", shouldUseServerSeededLeaderboard(base));
+  ok(
+    "returning to default cost after a user click must fetch page 0",
+    !shouldUseServerSeededLeaderboard({ ...base, hasUserInteracted: true })
+  );
+  ok(
+    "token sort must fetch its own top page",
+    !shouldUseServerSeededLeaderboard({ ...base, sortBy: "tokens" })
+  );
+  ok(
+    "loaded next pages must never masquerade as rank 1",
+    !shouldUseServerSeededLeaderboard({ ...base, page: 2 })
+  );
+}
+
+console.log("\n[2] Profile timelines use real calendar spacing");
+{
+  const daily = [
+    { date: "2026-06-01", cost: 10, tokens: 100 },
+    { date: "2026-06-03", cost: 30, tokens: 300 },
+  ];
+
+  const series = buildCalendarDailySeries(daily, {
+    range: "all",
+    today: "2026-06-05",
+  });
+
+  ok("fills missing in-range days", series.length === 5, `got ${series.length}`);
+  ok("keeps first recorded day", series[0]?.date === "2026-06-01");
+  ok("fills internal gap with zero cost", series[1]?.date === "2026-06-02" && series[1]?.cost === 0);
+  ok("extends to today so stale uploads are visible", series[4]?.date === "2026-06-05" && series[4]?.cost === 0);
+}
+
+console.log("\n[3] Profile sheet spark is last N calendar days, not last N recorded rows");
+{
+  const daily = [
+    { date: "2026-06-01", cost: 10, tokens: 100 },
+    { date: "2026-06-05", cost: 50, tokens: 500 },
+  ];
+
+  const spark = buildRecentSpendSpark(daily, {
+    days: 5,
+    today: "2026-06-05",
+  });
+
+  ok("returns exactly requested calendar days", spark.values.length === 5, `got ${spark.values.length}`);
+  ok("starts at the expected calendar day", spark.startDate === "2026-06-01", spark.startDate);
+  ok("preserves gaps as zero-height bars", JSON.stringify(spark.values) === "[10,0,0,0,50]", JSON.stringify(spark.values));
+}
+
+console.log("\n[4] Stale profile data is explicit");
+{
+  const stale = getDailyFreshness(
+    [
+      { date: "2026-06-01", cost: 10, tokens: 100 },
+      { date: "2026-06-03", cost: 30, tokens: 300 },
+    ],
+    "2026-06-05"
+  );
+
+  ok("reports last recorded date", stale.lastRecordedDate === "2026-06-03", stale.lastRecordedDate ?? "");
+  ok("marks stale data before today", stale.isStale);
+  ok("reports missing days", stale.missingDays === 2, `got ${stale.missingDays}`);
+}
+
+console.log("\n[5] Leaderboard ignores results from stale sort/filter requests");
+{
+  const oldRequest = { sortBy: "cost" as const, page: 2, pageSize: 25 };
+  const currentRequest = { sortBy: "tokens" as const, page: 0, pageSize: 25 };
+  const staleResult = {
+    items: [],
+    page: 2,
+    pageSize: 25,
+    hasMore: true,
+    requestKey: getLeaderboardRequestKey(oldRequest),
+  };
+
+  ok(
+    "old paginated cost result does not match current token request",
+    !isLeaderboardResultForRequest(staleResult, currentRequest)
+  );
+  ok(
+    "same request key is accepted",
+    isLeaderboardResultForRequest(
+      { ...staleResult, requestKey: getLeaderboardRequestKey(currentRequest), page: 0 },
+      currentRequest
+    )
+  );
+}
+
+console.log("\n[6] CLI/GitHub duplicate handles can be claimed safely");
+{
+  ok("normalizes invalid punctuation and case while preserving hyphens", normalizeClaimHandle("B-etter.Digital") === "b-etterdigital");
+  ok(
+    "matches unverified CLI alias against signed-in GitHub username",
+    isClaimableCliAlias("B-EtterDigital", {
+      username: "B-etter.Digital",
+      githubUsername: "B-etter.Digital",
+      source: "cli",
+      verified: false,
+    })
+  );
+  ok(
+    "does not claim verified aliases",
+    !isClaimableCliAlias("B-EtterDigital", {
+      username: "B-etter.Digital",
+      githubUsername: "B-etter.Digital",
+      source: "cli",
+      verified: true,
+    })
+  );
+}
+
+console.log(`\n${failed === 0 ? "✅" : "❌"} ${passed} passed, ${failed} failed\n`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Fix leaderboard sort/filter transitions so token/cost switches fetch page 0 instead of reusing stale seeded or later-page rows.
- Key leaderboard hook results to their active request so stale page-2 responses cannot repaint a new page-0 sort/filter state.
- Render profile usage charts on continuous calendar days, filling missing days with zero values and showing when data is stale because the user has not uploaded recent usage.
- Fix duplicate CLI/OAuth identity claiming for unverified CLI aliases such as `B-etter.Digital` versus the real GitHub login `B-EtterDigital`.

## Root cause

The leaderboard could reuse server-seeded default rows after user interaction, and older hook results were not tied to the request that produced them. That allowed later-page rows to appear as rank 1 after sort/filter changes.

Profile charts used the last recorded rows rather than the last calendar days. Sparse uploads compressed the timeline and hid missing recent days.

CLI submissions can store a raw `X-GitHub-User` value. If that value is a punctuation/case variant of the real GitHub handle, the existing exact `github_username` claim lookup misses it, leaving duplicate leaderboard identities.

## Validation

- `pnpm test` passes on this branch: 19 ccusage tests and 19 site-bug tests.
- Combined merge simulation for PRs #72, #73, #74, #75 passes `pnpm test`: 19 ccusage + 9 open-to-work + 10 model-list + 6 rank + 19 site-bug tests.
- Combined production build passes in a temp worktree with dummy auth/Supabase env values.
- `git diff --check` passes.

## Notes

Feature requests remain in separate PRs: #73 expandable model list, #74 rank presentation, #75 custom open-to-work email.
