### PR TITLE
fix: map 'timed out' race rejection to 504 instead of generic 500

### DIFF
--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -295,8 +295,14 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // Check for timeout or database-specific errors
-      if (error.message.includes("timeout") || error.message.includes("deadline")) {
+      // Check for timeout or database-specific errors. The 25s race above
+      // rejects with "Database operation timed out" — match that spelling too,
+      // or large-history merges surface as the generic 500 instead of a 504.
+      if (
+        error.message.includes("timeout") ||
+        error.message.includes("timed out") ||
+        error.message.includes("deadline")
+      ) {
         return NextResponse.json(
           { error: "Request timed out. Please try again or submit smaller batches of data." },
           { status: 504 }


### PR DESCRIPTION
## What

The submit route's own 25s timeout race rejects with the message `"Database operation timed out"`, but the error mapping below only checks for the substrings `"timeout"` and `"deadline"` — `"timed out"` (with a space) matches neither. So when a large-history merge blows the 25s window, the client gets the generic catch-all **500 "Failed to submit data. Please check your cc.json file format..."** instead of the intended **504 "Request timed out. Please try again or submit smaller batches of data."**

That message difference matters: the 500 sends users down a payload-format rabbit hole, while the 504 tells them the actual fix (smaller batches).

## How I hit this

My account (`eprouveze`) has a ~188-day history. Since the #43/#79 per-machine merge deploy, `mergeWithExisting` runs one sequential `daily_breakdowns` round-trip per incoming day, so a full-history re-submit merging into an existing ~180-day record can exceed the 25s race. Every attempt returned the generic 500 with a payload that field-diffs identical to my last accepted submission (June 10, pre-deploy) — I only found the real cause by reading this route's source. Splitting the same data into ≤60-day chunks submits fine.

## Notes

- Fix is intentionally minimal: add `"timed out"` to the existing substring check (plus a comment tying it to the race above).
- Possible follow-up (not in this PR): batching the per-day loop in `mergeWithExisting` (e.g. a single upsert on `(submission_id, date)`) would remove the timeout for long-history users entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CprMNM6BjWgqLGcmCjZVZJ