### PR TITLE
fix: exclude cache-read tokens from absolute token ceiling (#77)

### DIFF
--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -270,7 +270,12 @@ export function normalizeCcData(raw: RawCcData): NormalizedCcData {
 
 // Realistic-range constants (shared, ported from the original Convex checks).
 const MAX_DAILY_COST = 5000; // $5k/day is already extreme usage
-const MAX_DAILY_TOKENS = 250_000_000; // 250M tokens/day
+// Absolute token ceiling. Cache-read tokens are ~free (≈1/10th the input
+// price) and dominate `totalTokens` for heavy context-reuse users, so they're
+// excluded from this cap — counting them produced false rejections for genuine
+// high-cache submissions that sit far under the cost ceiling (#77). The cost
+// cap and the cost/token ratio band remain the primary anti-inflation guards.
+const MAX_DAILY_TOKENS = 250_000_000; // 250M non-cache-read tokens/day
 const MIN_COST_PER_TOKEN = 0.0000001; // cache reads are very cheap
 const MAX_COST_PER_TOKEN = 0.1; // sanity ceiling on cost/token
 
@@ -308,7 +313,12 @@ export function validateCcData(
   if (ccData.totals.totalCost > MAX_DAILY_COST * 365) {
     throw new Error("Total cost exceeds realistic limits.");
   }
-  if (ccData.totals.totalTokens > MAX_DAILY_TOKENS * 365) {
+  // Exclude cache-read tokens: they're ~free and legitimately balloon
+  // `totalTokens` for heavy context-reuse, so they don't belong against a
+  // "realistic tokens" bound (#77).
+  const nonCacheReadTokens =
+    ccData.totals.totalTokens - ccData.totals.cacheReadTokens;
+  if (nonCacheReadTokens > MAX_DAILY_TOKENS * 365) {
     throw new Error("Total tokens exceed realistic limits.");
   }
 

--- a/test/ccusage.test.mts
+++ b/test/ccusage.test.mts
@@ -178,6 +178,53 @@ console.log("\n[4] Anti-cheat still holds");
       ),
     "Cost per token ratio is unrealistic"
   );
+  // heavy cache-read user: totalTokens trips the old absolute cap but
+  // non-cache-read tokens are well under it, cost is far below the cap, and the
+  // cost/token ratio is in band -> must be accepted (#77).
+  doesNotThrow(
+    "cache-read-heavy submission accepted (was rejected by token cap)",
+    () =>
+      validateCcData(
+        {
+          totals: {
+            inputTokens: 25_000_000_000,
+            outputTokens: 113_577_997,
+            cacheCreationTokens: 0,
+            cacheReadTokens: 66_351_156_098,
+            totalTokens: 91_464_734_095,
+            totalCost: 44_218,
+          },
+          daily: [
+            {
+              date: "2025-01-01",
+              inputTokens: 25_000_000_000,
+              outputTokens: 113_577_997,
+              cacheCreationTokens: 0,
+              cacheReadTokens: 66_351_156_098,
+              totalTokens: 91_464_734_095,
+              totalCost: 44_218,
+              modelsUsed: ["claude-opus-4-8"],
+              agents: ["claude"],
+            },
+          ],
+        },
+        FIXED_NOW
+      )
+  );
+  // but inflating *non-cache-read* tokens past the cap is still rejected (cap
+  // still bites when cache reads aren't doing the inflating).
+  throws(
+    "non-cache-read tokens over cap still rejected",
+    () =>
+      validateCcData(
+        {
+          totals: { inputTokens: 100_000_000_000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 100_000_000_000, totalCost: 1_000_000 },
+          daily: [{ date: "2025-01-01", inputTokens: 100_000_000_000, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 100_000_000_000, totalCost: 1_000_000, modelsUsed: [], agents: [] }],
+        },
+        FIXED_NOW
+      ),
+    "Total tokens exceed realistic limits"
+  );
   // future date -> reject
   throws(
     "future date rejected",


### PR DESCRIPTION
## What

Fixes #77. Legitimate `ccusage`-generated submissions from heavy context-reuse users were rejected with `400 "Total tokens exceed realistic limits."` because the absolute token ceiling counted **cache-read tokens**, which are ~free yet dominate `totalTokens`.

## Change

`validateCcData` now measures **non-cache-read tokens** against `MAX_DAILY_TOKENS * 365`:

```ts
const nonCacheReadTokens = ccData.totals.totalTokens - ccData.totals.cacheReadTokens;
if (nonCacheReadTokens > MAX_DAILY_TOKENS * 365) { ... }
```

Cache reads cost ~1/10th of input tokens, so they don't belong against a "realistic tokens" bound. Inflation in both directions is still bounded by the existing cost cap (`MAX_DAILY_COST * 365`) and the cost/token ratio band — those remain the primary anti-cheat guards.

## Tests

Added two cases to `test/ccusage.test.mts` (run with `npm test`):
- The exact real example from the issue (91.46B totalTokens, 66.35B cache-read, $44,218) — now **accepted**.
- A submission inflating *non-cache-read* tokens past the cap — still **rejected**, confirming the ceiling still bites when cache reads aren't the cause.

All 21 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)