### PR TITLE
[codex] Add custom open-to-work contact email

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts"
+    "test": "node test/ccusage.test.mts && for f in test/*.test.mts; do [ \"$f\" = \"test/ccusage.test.mts\" ] || node \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/api/profile/open-to-work/route.ts
+++ b/src/app/api/profile/open-to-work/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getServerDataLayer } from "@/lib/data";
+import { normalizeWorkEmail } from "@/lib/open-to-work";
 
 // Toggle the signed-in user's own open-to-work flag. Identity comes from the
 // GitHub OAuth session only — there is no way to set this for someone else.
@@ -12,19 +13,24 @@ export async function POST(request: NextRequest) {
   }
 
   let open: boolean;
+  let workEmail: string | null;
   try {
     const body = await request.json();
     if (typeof body.open !== "boolean") throw new Error("bad payload");
     open = body.open;
-  } catch {
-    return NextResponse.json({ error: "Expected JSON body: { open: boolean }" }, { status: 400 });
+    workEmail = open ? normalizeWorkEmail(body.email) : null;
+  } catch (error) {
+    const message = error instanceof Error && error.message !== "bad payload"
+      ? error.message
+      : "Expected JSON body: { open: boolean, email?: string }";
+    return NextResponse.json({ error: message }, { status: 400 });
   }
 
   const dataLayer = await getServerDataLayer();
-  const result = await dataLayer.profiles.setOpenToWork(session.user.username, open);
+  const result = await dataLayer.profiles.setOpenToWork(session.user.username, open, workEmail);
 
   if (!result.success) {
     return NextResponse.json({ error: result.error || "Update failed" }, { status: 400 });
   }
-  return NextResponse.json({ success: true, open });
+  return NextResponse.json({ success: true, open, email: workEmail });
 }

--- a/src/app/hire/page.tsx
+++ b/src/app/hire/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Github, BadgeCheck, BriefcaseBusiness } from "lucide-react";
+import { Github, BadgeCheck, BriefcaseBusiness, Mail } from "lucide-react";
 import { getServerDataLayer } from "@/lib/data";
 import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl } from "@/lib/utils";
+import { buildWorkEmailHref } from "@/lib/open-to-work";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
 import TierBadge from "@/components/TierBadge";
@@ -69,59 +70,83 @@ export default async function HirePage() {
               <div className="hidden sm:block w-28">Tier</div>
               <div className="w-24 text-right">Usage</div>
               <div className="w-20 text-right hidden sm:block">Rank</div>
+              <div className="w-24 text-right">Contact</div>
             </div>
             <div className="divide-y divide-border-subtle">
               {listings.map((l) => (
-                <Link
+                <div
                   key={l.githubUsername}
-                  href={`/profile/${encodeURIComponent(l.githubUsername)}`}
                   className="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors group"
                 >
-                  <div className="flex items-center gap-3 flex-1 min-w-0">
-                    {l.avatar ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        src={sizedAvatarUrl(l.avatar, 80)}
-                        alt=""
-                        width={40}
-                        height={40}
-                        className="w-10 h-10 rounded-full ring-2 ring-emerald-500/40"
-                      />
-                    ) : (
-                      <div className="w-10 h-10 rounded-full bg-surface-2 flex items-center justify-center">
-                        <BriefcaseBusiness className="w-4 h-4 text-muted" />
-                      </div>
-                    )}
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-1.5">
-                        <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
-                          {l.githubUsername}
-                        </span>
-                        {l.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
-                        <Github className="w-3.5 h-3.5 text-muted flex-shrink-0" />
-                      </div>
-                      <div className="flex flex-wrap gap-1 mt-0.5">
-                        {l.tools.map((t) => (
-                          <span key={t} className="text-[10px] font-mono text-muted">
-                            {toolLabel(t)}
+                  <Link
+                    href={`/profile/${encodeURIComponent(l.githubUsername)}`}
+                    className="flex items-center gap-3 flex-1 min-w-0"
+                  >
+                    <div className="flex items-center gap-3 flex-1 min-w-0">
+                      {l.avatar ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={sizedAvatarUrl(l.avatar, 80)}
+                          alt=""
+                          width={40}
+                          height={40}
+                          className="w-10 h-10 rounded-full ring-2 ring-emerald-500/40"
+                        />
+                      ) : (
+                        <div className="w-10 h-10 rounded-full bg-surface-2 flex items-center justify-center">
+                          <BriefcaseBusiness className="w-4 h-4 text-muted" />
+                        </div>
+                      )}
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-1.5">
+                          <span className="text-sm font-medium group-hover:text-accent transition-colors truncate">
+                            {l.githubUsername}
                           </span>
-                        ))}
+                          {l.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+                          <Github className="w-3.5 h-3.5 text-muted flex-shrink-0" />
+                        </div>
+                        <div className="flex flex-wrap gap-1 mt-0.5">
+                          {l.tools.map((t) => (
+                            <span key={t} className="text-[10px] font-mono text-muted">
+                              {toolLabel(t)}
+                            </span>
+                          ))}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <div className="hidden sm:block w-28 flex-shrink-0">
-                    <TierBadge totalCost={l.bestCost} size="xs" bare />
-                  </div>
-                  <div className="w-24 text-right flex-shrink-0">
-                    <span className="text-sm font-mono font-semibold text-accent">
-                      ${formatCurrency(l.bestCost)}
-                    </span>
-                    <div className="text-[10px] font-mono text-muted">{formatNumber(l.totalTokens)} tok</div>
-                  </div>
-                  <div className="w-20 text-right flex-shrink-0 hidden sm:block">
-                    {l.rank && <span className="text-sm font-mono text-muted">#{l.rank}</span>}
-                  </div>
-                </Link>
+                    <div className="hidden sm:block w-28 flex-shrink-0">
+                      <TierBadge totalCost={l.bestCost} size="xs" bare />
+                    </div>
+                    <div className="w-24 text-right flex-shrink-0">
+                      <span className="text-sm font-mono font-semibold text-accent">
+                        ${formatCurrency(l.bestCost)}
+                      </span>
+                      <div className="text-[10px] font-mono text-muted">{formatNumber(l.totalTokens)} tok</div>
+                    </div>
+                    <div className="w-20 text-right flex-shrink-0 hidden sm:block">
+                      {l.rank && <span className="text-sm font-mono text-muted">#{l.rank}</span>}
+                    </div>
+                  </Link>
+                  {l.workEmail ? (
+                    <a
+                      href={buildWorkEmailHref(l.workEmail)}
+                      className="inline-flex w-24 flex-shrink-0 items-center justify-end gap-1.5 text-xs font-mono text-emerald-400 transition-colors hover:text-emerald-300"
+                    >
+                      <Mail className="w-3.5 h-3.5" />
+                      Email
+                    </a>
+                  ) : (
+                    <a
+                      href={`https://github.com/${l.githubUsername}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex w-24 flex-shrink-0 items-center justify-end gap-1.5 text-xs font-mono text-muted transition-colors hover:text-accent"
+                    >
+                      <Github className="w-3.5 h-3.5" />
+                      GitHub
+                    </a>
+                  )}
+                </div>
               ))}
             </div>
           </div>
@@ -138,7 +163,7 @@ export default async function HirePage() {
 
         <p className="text-xs text-muted mt-8">
           For engineers: opt in or out anytime from your profile — it&apos;s a single toggle, visible only
-          as this list and a badge. We never share emails; companies reach you via your GitHub.
+          as this list and a badge. Add a contact email if you want companies to skip GitHub DMs.
         </p>
       </div>
 

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -205,6 +205,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
                 <OpenToWorkToggle
                   profileGithubUsername={profileData.githubUsername}
                   initialOpen={profileData.openToWork ?? false}
+                  initialEmail={profileData.openToWork ? profileData.openToWorkEmail : undefined}
                 />
               </div>
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-sm text-muted">

--- a/src/components/OpenToWorkToggle.tsx
+++ b/src/components/OpenToWorkToggle.tsx
@@ -2,19 +2,23 @@
 
 import { useState } from "react";
 import { useSession } from "next-auth/react";
-import { BriefcaseBusiness, Loader2 } from "lucide-react";
+import { BriefcaseBusiness, Loader2, Mail } from "lucide-react";
 import { track } from "@vercel/analytics";
+import { buildWorkEmailHref, normalizeWorkEmail } from "@/lib/open-to-work";
 
 interface OpenToWorkToggleProps {
   profileGithubUsername?: string;
   initialOpen: boolean;
+  initialEmail?: string;
 }
 
 // Shown only to the profile's owner. Toggles the opt-in flag that puts them
 // on /hire and adds the badge to their public profile.
-export default function OpenToWorkToggle({ profileGithubUsername, initialOpen }: OpenToWorkToggleProps) {
+export default function OpenToWorkToggle({ profileGithubUsername, initialOpen, initialEmail }: OpenToWorkToggleProps) {
   const { data: session } = useSession();
   const [open, setOpen] = useState(initialOpen);
+  const [email, setEmail] = useState(initialEmail ?? "");
+  const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
   const isOwner =
@@ -26,30 +30,56 @@ export default function OpenToWorkToggle({ profileGithubUsername, initialOpen }:
   // owner gets the interactive toggle.
   if (!isOwner) {
     if (!initialOpen) return null;
-    return (
+    const content = (
+      <>
+        <BriefcaseBusiness className="w-3.5 h-3.5" />
+        Open to work
+      </>
+    );
+
+    return initialEmail ? (
+      <a
+        href={buildWorkEmailHref(initialEmail)}
+        className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono font-medium rounded-full border border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
+      >
+        {content}
+      </a>
+    ) : (
       <a
         href="/hire"
         className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono font-medium rounded-full border border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
       >
-        <BriefcaseBusiness className="w-3.5 h-3.5" />
-        Open to work
+        {content}
       </a>
     );
   }
 
-  const toggle = async () => {
+  const save = async (nextOpen: boolean) => {
     if (busy) return;
+    setError(null);
+
+    let normalizedEmail: string | null = null;
+    try {
+      normalizedEmail = nextOpen ? normalizeWorkEmail(email) : null;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Enter a valid contact email.");
+      return;
+    }
+
     setBusy(true);
-    const next = !open;
     try {
       const res = await fetch("/api/profile/open-to-work", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ open: next }),
+        body: JSON.stringify({ open: nextOpen, email: normalizedEmail }),
       });
       if (res.ok) {
-        setOpen(next);
-        track("open_to_work_toggled", { open: next });
+        setOpen(nextOpen);
+        setEmail(normalizedEmail ?? "");
+        track("open_to_work_toggled", { open: nextOpen, has_email: Boolean(normalizedEmail) });
+      } else {
+        const body = await res.json().catch(() => null);
+        setError(body?.error || "Update failed");
       }
     } finally {
       setBusy(false);
@@ -57,18 +87,46 @@ export default function OpenToWorkToggle({ profileGithubUsername, initialOpen }:
   };
 
   return (
-    <button
-      onClick={toggle}
-      disabled={busy}
-      title={open ? "Shown on viberank.app/hire — click to opt out" : "List yourself on viberank.app/hire"}
-      className={`inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-mono font-medium rounded-full border transition-colors ${
-        open
-          ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
-          : "border-border text-muted hover:text-foreground hover:bg-surface-2"
-      }`}
-    >
-      {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <BriefcaseBusiness className="w-3.5 h-3.5" />}
-      {open ? "Open to work" : "Set open to work"}
-    </button>
+    <div className="inline-flex max-w-full flex-col gap-1.5">
+      <div className="inline-flex max-w-full flex-wrap items-center gap-1.5">
+        <label className="relative">
+          <Mail className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted" />
+          <input
+            type="email"
+            aria-label="Contact email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            placeholder="contact email"
+            disabled={busy}
+            className="h-7 w-48 rounded-md border border-border bg-background pl-7 pr-2 text-xs font-mono text-foreground placeholder:text-muted focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+        </label>
+        <button
+          type="button"
+          onClick={() => save(true)}
+          disabled={busy}
+          title={open ? "Save open-to-work contact email" : "List yourself on viberank.app/hire"}
+          className={`inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-xs font-mono font-medium transition-colors ${
+            open
+              ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-400"
+              : "border-border text-muted hover:text-foreground hover:bg-surface-2"
+          }`}
+        >
+          {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <BriefcaseBusiness className="w-3.5 h-3.5" />}
+          {open ? "Save contact" : "Set open to work"}
+        </button>
+        {open && (
+          <button
+            type="button"
+            onClick={() => save(false)}
+            disabled={busy}
+            className="h-7 rounded-md border border-border px-2.5 text-xs font-mono text-muted transition-colors hover:text-foreground hover:bg-surface-2"
+          >
+            Opt out
+          </button>
+        )}
+      </div>
+      {error && <p className="text-[11px] text-red-400">{error}</p>}
+    </div>
   );
 }

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -88,6 +88,7 @@ interface DbProfile {
   total_submissions: number;
   best_submission_id: string | null;
   open_to_work: boolean | null;
+  open_to_work_email: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -989,6 +990,7 @@ class SupabaseProfilesService implements ProfilesService {
       totalSubmissions: profile.total_submissions,
       bestSubmission: profile.best_submission_id || undefined,
       openToWork: profile.open_to_work || false,
+      openToWorkEmail: profile.open_to_work_email || undefined,
       createdAt: new Date(profile.created_at).getTime(),
       submissions: (submissions || []).map((s) =>
         convertDbSubmissionToSubmission(s, dailyBySubmission.get(s.id) || [])
@@ -998,11 +1000,15 @@ class SupabaseProfilesService implements ProfilesService {
 
   async setOpenToWork(
     githubUsername: string,
-    open: boolean
+    open: boolean,
+    workEmail?: string | null
   ): Promise<{ success: boolean; error?: string }> {
     const { data, error } = await this.client
       .from("profiles")
-      .update({ open_to_work: open })
+      .update({
+        open_to_work: open,
+        open_to_work_email: open ? workEmail ?? null : null,
+      })
       .ilike("github_username", githubUsername)
       .select("id");
 
@@ -1054,6 +1060,7 @@ class SupabaseProfilesService implements ProfilesService {
           tools: best.tools && best.tools.length > 0 ? best.tools : ["claude"],
           rank: costs.length > 0 ? costs.filter((c) => c > bestCost).length + 1 : null,
           verified: best.verified,
+          workEmail: p.open_to_work_email || undefined,
         };
       })
       .sort((a, b) => b.bestCost - a.bestCost);

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -68,6 +68,8 @@ export interface Profile {
   bestSubmission?: string;
   /** Explicit opt-in flag shown on the profile and the /hire page. */
   openToWork?: boolean;
+  /** Optional contact email shown only when the profile is open to work. */
+  openToWorkEmail?: string;
   createdAt: number; // Unix timestamp in ms
 }
 
@@ -82,6 +84,7 @@ export interface HireListing {
   tools: string[];
   rank: number | null;
   verified: boolean;
+  workEmail?: string;
 }
 
 export interface ProfileWithSubmissions extends Profile {
@@ -273,7 +276,8 @@ export interface ProfilesService {
   /** Set the open-to-work flag for a GitHub-verified profile. */
   setOpenToWork(
     githubUsername: string,
-    open: boolean
+    open: boolean,
+    workEmail?: string | null
   ): Promise<{ success: boolean; error?: string }>;
   /** All opted-in profiles with board stats, sorted by best cost. */
   getHireListings(): Promise<HireListing[]>;

--- a/src/lib/open-to-work.ts
+++ b/src/lib/open-to-work.ts
@@ -1,0 +1,19 @@
+const EMAIL_RE = /^[A-Za-z0-9.!#$'*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
+const EMAIL_MAX_LENGTH = 254;
+
+export function normalizeWorkEmail(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value !== "string") throw new Error("Enter a valid contact email.");
+
+  const email = value.trim();
+  if (!email) return null;
+  if (email.length > EMAIL_MAX_LENGTH) throw new Error("Enter a valid contact email.");
+  if (/[?&%#:\r\n]/.test(email)) throw new Error("Enter a valid contact email.");
+  if (!EMAIL_RE.test(email)) throw new Error("Enter a valid contact email.");
+
+  return email;
+}
+
+export function buildWorkEmailHref(email: string): string {
+  return `mailto:${encodeURIComponent(email)}?subject=${encodeURIComponent("Viberank work inquiry")}`;
+}

--- a/supabase/migrations/005_open_to_work_email.sql
+++ b/supabase/migrations/005_open_to_work_email.sql
@@ -1,0 +1,30 @@
+-- Migration 005: optional contact email for explicit open-to-work listings.
+--
+-- The email is only meaningful when open_to_work is true. Application code
+-- clears it when a user opts out, so old rows keep working and no email is
+-- displayed unless the profile owner saves one.
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS open_to_work_email TEXT;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'profiles_open_to_work_email_format'
+      AND conrelid = 'profiles'::regclass
+  ) THEN
+    ALTER TABLE profiles
+      ADD CONSTRAINT profiles_open_to_work_email_format
+      CHECK (
+        open_to_work_email IS NULL
+        OR (
+          open_to_work
+          AND length(open_to_work_email) <= 254
+          AND open_to_work_email !~ ('[?&%#:' || chr(13) || chr(10) || ']')
+          AND open_to_work_email ~* '^[A-Za-z0-9.!#$''*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$'
+        )
+      );
+  END IF;
+END $$;

--- a/test/open-to-work.test.mts
+++ b/test/open-to-work.test.mts
@@ -1,0 +1,53 @@
+/**
+ * Focused tests for open-to-work contact settings.
+ * Run: node test/open-to-work.test.mts
+ */
+
+const { buildWorkEmailHref, normalizeWorkEmail } = await import("../src/lib/open-to-work.ts");
+
+let passed = 0;
+let failed = 0;
+
+function ok(name: string, cond: boolean, detail = "") {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${name} ${detail}`);
+  }
+}
+
+console.log("\n[1] Work email normalization");
+{
+  ok("trims valid email", normalizeWorkEmail("  hire@b-etter.digital  ") === "hire@b-etter.digital");
+  ok("turns empty input into null", normalizeWorkEmail("   ") === null);
+  ok("turns null input into null", normalizeWorkEmail(null) === null);
+}
+
+console.log("\n[2] Work email validation");
+{
+  for (const value of [
+    "not an email",
+    "hire@example.com?bcc=lead%40competitor.com",
+    "hire@example.com&body=pre-filled",
+    "hire@example.com%0D%0ABcc:lead%40competitor.com",
+  ]) {
+    try {
+      normalizeWorkEmail(value);
+      ok(`rejects ${value}`, false, "did not throw");
+    } catch (error) {
+      ok(`rejects ${value}`, error instanceof Error && error.message === "Enter a valid contact email.");
+    }
+  }
+}
+
+console.log("\n[3] Work email links are encoded");
+{
+  const href = buildWorkEmailHref("hire@b-etter.digital");
+  ok("builds mailto link", href.startsWith("mailto:hire%40b-etter.digital?"), href);
+  ok("encodes subject separately", href.includes("subject=Viberank%20work%20inquiry"), href);
+}
+
+console.log(`\n${failed === 0 ? "✅" : "❌"} ${passed} passed, ${failed} failed\n`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

- Add an optional custom contact email to open-to-work profiles.
- Validate/normalize the email in a shared helper and API route.
- Store the email in a nullable `profiles.open_to_work_email` column and clear it when opting out.
- Show email contact actions on `/hire` when an opted-in engineer has saved an email, falling back to GitHub contact otherwise.
- Harden `mailto:` links against query/header injection and encode mailto components.
- Add an accessible label to the owner contact email input.

## Migration

- Adds `supabase/migrations/005_open_to_work_email.sql` with nullable `open_to_work_email`, an email-format check constraint, and a DB invariant that email is only stored when `open_to_work` is true.
- `supabase db push` was attempted locally but blocked because this checkout is not linked to a Supabase project ref: `Cannot find project ref. Have you run supabase link?`

## Validation

- `pnpm test` passes on this branch: 19 ccusage tests and 9 open-to-work tests.
- Combined merge simulation for PRs #72, #73, #74, #75 passes `pnpm test`: 19 ccusage + 9 open-to-work + 10 model-list + 6 rank + 19 site-bug tests.
- Combined production build passes in a temp worktree with dummy auth/Supabase env values.
- `git diff --check` passes.

## Scope

Feature-only PR. It intentionally does not include PR #72 bug fixes, PR #73 expandable model list changes, or PR #74 rank presentation changes.
