### PR TITLE
feat: sum multi-machine daily usage via stable machine id (#43)

### DIFF
--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
+import crypto from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import chalk from 'chalk';
@@ -15,6 +17,29 @@ const __dirname = path.dirname(__filename);
 // Read package.json to get version
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
 const CLI_VERSION = packageJson.version;
+
+// Stable, anonymous per-machine id so the server can sum usage submitted from
+// multiple machines under one account instead of overwriting it, while still
+// treating a re-submission from this machine as a replace (issue #43). It's a
+// random UUID — no hardware/identifying info — persisted under ~/.viberank.
+function getMachineId() {
+  const dir = path.join(os.homedir(), '.viberank');
+  const idFile = path.join(dir, 'machine-id');
+  try {
+    return fs.readFileSync(idFile, 'utf8').trim();
+  } catch {
+    // Not created yet (or unreadable) — generate and persist one.
+  }
+  const id = crypto.randomUUID();
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(idFile, id, { mode: 0o600 });
+  } catch {
+    // Read-only home dir: fall back to an ephemeral id for this run. Worst case
+    // a future run gets a new id and that day sums once — never data loss.
+  }
+  return id;
+}
 
 async function main() {
   console.log(chalk.yellow.bold(`\n🚀 Viberank Submission Tool v${CLI_VERSION}\n`));
@@ -158,7 +183,8 @@ async function main() {
         headers: {
           'Content-Type': 'application/json',
           'X-GitHub-User': githubUser,
-          'X-CLI-Version': CLI_VERSION
+          'X-CLI-Version': CLI_VERSION,
+          'X-Machine-Id': getMachineId()
         },
         body: JSON.stringify(ccData)
       });

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viberank-cli",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",
@@ -30,7 +30,7 @@
     "node-fetch": "^3.3.2"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=14.17.0"
   },
   "repository": {
     "type": "git",

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -162,6 +162,11 @@ export async function POST(request: NextRequest) {
     try {
       const dataLayer = await getServerDataLayer();
 
+      // Stable per-machine id lets us sum overlapping dates across machines
+      // without double-counting same-machine re-submits (#43). Optional: web
+      // uploads and older CLIs omit it and fall back to a shared bucket.
+      const machineId = request.headers.get("X-Machine-Id") || undefined;
+
       const submissionPromise = dataLayer.submissions.submit({
         username: githubUsername,
         githubUsername: githubUsername,
@@ -169,6 +174,7 @@ export async function POST(request: NextRequest) {
         githubAvatar,
         source: source,
         verified: verified,
+        machineId,
         ccData: ccData,
       });
 
@@ -362,7 +368,7 @@ export async function OPTIONS() {
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, X-GitHub-User",
+      "Access-Control-Allow-Headers": "Content-Type, X-GitHub-User, X-Machine-Id, X-CLI-Version",
     },
   });
 }

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -110,6 +110,100 @@ function mergeModelBreakdowns(
   return Array.from(byModel.values());
 }
 
+// ---------------------------------------------------------------------------
+// Per-machine daily merge (issue #43)
+// ---------------------------------------------------------------------------
+// ccusage exposes no machine identifier, so the server can't tell "different
+// machine, same day" (should sum) from "re-submit, same day" (should replace).
+// The CLI now sends a stable `X-Machine-Id`; we record each machine's slice of
+// a day under that id so overlapping dates from distinct machines sum while a
+// re-submission from the same machine replaces only its own slice. The daily
+// row keeps aggregate (summed) fields for display — the per-machine map is
+// bookkeeping the merge needs and the UI never reads.
+
+/** One machine's contribution to a single day. */
+export interface MachineContribution {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  modelsUsed: string[];
+  agents: string[];
+  modelBreakdowns?: NormalizedModelBreakdown[];
+}
+
+/** Aggregate of every machine's slice for a day — what the row stores/displays. */
+export interface DailyAggregate {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  modelsUsed: string[];
+  agents: string[];
+  modelBreakdowns?: NormalizedModelBreakdown[];
+}
+
+/** Sentinel machine id for submissions that carry no `X-Machine-Id` header. */
+export const DEFAULT_MACHINE_ID = "default";
+
+function aggregateContributions(
+  contributions: Record<string, MachineContribution>
+): DailyAggregate {
+  const agg: DailyAggregate = {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: 0,
+    totalCost: 0,
+    modelsUsed: [],
+    agents: [],
+    modelBreakdowns: undefined,
+  };
+  const models = new Set<string>();
+  const agents = new Set<string>();
+  for (const c of Object.values(contributions)) {
+    agg.inputTokens += c.inputTokens;
+    agg.outputTokens += c.outputTokens;
+    agg.cacheCreationTokens += c.cacheCreationTokens;
+    agg.cacheReadTokens += c.cacheReadTokens;
+    agg.totalTokens += c.totalTokens;
+    agg.totalCost += c.totalCost;
+    c.modelsUsed.forEach((m) => models.add(m));
+    c.agents.forEach((a) => agents.add(a));
+    agg.modelBreakdowns = mergeModelBreakdowns(agg.modelBreakdowns, c.modelBreakdowns);
+  }
+  agg.modelsUsed = Array.from(models);
+  agg.agents = Array.from(agents);
+  return agg;
+}
+
+/**
+ * Fold one machine's slice for a day into the existing per-machine map and
+ * recompute the day's aggregate. Pure so it can be unit-tested.
+ *
+ * @param existing prior per-machine map, or null for a legacy row that predates
+ *   per-machine tracking. A legacy row's aggregate is *not* preserved: we can't
+ *   attribute it to a machine, so the first id'd submission replaces it (today's
+ *   overwrite behavior). Once a machine re-submits, distinct machines sum and
+ *   the day self-heals.
+ */
+export function mergeMachineContribution(
+  existing: Record<string, MachineContribution> | null | undefined,
+  machineId: string,
+  incoming: MachineContribution
+): { contributions: Record<string, MachineContribution>; aggregate: DailyAggregate } {
+  const contributions: Record<string, MachineContribution> = {
+    ...(existing ?? {}),
+    [machineId]: incoming,
+  };
+  return { contributions, aggregate: aggregateContributions(contributions) };
+}
+
 export interface NormalizedCcData {
   totals: {
     inputTokens: number;

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -29,7 +29,13 @@ import type {
   ModelBreakdown,
 } from "../types";
 import { SupabaseRateLimiter } from "./rate-limiter";
-import { validateCcData, inferToolFromModel } from "@/lib/ccusage";
+import {
+  validateCcData,
+  inferToolFromModel,
+  mergeMachineContribution,
+  DEFAULT_MACHINE_ID,
+  type MachineContribution,
+} from "@/lib/ccusage";
 
 // ============================================================================
 // DATABASE TYPES (matching Supabase schema)
@@ -75,6 +81,9 @@ interface DbDailyBreakdown {
   models_used: string[];
   agents: string[] | null;
   model_breakdowns: ModelBreakdown[] | null;
+  // Per-machine slices of this day, keyed by machine id. NULL on legacy rows
+  // that predate per-machine tracking (#43).
+  machine_contributions: Record<string, MachineContribution> | null;
 }
 
 interface DbProfile {
@@ -125,6 +134,23 @@ function convertDbSubmissionToSubmission(
     claimedBy: dbSubmission.claimed_by || undefined,
     flaggedForReview: dbSubmission.flagged_for_review || undefined,
     flagReasons: dbSubmission.flag_reasons || undefined,
+  };
+}
+
+/** One incoming day (one machine's cc.json) as a per-machine contribution. */
+function dailyEntryToContribution(
+  day: SubmitData["ccData"]["daily"][number]
+): MachineContribution {
+  return {
+    inputTokens: day.inputTokens,
+    outputTokens: day.outputTokens,
+    cacheCreationTokens: day.cacheCreationTokens,
+    cacheReadTokens: day.cacheReadTokens,
+    totalTokens: day.totalTokens,
+    totalCost: day.totalCost,
+    modelsUsed: day.modelsUsed,
+    agents: day.agents ?? [],
+    modelBreakdowns: day.modelBreakdowns,
   };
 }
 
@@ -198,6 +224,11 @@ class SupabaseSubmissionsService implements SubmissionsService {
       )
       .limit(1);
 
+    // Identify the contributing machine so overlapping dates from distinct
+    // machines sum while a same-machine re-submit replaces only its slice (#43).
+    // Web uploads / older CLIs send no id and share the "default" bucket.
+    const machineId = data.machineId || DEFAULT_MACHINE_ID;
+
     let submissionId: string;
 
     if (existingSubmissions && existingSubmissions.length > 0) {
@@ -208,7 +239,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
         dateRangeStart,
         dateRangeEnd,
         modelsUsed,
-        tools
+        tools,
+        machineId
       );
     } else {
       // Create new submission
@@ -217,7 +249,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
         dateRangeStart,
         dateRangeEnd,
         modelsUsed,
-        tools
+        tools,
+        machineId
       );
     }
 
@@ -240,7 +273,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
     dateRangeStart: string,
     dateRangeEnd: string,
     modelsUsed: string[],
-    tools: string[]
+    tools: string[],
+    machineId: string
   ): Promise<string> {
     // Get existing daily breakdowns
     const { data: existingDaily } = await this.client
@@ -252,23 +286,33 @@ class SupabaseSubmissionsService implements SubmissionsService {
     const dailyMap = new Map<string, DbDailyBreakdown>();
     (existingDaily || []).forEach((day) => dailyMap.set(day.date, day));
 
-    // Update with new daily data
+    // Fold each incoming day into the existing per-machine map. A day from a new
+    // machine adds a slice (sums); a re-submit from the same machine replaces
+    // only its own slice (no double-count). #43
     for (const day of data.ccData.daily) {
+      const prior = dailyMap.get(day.date);
+      const { contributions, aggregate } = mergeMachineContribution(
+        prior?.machine_contributions ?? null,
+        machineId,
+        dailyEntryToContribution(day)
+      );
+
       const dailyData = {
         submission_id: existing.id,
         date: day.date,
-        input_tokens: day.inputTokens,
-        output_tokens: day.outputTokens,
-        cache_creation_tokens: day.cacheCreationTokens,
-        cache_read_tokens: day.cacheReadTokens,
-        total_tokens: day.totalTokens,
-        total_cost: day.totalCost,
-        models_used: day.modelsUsed,
-        agents: day.agents ?? [],
-        model_breakdowns: day.modelBreakdowns ?? null,
+        input_tokens: aggregate.inputTokens,
+        output_tokens: aggregate.outputTokens,
+        cache_creation_tokens: aggregate.cacheCreationTokens,
+        cache_read_tokens: aggregate.cacheReadTokens,
+        total_tokens: aggregate.totalTokens,
+        total_cost: aggregate.totalCost,
+        models_used: aggregate.modelsUsed,
+        agents: aggregate.agents,
+        model_breakdowns: aggregate.modelBreakdowns ?? null,
+        machine_contributions: contributions,
       };
 
-      if (dailyMap.has(day.date)) {
+      if (prior) {
         // Update existing
         await this.client
           .from("daily_breakdowns")
@@ -347,7 +391,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
     dateRangeStart: string,
     dateRangeEnd: string,
     modelsUsed: string[],
-    tools: string[]
+    tools: string[],
+    machineId: string
   ): Promise<string> {
     // Insert submission
     const { data: submission, error } = await this.client
@@ -378,7 +423,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
       throw new Error("Failed to create submission: " + error?.message);
     }
 
-    // Insert daily breakdowns
+    // Insert daily breakdowns. Seed each day's per-machine map with this
+    // machine's slice so a later submission from another machine sums (#43).
     const dailyRows = data.ccData.daily.map((day) => ({
       submission_id: submission.id,
       date: day.date,
@@ -391,6 +437,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
       models_used: day.modelsUsed,
       agents: day.agents ?? [],
       model_breakdowns: day.modelBreakdowns ?? null,
+      machine_contributions: { [machineId]: dailyEntryToContribution(day) },
     }));
 
     const { error: dailyError } = await this.client
@@ -823,6 +870,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
         models_used: d.models_used,
         agents: d.agents || [],
         model_breakdowns: d.model_breakdowns ?? null,
+        machine_contributions: d.machine_contributions ?? null,
       }))
     );
 

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -123,6 +123,10 @@ export interface SubmitData {
   githubAvatar?: string;
   source: "cli" | "oauth";
   verified: boolean;
+  // Stable per-machine id (CLI `X-Machine-Id` header). Absent for web uploads /
+  // older CLIs; the data layer falls back to a shared "default" bucket. Used to
+  // sum overlapping dates across machines without double-counting re-submits (#43).
+  machineId?: string;
   ccData: {
     totals: {
       inputTokens: number;

--- a/submit-to-viberank.sh
+++ b/submit-to-viberank.sh
@@ -48,12 +48,26 @@ echo "Summary:"
 jq -r '.totals | "  Total Cost: $\(.totalCost | round)\n  Total Tokens: \(.totalTokens)\n  Days Tracked: \(.daily | length)"' cc.json 2>/dev/null || echo "  (install jq for summary)"
 echo ""
 
+# Stable, anonymous per-machine id so submissions from multiple machines under
+# one account sum instead of overwriting, while a re-submit from this machine
+# replaces (issue #43). Random UUID persisted under ~/.viberank.
+MACHINE_ID_FILE="$HOME/.viberank/machine-id"
+if [ -s "$MACHINE_ID_FILE" ]; then
+    MACHINE_ID=$(cat "$MACHINE_ID_FILE")
+else
+    MACHINE_ID=$(uuidgen 2>/dev/null || cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "")
+    if [ -n "$MACHINE_ID" ]; then
+        mkdir -p "$HOME/.viberank" && printf '%s' "$MACHINE_ID" > "$MACHINE_ID_FILE" 2>/dev/null || true
+    fi
+fi
+
 # Submit to Viberank
 echo -e "${YELLOW}Submitting to Viberank...${NC}"
 
 RESPONSE=$(curl -s -X POST https://www.viberank.app/api/submit \
   -H "Content-Type: application/json" \
   -H "X-GitHub-User: $GITHUB_USER" \
+  -H "X-Machine-Id: $MACHINE_ID" \
   -d @cc.json)
 
 # Check if submission was successful

--- a/supabase/migrations/005_machine_contributions.sql
+++ b/supabase/migrations/005_machine_contributions.sql
@@ -1,0 +1,21 @@
+-- Migration 005: per-machine daily contributions (issue #43).
+--
+-- ccusage has no machine identifier, so two machines submitting the same date
+-- under one account used to overwrite each other (data loss), while we still
+-- had to overwrite a re-submission from the *same* machine (no double-count).
+-- The CLI now sends a stable `X-Machine-Id`; this column records each machine's
+-- slice of a day keyed by that id. The row's aggregate columns stay the sum
+-- across machines (what the UI reads); machine_contributions is merge-only
+-- bookkeeping.
+--
+-- Shape: { "<machineId>": { inputTokens, outputTokens, cacheCreationTokens,
+--          cacheReadTokens, totalTokens, totalCost, modelsUsed, agents,
+--          modelBreakdowns } }
+--
+-- NULL means "submitted before this migration" (legacy row). The first id'd
+-- submission for an overlapping date replaces such a row (today's behavior);
+-- once each machine has re-submitted, distinct machines sum. Apply BEFORE
+-- deploying the matching app code.
+
+ALTER TABLE daily_breakdowns
+  ADD COLUMN IF NOT EXISTS machine_contributions JSONB;

--- a/test/ccusage.test.mts
+++ b/test/ccusage.test.mts
@@ -7,7 +7,7 @@
 import { readFileSync } from "node:fs";
 // Dynamic import: Node's native .ts loader reparses as ESM at runtime, so a
 // static `import {…} from "….ts"` fails name resolution; dynamic import works.
-const { normalizeCcData, validateCcData } = await import("../src/lib/ccusage.ts");
+const { normalizeCcData, validateCcData, mergeMachineContribution } = await import("../src/lib/ccusage.ts");
 
 let passed = 0;
 let failed = 0;
@@ -258,6 +258,42 @@ console.log("\n[7] Real cc.json (your machine, if present)");
   } else {
     console.log("  (no path arg given, skipping)");
   }
+}
+
+// ---------------------------------------------------------------------------
+console.log("\n[8] Per-machine daily merge (#43)");
+{
+  const contrib = (cost: number, models: string[] = ["claude-opus-4-8"], agents: string[] = ["claude"]) => ({
+    inputTokens: cost * 100,
+    outputTokens: cost * 10,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: cost * 110,
+    totalCost: cost,
+    modelsUsed: models,
+    agents,
+  });
+
+  // Two distinct machines on the same day -> SUM.
+  const m1 = mergeMachineContribution(null, "machineA", contrib(15));
+  const m2 = mergeMachineContribution(m1.contributions, "machineB", contrib(10));
+  ok("distinct machines sum cost ($15+$10=$25)", m2.aggregate.totalCost === 25, `got ${m2.aggregate.totalCost}`);
+  ok("distinct machines sum tokens", m2.aggregate.totalTokens === 110 * 25, `got ${m2.aggregate.totalTokens}`);
+  ok("both machines tracked", Object.keys(m2.contributions).sort().join(",") === "machineA,machineB");
+
+  // Same machine re-submits (ccusage is authoritative) -> REPLACE its slice, no double-count.
+  const m3 = mergeMachineContribution(m2.contributions, "machineA", contrib(20));
+  ok("same-machine re-submit replaces ($20+$10=$30, not $45)", m3.aggregate.totalCost === 30, `got ${m3.aggregate.totalCost}`);
+
+  // Legacy row (null contributions) -> first id'd submission starts fresh.
+  const legacy = mergeMachineContribution(null, "machineA", contrib(12));
+  ok("legacy null starts at incoming ($12)", legacy.aggregate.totalCost === 12, `got ${legacy.aggregate.totalCost}`);
+
+  // Models/agents unioned across machines.
+  const u1 = mergeMachineContribution(null, "machineA", contrib(5, ["claude-opus-4-8"], ["claude"]));
+  const u2 = mergeMachineContribution(u1.contributions, "machineB", contrib(5, ["gpt-5-codex"], ["codex"]));
+  ok("agents unioned across machines", u2.aggregate.agents.sort().join(",") === "claude,codex");
+  ok("models unioned across machines", u2.aggregate.modelsUsed.sort().join(",") === "claude-opus-4-8,gpt-5-codex");
 }
 
 console.log(`\n${failed === 0 ? "✅" : "❌"} ${passed} passed, ${failed} failed\n`);


### PR DESCRIPTION
Fixes #43.

## Problem

Submitting `cc.json` from **multiple machines** under one account **overwrites** daily data on overlapping dates instead of summing. The root constraint (per the issue thread): `ccusage` exposes no machine identifier, so the server can't distinguish *"different machine, same day"* (should sum) from *"re-submit, same day"* (should replace) — and naive summing would double-count same-machine re-submits.

## Approach — stable machine id + per-machine daily slices

This implements the path the issue settled on (`X-Machine-Id`, key daily data by machine) **without** breaking the display layer.

- **CLI** (`packages/viberank-cli/cli.js`, `submit-to-viberank.sh`) generates a stable, anonymous random-UUID machine id, persists it at `~/.viberank/machine-id`, and sends it as `X-Machine-Id`. No hardware or identifying info.
- **Server** (`api/submit`) reads the optional header and threads it to the data layer.
- **Storage** (migration `005`) adds `daily_breakdowns.machine_contributions JSONB` — each machine's slice of a day keyed by id. The existing **aggregate columns stay the sum across machines**, so every chart/heatmap/leaderboard query is untouched (no multiple-rows-per-date).
- **Merge rule** (pure, unit-tested `mergeMachineContribution` in `src/lib/ccusage.ts`):
  - day from a **new machine** → adds a slice → **sums**
  - **re-submit from same machine** → replaces only its slice → **no double-count**

## Backward compatibility

- Web uploads and older CLIs send no header → shared `"default"` bucket → **identical to today's behavior**.
- Legacy rows (`machine_contributions IS NULL`) are replaced by the first id'd submission (today's overwrite) and **self-heal** once each machine re-submits — no leaderboard inflation, no permanent loss.

## Migration

`supabase/migrations/005_machine_contributions.sql` — additive nullable column, apply **before** deploying the app code (same convention as `004`).

## Tests

`npm test` — added section **[8]** covering distinct-machines-sum, same-machine-replace (no double-count), legacy-null bootstrap, and model/agent union. All 26 pass.

## Note

Server accepts the header from any CLI version immediately; the summing benefit kicks in once users are on a CLI that sends the id. A short release note ("update the CLI and re-submit from each machine") would help multi-machine users converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)