### PR TITLE
fix: stop default bucket double-counting against machine-id'd slices (#81)

### DIFF
--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -120,6 +120,15 @@ function mergeModelBreakdowns(
 // re-submission from the same machine replaces only its own slice. The daily
 // row keeps aggregate (summed) fields for display — the per-machine map is
 // bookkeeping the merge needs and the UI never reads.
+//
+// The "default" bucket (no X-Machine-Id: web uploads, pre-1.2 CLIs) is NOT a
+// machine — it is unattributable data that in practice comes from the same
+// machine that later submits with an id. Summing it against a UUID slice
+// double-counts the same history (#81), so it never coexists with id'd
+// slices: an id'd submission drops the default slice for the days it covers,
+// and a no-id submission replaces the whole day (pre-#43 overwrite
+// semantics). Cross-machine summing therefore only happens between id'd
+// slices, where attribution is sound.
 
 /** One machine's contribution to a single day. */
 export interface MachineContribution {
@@ -187,20 +196,24 @@ function aggregateContributions(
  * recompute the day's aggregate. Pure so it can be unit-tested.
  *
  * @param existing prior per-machine map, or null for a legacy row that predates
- *   per-machine tracking. A legacy row's aggregate is *not* preserved: we can't
- *   attribute it to a machine, so the first id'd submission replaces it (today's
- *   overwrite behavior). Once a machine re-submits, distinct machines sum and
- *   the day self-heals.
+ *   per-machine tracking. Unattributable data (legacy null rows and the
+ *   "default" slice) is never preserved alongside id'd slices: we can't know
+ *   which machine it came from, and assuming "a different one" double-counts
+ *   single-machine users (#81). It is replaced instead.
  */
 export function mergeMachineContribution(
   existing: Record<string, MachineContribution> | null | undefined,
   machineId: string,
   incoming: MachineContribution
 ): { contributions: Record<string, MachineContribution>; aggregate: DailyAggregate } {
-  const contributions: Record<string, MachineContribution> = {
-    ...(existing ?? {}),
-    [machineId]: incoming,
-  };
+  let contributions: Record<string, MachineContribution>;
+  if (machineId === DEFAULT_MACHINE_ID) {
+    // No-id submission: unattributable, so it owns the whole day.
+    contributions = { [DEFAULT_MACHINE_ID]: incoming };
+  } else {
+    const { [DEFAULT_MACHINE_ID]: _unattributed, ...idSlices } = existing ?? {};
+    contributions = { ...idSlices, [machineId]: incoming };
+  }
   return { contributions, aggregate: aggregateContributions(contributions) };
 }
 

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -226,7 +226,8 @@ class SupabaseSubmissionsService implements SubmissionsService {
 
     // Identify the contributing machine so overlapping dates from distinct
     // machines sum while a same-machine re-submit replaces only its slice (#43).
-    // Web uploads / older CLIs send no id and share the "default" bucket.
+    // Web uploads / older CLIs send no id ("default"): unattributable, so
+    // they replace the whole day rather than sum against id'd slices (#81).
     const machineId = data.machineId || DEFAULT_MACHINE_ID;
 
     let submissionId: string;

--- a/test/ccusage.test.mts
+++ b/test/ccusage.test.mts
@@ -343,5 +343,41 @@ console.log("\n[8] Per-machine daily merge (#43)");
   ok("models unioned across machines", u2.aggregate.modelsUsed.sort().join(",") === "claude-opus-4-8,gpt-5-codex");
 }
 
+// ---------------------------------------------------------------------------
+console.log("\n[9] Default bucket never sums against id'd slices (#81)");
+{
+  const contrib = (cost: number) => ({
+    inputTokens: cost * 100,
+    outputTokens: cost * 10,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: cost * 110,
+    totalCost: cost,
+    modelsUsed: ["claude-opus-4-8"],
+    agents: ["claude"],
+  });
+
+  // The #81 doubling: no-id submission filled "default", then the same machine
+  // re-submits with an id. The id'd slice must REPLACE default, not add to it.
+  const d1 = mergeMachineContribution(null, "default", contrib(15));
+  const d2 = mergeMachineContribution(d1.contributions, "machineA", contrib(15));
+  ok("id'd submission drops default slice ($15, not $30)", d2.aggregate.totalCost === 15, `got ${d2.aggregate.totalCost}`);
+  ok("default slice removed from map", Object.keys(d2.contributions).join(",") === "machineA");
+
+  // Id'd slices survive an id'd submission from another machine.
+  const d3 = mergeMachineContribution(d2.contributions, "machineB", contrib(10));
+  ok("distinct id'd machines still sum ($15+$10=$25)", d3.aggregate.totalCost === 25, `got ${d3.aggregate.totalCost}`);
+
+  // A no-id submission is unattributable: it owns the whole day (pre-#43
+  // overwrite), never sums against id'd slices it may itself contain.
+  const d4 = mergeMachineContribution(d3.contributions, "default", contrib(30));
+  ok("no-id submission replaces whole day ($30, not $55)", d4.aggregate.totalCost === 30, `got ${d4.aggregate.totalCost}`);
+  ok("only default slice remains", Object.keys(d4.contributions).join(",") === "default");
+
+  // No-id re-submit over default-only day: plain replace, unchanged behavior.
+  const d5 = mergeMachineContribution(d4.contributions, "default", contrib(12));
+  ok("no-id re-submit replaces default ($12)", d5.aggregate.totalCost === 12, `got ${d5.aggregate.totalCost}`);
+}
+
 console.log(`\n${failed === 0 ? "✅" : "❌"} ${passed} passed, ${failed} failed\n`);
 process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Problem

#81 — a user's total jumped $73k → ~$154k overnight. Root cause is in the #43 multi-machine merge (#79): the `"default"` bucket (submissions with no `X-Machine-Id` — web uploads, pre-1.2 CLIs) was treated as a *distinct machine*. In practice it's the **same machine** that later submits with an id. Since ccusage always sends full history, the first id'd submission after a no-id one added a UUID slice next to an identical `default` slice on every day → history doubled, and later no-id submissions only refreshed the `default` slice, so it never self-healed.

Verified in prod: 7 submissions affected, ~$150k of phantom spend, with per-day `default`/UUID cost ratios of exactly **1.000** (same data twice — not legitimate multi-machine usage):

| User | Stored total | Repaired total |
|---|---|---|
| StartupBros | $154,020 | $87,765 |
| eprouveze | $56,134 | $28,726 |
| charlie23 | $53,295 | $27,698 |
| cypres0099 | $36,095 | $18,964 |
| mike-tan-coder | $24,212 | $13,843 |
| kenshin579 | $11,692 | $9,281 |
| Zhan-boyi | $3,662 | $1,880 |

## Fix

Unattributable data never coexists with id'd slices in `mergeMachineContribution`:

- An **id'd** submission drops the `default` slice for the days it covers (same rule as legacy `NULL` rows).
- A **no-id** submission replaces the whole day (pre-#43 overwrite semantics).
- Summing only happens between distinct machine UUIDs, where attribution is sound.

Multi-machine users keep working as designed as long as every machine uses CLI ≥ 1.2 — which is the only regime where per-machine attribution exists at all.

## Data repair

One-off idempotent script (`scripts/repair-default-machine-doubling.mts`, untracked per the `scripts/` gitignore convention) reuses the fixed `mergeMachineContribution`: for each doubled day it keeps the **larger** side (`default` vs UUID slices — same-machine ccusage day totals only grow, so larger = fresher; this correctly handles days like StartupBros 2026-07-01 where a stale $5.74 UUID snapshot sat next to a complete $693.53 default slice), then recomputes submission totals from daily rows. Dry-run by default, `--apply` to write.

⚠️ Repair should be re-run once after this deploys — until then, a mixed-path submission can re-introduce a doubled day (script is idempotent, safe to re-run).

## Tests

`pnpm test` — 34 passed, including new section [9] covering: id'd drops default, distinct UUIDs still sum, no-id replaces whole day, no-id re-submit unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)