### PR TITLE
[codex] Make profile rank more prominent

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts"
+    "test": "node test/ccusage.test.mts && for f in test/*.test.mts; do [ \"$f\" = \"test/ccusage.test.mts\" ] || node \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -17,6 +17,7 @@ import { getTierProgress } from "@/lib/tiers";
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "./getProfile";
 import UsageChart from "./UsageChartLazy";
+import { getProfileRankDisplay } from "@/lib/profile-rank";
 import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
 import TierBadge from "@/components/TierBadge";
@@ -107,6 +108,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
   } catch {
     // rank is nice-to-have; render without it on failure
   }
+  const rankDisplay = getProfileRankDisplay(globalRank);
 
   const tokenRows = [
     { label: "Input", value: tokenAgg.input, color: "bg-accent" },
@@ -197,11 +199,6 @@ export default async function ProfilePage({ params }: ProfileParams) {
               <div className="flex flex-wrap items-center gap-2.5 mb-2">
                 <h1 className="text-2xl font-bold tracking-tight">{displayName}</h1>
                 <TierBadge totalCost={bestCost} size="md" />
-                {globalRank && (
-                  <span className="font-mono text-xs font-semibold px-2 py-1 rounded bg-accent/12 text-accent leading-none">
-                    #{globalRank}
-                  </span>
-                )}
                 <OpenToWorkToggle
                   profileGithubUsername={profileData.githubUsername}
                   initialOpen={profileData.openToWork ?? false}
@@ -221,6 +218,20 @@ export default async function ProfilePage({ params }: ProfileParams) {
                   <Calendar className="w-4 h-4" />
                   Joined {new Date(profileData.createdAt).toLocaleDateString()}
                 </span>
+              </div>
+              <div className="mt-4 inline-flex max-w-full items-center gap-3 rounded-lg border border-accent/30 bg-accent/10 px-4 py-3">
+                <Trophy className="w-5 h-5 text-accent flex-shrink-0" />
+                <div className="min-w-0">
+                  <p className="micro-label text-accent/90">{rankDisplay.label}</p>
+                  <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                    <span className="font-mono text-3xl font-bold leading-none text-foreground">
+                      {rankDisplay.value}
+                    </span>
+                    {rankDisplay.isRanked && (
+                      <span className="text-xs text-muted">on the global leaderboard</span>
+                    )}
+                  </div>
+                </div>
               </div>
               {tools.length > 0 && (
                 <div className="flex flex-wrap items-center gap-1.5 mt-3">
@@ -255,8 +266,8 @@ export default async function ProfilePage({ params }: ProfileParams) {
               <p className="text-xs text-muted mt-1">{profileData.totalSubmissions} submission{profileData.totalSubmissions === 1 ? "" : "s"}</p>
             </div>
             <div className="bg-surface-1 border border-border rounded-lg p-4">
-              <p className="flex items-center gap-1.5 micro-label mb-1"><Trophy className="w-3.5 h-3.5" />Global rank</p>
-              <p className="text-xl font-bold">{globalRank ? `#${globalRank}` : "—"}</p>
+              <p className="flex items-center gap-1.5 micro-label mb-1"><Trophy className="w-3.5 h-3.5" />{rankDisplay.label}</p>
+              <p className="text-2xl font-bold font-mono">{rankDisplay.value}</p>
               <p className="text-xs text-muted mt-1 truncate">{tools.length ? `${tools.map(toolLabel).slice(0, 2).join(", ")}${tools.length > 2 ? " +" + (tools.length - 2) : ""}` : "by cost"}</p>
             </div>
           </div>

--- a/src/lib/profile-rank.ts
+++ b/src/lib/profile-rank.ts
@@ -1,0 +1,13 @@
+export interface ProfileRankDisplay {
+  label: string;
+  value: string;
+  isRanked: boolean;
+}
+
+export function getProfileRankDisplay(rank: number | null): ProfileRankDisplay {
+  return {
+    label: "Viberank position",
+    value: rank ? `#${rank}` : "—",
+    isRanked: Boolean(rank),
+  };
+}

--- a/test/profile-rank.test.mts
+++ b/test/profile-rank.test.mts
@@ -1,0 +1,40 @@
+/**
+ * Focused tests for profile rank presentation helpers.
+ * Run: node test/profile-rank.test.mts
+ */
+
+const { getProfileRankDisplay } = await import("../src/lib/profile-rank.ts");
+
+let passed = 0;
+let failed = 0;
+
+function ok(name: string, cond: boolean, detail = "") {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${name} ${detail}`);
+  }
+}
+
+console.log("\n[1] Ranked profiles get a strong rank display");
+{
+  const display = getProfileRankDisplay(2);
+
+  ok("marks profile as ranked", display.isRanked);
+  ok("formats rank with hash prefix", display.value === "#2", display.value);
+  ok("uses a leaderboard-specific label", display.label === "Viberank position", display.label);
+}
+
+console.log("\n[2] Unranked profiles are explicit");
+{
+  const display = getProfileRankDisplay(null);
+
+  ok("marks profile as unranked", !display.isRanked);
+  ok("does not fake a rank", display.value === "—", display.value);
+  ok("keeps the same label for layout stability", display.label === "Viberank position", display.label);
+}
+
+console.log(`\n${failed === 0 ? "✅" : "❌"} ${passed} passed, ${failed} failed\n`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Promote the achieved global rank from a small inline chip to a prominent profile-header element.
- Re-label the profile rank stat as `Viberank position` and keep the unranked state explicit.
- Add a small helper and regression test for rank display formatting.

## Validation

- `node test/profile-rank.test.mts` passes: 6 tests.
- `pnpm test` passes: 19 existing ccusage tests and 6 profile rank tests.
- `git diff --check` and `git diff --cached --check` pass.
- `GITHUB_ID=dummy GITHUB_SECRET=dummy NEXTAUTH_SECRET=dummy-secret NEXTAUTH_URL=http://localhost:3000 pnpm build` compiles successfully, then fails prerendering `/hire` because Supabase server env vars are not configured locally.

## Scope

Feature-only PR. It intentionally does not include PR #72 bug fixes, PR #73 expandable model list changes, or custom open-to-work email handling.
