### PR TITLE
feat: profile heatmap + streaks, /stats page, raw payload archive, OG caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts"
+    "test": "node test/ccusage.test.mts && node test/streaks.test.mts"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -35,13 +35,14 @@ function getFonts() {
 
 // Share card for profile pages: avatar, rank, tier, cost, tokens — in the
 // site's visual language (Geist, dark surface, tier-colored glow).
-async function profileCard(searchParams: URLSearchParams) {
+async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) {
   const username = searchParams.get('username') || 'developer';
   const avatar = searchParams.get('avatar');
   const cost = Number(searchParams.get('cost') || 0);
   const tokens = searchParams.get('tokens') || '';
   const rank = searchParams.get('rank');
   const days = searchParams.get('days');
+  const streak = searchParams.get('streak');
   const tools = (searchParams.get('tools') || '').split(',').filter(Boolean);
   const tier = getTier(cost);
   const costLabel =
@@ -193,10 +194,11 @@ async function profileCard(searchParams: URLSearchParams) {
 
           {/* stats + CTA */}
           <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
-            <div style={{ display: 'flex', gap: 72 }}>
+            <div style={{ display: 'flex', gap: streak ? 56 : 72 }}>
               {stat(costLabel, 'AI CODING USAGE', '#f97316')}
               {tokens ? stat(tokens, 'TOKENS', '#fafafa') : null}
               {days ? stat(days, 'ACTIVE DAYS', '#fafafa') : null}
+              {streak ? stat(`${streak}d`, 'STREAK', tier.color) : null}
             </div>
             <div
               style={{
@@ -228,7 +230,7 @@ async function profileCard(searchParams: URLSearchParams) {
         />
       </div>
     ),
-    { width: 1200, height: 630, fonts }
+    { width: 1200, height: 630, fonts, headers }
   );
 }
 
@@ -236,8 +238,17 @@ export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
 
+    // Versioned URLs carry a content fingerprint (`v`) that changes whenever
+    // the stats do, so the response itself can be cached as immutable — the
+    // CDN serves repeat crawler hits without re-rendering.
+    const cacheHeaders: HeadersInit = {
+      'Cache-Control': searchParams.has('v')
+        ? 'public, immutable, no-transform, max-age=31536000'
+        : 'public, max-age=3600, s-maxage=86400',
+    };
+
     if (searchParams.get('type') === 'profile') {
-      return profileCard(searchParams);
+      return profileCard(searchParams, cacheHeaders);
     }
 
     const title = searchParams.get('title') || 'Viberank';
@@ -331,6 +342,7 @@ export async function GET(request: Request) {
       {
         width: 1200,
         height: 630,
+        headers: cacheHeaders,
       },
     );
   } catch (e: unknown) {

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -37,7 +37,20 @@ function getFonts() {
 // site's visual language (Geist, dark surface, tier-colored glow).
 async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) {
   const username = searchParams.get('username') || 'developer';
-  const avatar = searchParams.get('avatar');
+  // This endpoint is an unauthenticated GET and Satori fetches the <img> src,
+  // so only allow GitHub-hosted avatars — anything else would let callers turn
+  // the edge function into an open image proxy.
+  const avatar = (() => {
+    try {
+      const u = new URL(searchParams.get('avatar') ?? '');
+      const ok =
+        u.protocol === 'https:' &&
+        (u.hostname === 'github.com' || u.hostname.endsWith('.githubusercontent.com'));
+      return ok ? u.toString() : null;
+    } catch {
+      return null;
+    }
+  })();
   const cost = Number(searchParams.get('cost') || 0);
   const tokens = searchParams.get('tokens') || '';
   const rank = searchParams.get('rank');

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { getServerDataLayer, getDatabaseBackend } from "@/lib/data";
 import { normalizeCcData } from "@/lib/ccusage";
+import { archiveRawSubmission } from "@/lib/data/supabase/rawArchive";
 import { getCliNotice } from "@/lib/sponsor";
 
 export async function POST(request: NextRequest) {
@@ -138,6 +139,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: message }, { status: 400 });
     }
 
+    // Keep the pre-normalization payload for the raw archive (006): once
+    // ccData is reassigned below, the original report shape is gone.
+    const rawPayload = ccData;
+
     // Hand the data layer the canonical shape from here on.
     ccData = {
       totals: normalized.totals,
@@ -184,6 +189,15 @@ export async function POST(request: NextRequest) {
       );
 
       submissionId = await Promise.race([submissionPromise, timeoutPromise]);
+
+      // Archive the original payload for future re-parse/backfill. Best
+      // effort — never blocks or fails an accepted submission.
+      await archiveRawSubmission(rawPayload, {
+        username: githubUsername,
+        source,
+        machineId,
+        cliVersion: cliVersion || undefined,
+      });
     } catch (dbError: any) {
       console.error("Database mutation error:", {
         message: dbError?.message,

--- a/src/app/profile/[username]/layout.tsx
+++ b/src/app/profile/[username]/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { computeStreaks } from "@/lib/streaks";
 import { getProfileCached } from "./getProfile";
 
 interface ProfileParams {
@@ -59,9 +60,11 @@ export async function generateMetadata({ params }: ProfileParams): Promise<Metad
       // rank is nice-to-have on the card; render without it on failure
     }
     const avatar = profile.submissions.find((s) => s.githubAvatar)?.githubAvatar;
-    const daysActive = new Set(
+    const activeDates = new Set(
       profile.submissions.flatMap((s) => (s.dailyBreakdown ?? []).map((d) => d.date))
-    ).size;
+    );
+    const daysActive = activeDates.size;
+    const { current: streak } = computeStreaks(activeDates);
     const ogParams = new URLSearchParams({
       type: "profile",
       username: profile.githubUsername || profile.username,
@@ -71,7 +74,12 @@ export async function generateMetadata({ params }: ProfileParams): Promise<Metad
     if (rank) ogParams.set("rank", String(rank));
     if (avatar) ogParams.set("avatar", avatar);
     if (daysActive > 0) ogParams.set("days", String(daysActive));
+    if (streak > 1) ogParams.set("streak", String(streak));
     if (tools.length > 0) ogParams.set("tools", tools.slice(0, 4).join(","));
+    // Content fingerprint: the URL changes whenever the underlying stats do,
+    // so the OG route can serve versioned responses as immutable and crawlers
+    // still pick up fresh cards after each submission.
+    ogParams.set("v", `${Math.round(totalCost)}-${daysActive}-${rank ?? 0}`);
     const ogImage = `/api/og?${ogParams.toString()}`;
 
     return {

--- a/src/app/profile/[username]/layout.tsx
+++ b/src/app/profile/[username]/layout.tsx
@@ -165,7 +165,9 @@ export default async function ProfileLayout({
     <>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        // GitHub display names are attacker-controlled free text; a literal
+        // "</script>" inside would break out of this tag, so escape "<".
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c") }}
       />
       {children}
     </>

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -11,12 +11,17 @@ import {
   Trophy,
   Cpu,
   Wrench,
+  Flame,
+  Award,
+  BarChart3,
 } from "lucide-react";
-import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl } from "@/lib/utils";
+import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl, prettyModelName } from "@/lib/utils";
 import { getTierProgress } from "@/lib/tiers";
+import { computeStreaks } from "@/lib/streaks";
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "./getProfile";
 import UsageChart from "./UsageChartLazy";
+import ActivityHeatmap from "@/components/ActivityHeatmap";
 import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
 import TierBadge from "@/components/TierBadge";
@@ -75,6 +80,38 @@ export default async function ProfilePage({ params }: ProfileParams) {
   }, {} as Record<string, { date: string; cost: number; tokens: number }>);
   const dailySeries = Object.values(dailyMap);
 
+  // Streaks over days that actually have usage recorded.
+  const streaks = computeStreaks(Object.keys(dailyMap));
+
+  // Spend by weekday (Monday-first) and by calendar month, for the rhythm
+  // charts. Weekday comes from the date string itself (UTC, matching how
+  // ccusage buckets days).
+  const weekdayCost = new Array(7).fill(0) as number[];
+  const monthlyCost = new Map<string, number>();
+  for (const d of dailySeries) {
+    weekdayCost[new Date(`${d.date}T00:00:00Z`).getUTCDay()] += d.cost;
+    const month = d.date.slice(0, 7);
+    monthlyCost.set(month, (monthlyCost.get(month) ?? 0) + d.cost);
+  }
+  const WEEKDAYS = [
+    { label: "Mon", idx: 1 },
+    { label: "Tue", idx: 2 },
+    { label: "Wed", idx: 3 },
+    { label: "Thu", idx: 4 },
+    { label: "Fri", idx: 5 },
+    { label: "Sat", idx: 6 },
+    { label: "Sun", idx: 0 },
+  ];
+  const maxWeekdayCost = Math.max(...weekdayCost, 1);
+  const monthEntries = Array.from(monthlyCost.entries())
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .slice(-12);
+  const maxMonthCost = Math.max(...monthEntries.map(([, c]) => c), 1);
+  const monthLabel = (ym: string) => {
+    const [y, m] = ym.split("-").map(Number);
+    return `${["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][m - 1]} '${String(y).slice(2)}`;
+  };
+
   // Tools used across the profile (Claude sorts first).
   const tools = Array.from(new Set(submissions.flatMap((s) => s.tools ?? []))).sort();
 
@@ -126,12 +163,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
     return true;
   });
 
-  const prettyModel = (raw: string) => {
-    let m = raw.replace(/^\[[^\]]+\]\s*/, ""); // "[openclaw] x/y" → "x/y"
-    m = m.split("/").pop() ?? m; // drop provider path
-    m = m.replace(/-\d{8}$/, ""); // drop date suffix
-    return m;
-  };
+  const prettyModel = prettyModelName;
 
   const modelCost = new Map<string, number>();
   const modelDays = new Map<string, number>();
@@ -238,7 +270,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
           </div>
 
           {/* Key stats */}
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
             <div className="bg-surface-1 border border-border rounded-lg p-4">
               <p className="flex items-center gap-1.5 micro-label mb-1"><DollarSign className="w-3.5 h-3.5" />Total spent</p>
               <p className="text-xl font-bold font-mono text-accent">${formatNumber(totalCost)}</p>
@@ -258,6 +290,16 @@ export default async function ProfilePage({ params }: ProfileParams) {
               <p className="flex items-center gap-1.5 micro-label mb-1"><Trophy className="w-3.5 h-3.5" />Global rank</p>
               <p className="text-xl font-bold">{globalRank ? `#${globalRank}` : "—"}</p>
               <p className="text-xs text-muted mt-1 truncate">{tools.length ? `${tools.map(toolLabel).slice(0, 2).join(", ")}${tools.length > 2 ? " +" + (tools.length - 2) : ""}` : "by cost"}</p>
+            </div>
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1"><Flame className="w-3.5 h-3.5" />Streak</p>
+              <p className="text-xl font-bold font-mono">{streaks.current}<span className="text-sm text-muted font-sans">d</span></p>
+              <p className="text-xs text-muted mt-1">{streaks.current > 0 ? "active now" : "start one today"}</p>
+            </div>
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1"><Award className="w-3.5 h-3.5" />Longest streak</p>
+              <p className="text-xl font-bold font-mono">{streaks.longest}<span className="text-sm text-muted font-sans">d</span></p>
+              <p className="text-xs text-muted mt-1">consecutive days</p>
             </div>
           </div>
 
@@ -297,6 +339,15 @@ export default async function ProfilePage({ params }: ProfileParams) {
 
         {/* Usage chart (client island) */}
         <UsageChart daily={dailySeries} />
+
+        {/* Activity heatmap */}
+        <div className="bg-surface-1 border border-border rounded-lg p-5 mb-4">
+          <h2 className="text-base font-medium mb-4 flex items-center gap-2">
+            <CalendarDays className="w-4 h-4 text-accent" />
+            Activity
+          </h2>
+          <ActivityHeatmap daily={dailySeries} />
+        </div>
 
         {/* Token breakdown + insights */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
@@ -351,6 +402,58 @@ export default async function ProfilePage({ params }: ProfileParams) {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Rhythm: weekday + monthly spend */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-4">
+          <div className="bg-surface-1 border border-border rounded-lg p-5">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-base font-medium flex items-center gap-2">
+                <BarChart3 className="w-4 h-4 text-accent" />
+                Most active days
+              </h2>
+              <span className="micro-label">by spend</span>
+            </div>
+            <div className="space-y-2.5">
+              {WEEKDAYS.map(({ label, idx }) => (
+                <div key={label} className="flex items-center gap-3">
+                  <span className="w-8 text-xs text-muted font-mono">{label}</span>
+                  <div className="flex-1 bg-surface-3 rounded-full h-1.5">
+                    <div
+                      className="bg-accent h-1.5 rounded-full"
+                      style={{ width: `${Math.max((weekdayCost[idx] / maxWeekdayCost) * 100, weekdayCost[idx] > 0 ? 1 : 0)}%` }}
+                    />
+                  </div>
+                  <span className="w-16 text-right font-mono text-xs text-muted">${formatCurrency(weekdayCost[idx])}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {monthEntries.length > 0 && (
+            <div className="bg-surface-1 border border-border rounded-lg p-5">
+              <div className="flex items-center justify-between mb-4">
+                <h2 className="text-base font-medium flex items-center gap-2">
+                  <Calendar className="w-4 h-4 text-accent" />
+                  Monthly spend
+                </h2>
+                <span className="micro-label">last {monthEntries.length} months</span>
+              </div>
+              <div className="flex items-end gap-2 h-32">
+                {monthEntries.map(([month, cost]) => (
+                  <div key={month} className="flex-1 flex flex-col items-center gap-1.5 min-w-0" title={`${monthLabel(month)}: $${formatCurrency(cost)}`}>
+                    <div className="w-full flex-1 flex items-end">
+                      <div
+                        className="w-full bg-accent/80 rounded-t-sm"
+                        style={{ height: `${Math.max((cost / maxMonthCost) * 100, 2)}%` }}
+                      />
+                    </div>
+                    <span className="text-[9px] font-mono text-muted/70 truncate">{monthLabel(month)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Model + tool breakdown */}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -80,15 +80,27 @@ export default async function ProfilePage({ params }: ProfileParams) {
   }, {} as Record<string, { date: string; cost: number; tokens: number }>);
   const dailySeries = Object.values(dailyMap);
 
+  // Dates can repeat across un-merged submissions (e.g. an unclaimed cli row
+  // next to an oauth row), so per-day dollar figures must come from deduped
+  // days — prefer the newest submission's row, matching how merge overwrites
+  // days. The heatmap, streaks and rhythm charts all read from this.
+  const seenDates = new Set<string>();
+  const uniqueDaily = allDaily.filter((d) => {
+    if (seenDates.has(d.date)) return false;
+    seenDates.add(d.date);
+    return true;
+  });
+  const dedupedSeries = uniqueDaily.map((d) => ({ date: d.date, cost: d.totalCost }));
+
   // Streaks over days that actually have usage recorded.
-  const streaks = computeStreaks(Object.keys(dailyMap));
+  const streaks = computeStreaks(uniqueDaily.map((d) => d.date));
 
   // Spend by weekday (Monday-first) and by calendar month, for the rhythm
   // charts. Weekday comes from the date string itself (UTC, matching how
   // ccusage buckets days).
   const weekdayCost = new Array(7).fill(0) as number[];
   const monthlyCost = new Map<string, number>();
-  for (const d of dailySeries) {
+  for (const d of dedupedSeries) {
     weekdayCost[new Date(`${d.date}T00:00:00Z`).getUTCDay()] += d.cost;
     const month = d.date.slice(0, 7);
     monthlyCost.set(month, (monthlyCost.get(month) ?? 0) + d.cost);
@@ -152,17 +164,8 @@ export default async function ProfilePage({ params }: ProfileParams) {
     { label: "Cache creation", value: tokenAgg.cacheCreation, color: "bg-purple-500" },
   ];
 
-  // Per-model aggregation. Cost splits exist on rows ingested after migration
-  // 004; older rows fall back to "days used". Dates can repeat across
-  // submissions, so dedupe per date first (prefer the newest submission's row,
-  // matching how merge overwrites days).
-  const seenDates = new Set<string>();
-  const uniqueDaily = allDaily.filter((d) => {
-    if (seenDates.has(d.date)) return false;
-    seenDates.add(d.date);
-    return true;
-  });
-
+  // Per-model aggregation over the deduped days. Cost splits exist on rows
+  // ingested after migration 004; older rows fall back to "days used".
   const prettyModel = prettyModelName;
 
   const modelCost = new Map<string, number>();
@@ -346,7 +349,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
             <CalendarDays className="w-4 h-4 text-accent" />
             Activity
           </h2>
-          <ActivityHeatmap daily={dailySeries} />
+          <ActivityHeatmap daily={dedupedSeries} />
         </div>
 
         {/* Token breakdown + insights */}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,6 +15,7 @@ const staticEntries: MetadataRoute.Sitemap = [
   { url: SITE, lastModified: new Date(), changeFrequency: "daily", priority: 1 },
   ...toolEntries,
   { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+  { url: `${SITE}/stats`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
   { url: `${SITE}/blog/state-of-ai-coding-2026`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
   { url: `${SITE}/blog/codex-vs-claude-code-vs-gemini-cli`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -105,11 +105,15 @@ export default async function StatsPage() {
   // the max as a lower bound instead of overcounting.
   const modelUsers = new Map<string, number>();
   for (const { model, users } of site?.models ?? []) {
+    // models_used elements aren't type-checked at ingest; skip junk instead
+    // of crashing the ISR render on a null.
+    if (typeof model !== "string" || !model) continue;
     const name = prettyModelName(model);
     modelUsers.set(name, Math.max(modelUsers.get(name) ?? 0, users));
   }
   const modelSpend = new Map<string, number>();
   for (const { model, cost } of site?.modelSpend ?? []) {
+    if (typeof model !== "string" || !model) continue;
     const name = prettyModelName(model);
     modelSpend.set(name, (modelSpend.get(name) ?? 0) + Number(cost));
   }

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,264 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, BarChart3, Cpu, DollarSign, Users, Wrench, Zap, CalendarDays, Database } from "lucide-react";
+import { formatNumber, formatCurrency, toolLabel, prettyModelName } from "@/lib/utils";
+import { getServerDataLayer } from "@/lib/data";
+import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
+
+// Full-table aggregates are computed in-database (get_site_stats, migration
+// 007); the hourly ISR window keeps those scans rare.
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "AI Coding Usage Stats | Viberank",
+  description:
+    "Site-wide AI coding usage: total spend, tokens burned, cache hit share, and the most used models across Claude Code, Codex, Gemini CLI and more.",
+  alternates: { canonical: "https://www.viberank.app/stats" },
+  openGraph: {
+    title: "AI Coding Usage Stats | Viberank",
+    description:
+      "Total spend, tokens burned, and the most used models across every coding agent tracked on Viberank.",
+    url: "https://www.viberank.app/stats",
+    siteName: "Viberank",
+  },
+};
+
+function StatTile({
+  icon,
+  label,
+  value,
+  sub,
+  accent = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+  accent?: boolean;
+}) {
+  return (
+    <div className="bg-surface-1 border border-border rounded-lg p-4">
+      <p className="flex items-center gap-1.5 micro-label mb-1">
+        {icon}
+        {label}
+      </p>
+      <p className={`text-xl font-bold font-mono ${accent ? "text-accent" : ""}`}>{value}</p>
+      {sub && <p className="text-xs text-muted mt-1">{sub}</p>}
+    </div>
+  );
+}
+
+function BarList({
+  rows,
+  format,
+  barClass = "bg-accent",
+}: {
+  rows: { label: string; value: number }[];
+  format: (value: number) => string;
+  barClass?: string;
+}) {
+  const max = Math.max(...rows.map((r) => r.value), 1);
+  return (
+    <div className="space-y-3">
+      {rows.map(({ label, value }) => (
+        <div key={label}>
+          <div className="flex justify-between items-center mb-1.5 gap-2">
+            <span className="text-xs font-mono truncate">{label}</span>
+            <span className="font-mono text-xs text-muted flex-shrink-0">{format(value)}</span>
+          </div>
+          <div className="w-full bg-surface-3 rounded-full h-1.5">
+            <div className={`${barClass} h-1.5 rounded-full`} style={{ width: `${Math.max((value / max) * 100, 1)}%` }} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default async function StatsPage() {
+  const dataLayer = await getServerDataLayer();
+  const [site, global] = await Promise.all([
+    dataLayer.stats.getSiteStats().catch(() => null),
+    dataLayer.stats.getGlobalStats().catch(() => null),
+  ]);
+
+  const totalUsers = site?.totalUsers ?? global?.totalUsers ?? 0;
+  const totalSubmissions = site?.totalSubmissions ?? global?.totalSubmissions ?? 0;
+  const totalCost = site?.totalCost ?? global?.totalCost ?? 0;
+  const totalTokens = site?.totalTokens ?? global?.totalTokens ?? 0;
+  const exact = site !== null;
+
+  const cacheShare = site && site.totalTokens > 0 ? site.cacheReadTokens / site.totalTokens : null;
+
+  const tokenRows = site
+    ? [
+        { label: "Input", value: site.inputTokens, color: "bg-accent" },
+        { label: "Output", value: site.outputTokens, color: "bg-blue-500" },
+        { label: "Cache read", value: site.cacheReadTokens, color: "bg-emerald-500" },
+        { label: "Cache creation", value: site.cacheCreationTokens, color: "bg-purple-500" },
+      ]
+    : [];
+
+  // Raw model ids collapse to the same pretty name ("claude-sonnet-4-2025…"
+  // variants etc.). Spend sums correctly; distinct-user counts don't, so keep
+  // the max as a lower bound instead of overcounting.
+  const modelUsers = new Map<string, number>();
+  for (const { model, users } of site?.models ?? []) {
+    const name = prettyModelName(model);
+    modelUsers.set(name, Math.max(modelUsers.get(name) ?? 0, users));
+  }
+  const modelSpend = new Map<string, number>();
+  for (const { model, cost } of site?.modelSpend ?? []) {
+    const name = prettyModelName(model);
+    modelSpend.set(name, (modelSpend.get(name) ?? 0) + Number(cost));
+  }
+  const topModelUsers = Array.from(modelUsers.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  const topModelSpend = Array.from(modelSpend.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+  const toolRows = (site?.tools ?? []).slice(0, 10);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+
+      <div className="max-w-6xl mx-auto px-6 py-8">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
+        <div className="mb-8">
+          <p className="micro-label mb-3">Site-wide telemetry</p>
+          <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight">
+            The state of the board<span className="cursor-block" aria-hidden />
+          </h1>
+          <p className="text-muted text-base mt-3 max-w-2xl">
+            Aggregate AI coding usage across every developer on Viberank — Claude Code, OpenAI Codex,
+            Gemini CLI, Copilot and every agent ccusage tracks.
+            {site?.firstDate && site?.lastDate && (
+              <> Tracking {site.firstDate} → {site.lastDate}.</>
+            )}
+          </p>
+          {!exact && (
+            <p className="text-xs text-muted/70 mt-2">
+              Showing approximate totals (based on top {global?.basedOnTop ?? 500} submissions).
+            </p>
+          )}
+        </div>
+
+        {/* Headline tiles */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-4">
+          <StatTile icon={<DollarSign className="w-3.5 h-3.5" />} label="Total spend" value={`$${formatNumber(totalCost)}`} accent sub="API-equivalent" />
+          <StatTile icon={<Zap className="w-3.5 h-3.5" />} label="Tokens" value={formatNumber(totalTokens)} sub="all time" />
+          <StatTile icon={<Users className="w-3.5 h-3.5" />} label="Developers" value={formatNumber(totalUsers)} sub="on the board" />
+          <StatTile icon={<Database className="w-3.5 h-3.5" />} label="Submissions" value={formatNumber(totalSubmissions)} sub="tracked" />
+          {site && (
+            <StatTile icon={<CalendarDays className="w-3.5 h-3.5" />} label="Active days" value={formatNumber(site.activeDays)} sub="distinct dates" />
+          )}
+          {cacheShare !== null && (
+            <StatTile
+              icon={<BarChart3 className="w-3.5 h-3.5" />}
+              label="Cache read"
+              value={`${Math.round(cacheShare * 100)}%`}
+              sub="of all tokens"
+            />
+          )}
+        </div>
+
+        {/* Token split */}
+        {site && (
+          <div className="bg-surface-1 border border-border rounded-lg p-5 mb-4">
+            <h2 className="text-base font-medium mb-4 flex items-center gap-2">
+              <Zap className="w-4 h-4 text-accent" />
+              Token breakdown
+            </h2>
+            <div className="space-y-3">
+              {tokenRows.map((row) => (
+                <div key={row.label}>
+                  <div className="flex justify-between items-center mb-1.5">
+                    <span className="text-xs text-muted">{row.label}</span>
+                    <span className="font-mono text-xs">
+                      {formatNumber(row.value)}
+                      <span className="text-muted/60"> · {site.totalTokens > 0 ? Math.round((row.value / site.totalTokens) * 100) : 0}%</span>
+                    </span>
+                  </div>
+                  <div className="w-full bg-surface-3 rounded-full h-1.5">
+                    <div
+                      className={`${row.color} h-1.5 rounded-full`}
+                      style={{ width: `${site.totalTokens > 0 ? (row.value / site.totalTokens) * 100 : 0}%` }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+            {cacheShare !== null && cacheShare > 0.3 && (
+              <p className="text-[11px] text-muted/70 mt-3">
+                {Math.round(cacheShare * 100)}% of all tokens are cache reads — prompt caching is doing
+                most of the heavy lifting.
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Models + tools */}
+        {(topModelUsers.length > 0 || topModelSpend.length > 0 || toolRows.length > 0) && (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+            {topModelUsers.length > 0 && (
+              <div className="bg-surface-1 border border-border rounded-lg p-5">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-base font-medium flex items-center gap-2">
+                    <Cpu className="w-4 h-4 text-accent" />
+                    Popular models
+                  </h2>
+                  <span className="micro-label">by users</span>
+                </div>
+                <BarList rows={topModelUsers.map(([label, value]) => ({ label, value }))} format={(v) => `${formatNumber(v)} devs`} />
+              </div>
+            )}
+
+            {topModelSpend.length > 0 && (
+              <div className="bg-surface-1 border border-border rounded-lg p-5">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-base font-medium flex items-center gap-2">
+                    <DollarSign className="w-4 h-4 text-accent" />
+                    Top models
+                  </h2>
+                  <span className="micro-label">by spend</span>
+                </div>
+                <BarList rows={topModelSpend.map(([label, value]) => ({ label, value }))} format={(v) => `$${formatNumber(v)}`} />
+              </div>
+            )}
+
+            {toolRows.length > 0 && (
+              <div className="bg-surface-1 border border-border rounded-lg p-5">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-base font-medium flex items-center gap-2">
+                    <Wrench className="w-4 h-4 text-accent" />
+                    Tools
+                  </h2>
+                  <span className="micro-label">by users</span>
+                </div>
+                <BarList
+                  rows={toolRows.map((t) => ({ label: toolLabel(t.tool), value: t.users }))}
+                  format={(v) => `${formatNumber(v)} devs`}
+                  barClass="bg-blue-500"
+                />
+              </div>
+            )}
+          </div>
+        )}
+
+        <p className="text-xs text-muted/70 mt-6">
+          Updated hourly. Spend is the API-equivalent cost reported by ccusage — most developers pay
+          far less on subscription plans. Want on the board?{" "}
+          <code className="font-mono text-accent">npx viberank-cli</code>
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -1,0 +1,130 @@
+import { formatCurrency } from "@/lib/utils";
+
+interface ActivityHeatmapProps {
+  /** Per-date spend, one entry per active day (YYYY-MM-DD). */
+  daily: { date: string; cost: number }[];
+}
+
+const DAY_MS = 86_400_000;
+const WEEKDAY_LABELS = ["", "Mon", "", "Wed", "", "Fri", ""];
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+// Opacity steps must be literal class names so Tailwind emits them.
+const LEVEL_CLASSES = ["bg-surface-3", "bg-accent/25", "bg-accent/45", "bg-accent/70", "bg-accent"];
+
+function toUtc(date: string): number {
+  const [y, m, d] = date.split("-").map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+function toIso(utc: number): string {
+  return new Date(utc).toISOString().slice(0, 10);
+}
+
+/**
+ * GitHub-style contribution calendar of the trailing year's daily spend.
+ * Server-rendered: plain divs with native title tooltips, no client JS.
+ */
+export default function ActivityHeatmap({ daily }: ActivityHeatmapProps) {
+  const costByDate = new Map(daily.map((d) => [d.date, d.cost]));
+
+  const todayUtc = toUtc(new Date().toISOString().slice(0, 10));
+  // Start on the Sunday on/before one year ago so columns are whole weeks.
+  const yearAgo = todayUtc - 364 * DAY_MS;
+  const startUtc = yearAgo - new Date(yearAgo).getUTCDay() * DAY_MS;
+  const totalDays = Math.round((todayUtc - startUtc) / DAY_MS) + 1;
+  const weeks = Math.ceil(totalDays / 7);
+
+  // Spend thresholds from the year's nonzero days (quartiles), so the scale
+  // adapts to each profile instead of using fixed dollar cutoffs.
+  const nonzero = [] as number[];
+  for (let i = 0; i < totalDays; i++) {
+    const cost = costByDate.get(toIso(startUtc + i * DAY_MS)) ?? 0;
+    if (cost > 0) nonzero.push(cost);
+  }
+  nonzero.sort((a, b) => a - b);
+  const q = (p: number) => nonzero[Math.min(nonzero.length - 1, Math.floor(p * nonzero.length))] ?? 0;
+  const thresholds = [q(0.25), q(0.5), q(0.75)];
+  const level = (cost: number) => {
+    if (cost <= 0) return 0;
+    if (cost <= thresholds[0]) return 1;
+    if (cost <= thresholds[1]) return 2;
+    if (cost <= thresholds[2]) return 3;
+    return 4;
+  };
+
+  // One cell per day in chronological order; grid-flow-col + 7 rows lays them
+  // out column-per-week like GitHub's calendar.
+  const cells = [] as { date: string; cost: number; level: number }[];
+  for (let i = 0; i < weeks * 7; i++) {
+    const utc = startUtc + i * DAY_MS;
+    const date = toIso(utc);
+    const cost = costByDate.get(date) ?? 0;
+    cells.push({ date, cost, level: utc > todayUtc ? -1 : level(cost) });
+  }
+
+  // Month labels: mark each column whose first day starts a new month.
+  const monthLabels = [] as { label: string; week: number }[];
+  let prevMonth = -1;
+  for (let w = 0; w < weeks; w++) {
+    const month = new Date(startUtc + w * 7 * DAY_MS).getUTCMonth();
+    if (month !== prevMonth) {
+      // Skip a label crammed into the very last column.
+      if (w < weeks - 2) monthLabels.push({ label: MONTHS[month], week: w });
+      prevMonth = month;
+    }
+  }
+
+  const activeDays = nonzero.length;
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="inline-flex flex-col min-w-max">
+        <div
+          className="grid gap-[3px] text-[9px] text-muted/70 font-mono mb-1 ml-[30px]"
+          style={{ gridTemplateColumns: `repeat(${weeks}, 11px)` }}
+        >
+          {monthLabels.map(({ label, week }) => (
+            <span key={`${label}-${week}`} style={{ gridColumnStart: week + 1, gridColumnEnd: "span 3" }}>
+              {label}
+            </span>
+          ))}
+        </div>
+        <div className="flex gap-[3px]">
+          <div className="grid grid-rows-7 gap-[3px] w-[27px] text-[9px] text-muted/70 font-mono">
+            {WEEKDAY_LABELS.map((label, i) => (
+              <span key={i} className="h-[11px] leading-[11px]">
+                {label}
+              </span>
+            ))}
+          </div>
+          <div className="grid grid-rows-7 grid-flow-col gap-[3px]">
+            {cells.map(({ date, cost, level }) =>
+              level < 0 ? (
+                <span key={date} className="w-[11px] h-[11px]" />
+              ) : (
+                <span
+                  key={date}
+                  title={`${date}: $${formatCurrency(cost)}`}
+                  className={`w-[11px] h-[11px] rounded-[2px] ${LEVEL_CLASSES[level]}`}
+                />
+              )
+            )}
+          </div>
+        </div>
+        <div className="flex items-center justify-between mt-2 ml-[30px]">
+          <span className="text-[11px] text-muted">
+            {activeDays} active day{activeDays === 1 ? "" : "s"} in the last year
+          </span>
+          <div className="flex items-center gap-1 text-[9px] text-muted/70 font-mono">
+            <span className="mr-0.5">Less</span>
+            {LEVEL_CLASSES.map((cls) => (
+              <span key={cls} className={`w-[11px] h-[11px] rounded-[2px] ${cls}`} />
+            ))}
+            <span className="ml-0.5">More</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -74,6 +74,11 @@ export default function ActivityHeatmap({ daily }: ActivityHeatmapProps) {
       prevMonth = month;
     }
   }
+  // The first column labels a partial month; drop it when the next label is
+  // close enough that the two (each spanning 3 columns) would overlap.
+  if (monthLabels.length >= 2 && monthLabels[1].week - monthLabels[0].week < 3) {
+    monthLabels.shift();
+  }
 
   const activeDays = nonzero.length;
 

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -69,6 +69,40 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   const ITEMS_PER_PAGE = 25;
   const isDateFiltered = dateFrom && dateTo;
 
+  // Filters ⇄ URL. Parsed once on mount (not useSearchParams — that would
+  // opt the ISR'd home page out of static rendering), then mirrored back via
+  // replaceState so any filtered view is a shareable link.
+  const [urlSynced, setUrlSynced] = useState(false);
+  useEffect(() => {
+    const p = new URLSearchParams(window.location.search);
+    if (p.get("sort") === "tokens") setSortBy("tokens");
+    const urlTool = p.get("tool");
+    if (urlTool) setTool(urlTool);
+    if (p.get("verified") === "1") setVerifiedOnly(true);
+    const from = p.get("from");
+    const to = p.get("to");
+    if (from && /^\d{4}-\d{2}-\d{2}$/.test(from)) setDateFrom(from);
+    if (to && /^\d{4}-\d{2}-\d{2}$/.test(to)) setDateTo(to);
+    setUrlSynced(true);
+  }, []);
+
+  useEffect(() => {
+    // urlSynced is still false during the mount commit, which keeps this from
+    // wiping the URL params before the parse above lands in state.
+    if (!urlSynced) return;
+    const p = new URLSearchParams(window.location.search);
+    const write = (key: string, value: string) => (value ? p.set(key, value) : p.delete(key));
+    write("sort", sortBy === "tokens" ? "tokens" : "");
+    write("tool", tool ?? "");
+    write("verified", verifiedOnly ? "1" : "");
+    write("from", dateFrom);
+    write("to", dateTo);
+    const qs = p.toString();
+    if ((qs ? `?${qs}` : "") !== window.location.search) {
+      window.history.replaceState(null, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
+    }
+  }, [urlSynced, sortBy, tool, verifiedOnly, dateFrom, dateTo]);
+
   // The server already rendered page 0 of the default view — don't re-fetch
   // it on mount. The hook only runs for non-default filters or later pages.
   const isSeededDefaultView =

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -40,6 +40,7 @@ export default function NavBar() {
   const isAdmin = checkIsAdmin(session?.user?.username);
 
   const navItems = [
+    { name: "Stats", href: "/stats" },
     { name: "Blog", href: "/blog" },
     { name: "Hire", href: "/hire" },
     ...(isAdmin ? [{ name: "Admin", href: "/admin" }] : []),

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -20,6 +20,11 @@
 // ratio checks downstream.
 const TOKEN_SLOP = 1;
 
+// Bump when normalizeCcData's behavior changes. Stored alongside each raw
+// payload in the raw_submissions archive so history can be re-parsed with a
+// newer normalizer and backfilled.
+export const PARSER_VERSION = "viberank-normalize-v1";
+
 /** A daily entry as it arrives from ccusage, before normalization. */
 interface RawDailyEntry {
   date?: string;

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -20,6 +20,7 @@ import type {
   DailyBreakdown,
   ProfileWithSubmissions,
   GlobalStats,
+  SiteStats,
   ClaimStatus,
   ClaimResult,
   DeleteResult,
@@ -1306,6 +1307,18 @@ class SupabaseStatsService implements StatsService {
       isApproximate: true,
       basedOnTop: 500,
     };
+  }
+
+  async getSiteStats(): Promise<SiteStats | null> {
+    // Exact aggregates computed in-database (migration 007). Returns null when
+    // the function isn't deployed yet so callers can fall back to the
+    // approximate getGlobalStats().
+    const { data, error } = await this.client.rpc("get_site_stats");
+    if (error || !data) {
+      if (error) console.error("get_site_stats failed:", error.message);
+      return null;
+    }
+    return data as SiteStats;
   }
 }
 

--- a/src/lib/data/supabase/rawArchive.ts
+++ b/src/lib/data/supabase/rawArchive.ts
@@ -1,0 +1,58 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { createHash } from "node:crypto";
+import { PARSER_VERSION } from "@/lib/ccusage";
+
+/**
+ * Best-effort archive of pre-normalization submission payloads (migration
+ * 006). Keeping the raw ccusage output lets us re-parse history when the
+ * normalizer changes shape again — without it, every format change is a
+ * one-way door for already-submitted data.
+ *
+ * Never throws: archiving must not block or fail a submission, including when
+ * the migration hasn't been applied yet.
+ */
+
+let client: SupabaseClient | null = null;
+
+function getServiceClient(): SupabaseClient {
+  if (!client) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!url || !serviceKey) throw new Error("Supabase server environment variables not set");
+    client = createClient(url, serviceKey);
+  }
+  return client;
+}
+
+export interface RawArchiveMeta {
+  username: string;
+  source: "cli" | "oauth";
+  machineId?: string;
+  cliVersion?: string;
+}
+
+export async function archiveRawSubmission(payload: unknown, meta: RawArchiveMeta): Promise<void> {
+  try {
+    const json = JSON.stringify(payload);
+    const sha256 = createHash("sha256").update(json).digest("hex");
+
+    const { error } = await getServiceClient()
+      .from("raw_submissions")
+      .upsert(
+        {
+          payload_sha256: sha256,
+          username: meta.username,
+          source: meta.source,
+          machine_id: meta.machineId ?? null,
+          cli_version: meta.cliVersion ?? null,
+          parser_version: PARSER_VERSION,
+          payload: JSON.parse(json),
+        },
+        { onConflict: "payload_sha256", ignoreDuplicates: true }
+      );
+
+    if (error) console.error("Raw archive insert failed:", error.message);
+  } catch (e) {
+    console.error("Raw archive failed:", e instanceof Error ? e.message : e);
+  }
+}

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -201,6 +201,28 @@ export interface GlobalStats {
   basedOnTop?: number;
 }
 
+/**
+ * Exact site-wide aggregates from the get_site_stats() SQL function
+ * (migration 007) — unlike GlobalStats, these are not approximated from the
+ * top-N submissions.
+ */
+export interface SiteStats {
+  totalUsers: number;
+  totalSubmissions: number;
+  totalCost: number;
+  totalTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreationTokens: number;
+  firstDate: string | null;
+  lastDate: string | null;
+  activeDays: number;
+  tools: { tool: string; users: number }[];
+  models: { model: string; users: number }[];
+  modelSpend: { model: string; cost: number }[];
+}
+
 export interface ClaimStatus {
   actionNeeded: "claim" | "merge" | null;
   actionText: string;
@@ -293,6 +315,8 @@ export interface ProfilesService {
 
 export interface StatsService {
   getGlobalStats(): Promise<GlobalStats>;
+  /** Exact aggregates via get_site_stats() (migration 007); null if the function isn't deployed. */
+  getSiteStats(): Promise<SiteStats | null>;
 }
 
 export interface DataLayer {

--- a/src/lib/streaks.ts
+++ b/src/lib/streaks.ts
@@ -1,0 +1,43 @@
+/**
+ * Daily-usage streaks from a set of YYYY-MM-DD active dates.
+ *
+ * "Current" tolerates a one-day lag: usage data is submitted after the fact,
+ * so a streak whose last active day is yesterday (UTC) still counts as alive.
+ */
+
+export interface Streaks {
+  current: number;
+  longest: number;
+}
+
+/** Days since epoch for a YYYY-MM-DD string (UTC, no DST wobble). */
+function epochDay(date: string): number {
+  const [y, m, d] = date.split("-").map(Number);
+  return Date.UTC(y, m - 1, d) / 86_400_000;
+}
+
+export function computeStreaks(dates: Iterable<string>, today?: string): Streaks {
+  const todayStr = today ?? new Date().toISOString().slice(0, 10);
+  const days = Array.from(new Set(dates), epochDay)
+    .filter(Number.isFinite)
+    .sort((a, b) => a - b);
+  if (days.length === 0) return { current: 0, longest: 0 };
+
+  let longest = 1;
+  let run = 1;
+  for (let i = 1; i < days.length; i++) {
+    run = days[i] === days[i - 1] + 1 ? run + 1 : 1;
+    if (run > longest) longest = run;
+  }
+
+  // Current streak: the run ending on the most recent active day, but only if
+  // that day is today or yesterday.
+  let current = 0;
+  const last = days[days.length - 1];
+  if (epochDay(todayStr) - last <= 1) {
+    current = 1;
+    for (let i = days.length - 1; i > 0 && days[i - 1] === days[i] - 1; i--) current++;
+  }
+
+  return { current, longest };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,6 +50,14 @@ export function toolBlurb(tool: string): string {
   return FEATURED_TOOLS.find((t) => t.key === tool.toLowerCase())?.blurb ?? `the ${toolLabel(tool)} CLI`;
 }
 
+/** "[openclaw] anthropic/claude-sonnet-4-20250514" → "claude-sonnet-4". */
+export function prettyModelName(raw: string): string {
+  let m = raw.replace(/^\[[^\]]+\]\s*/, ""); // "[openclaw] x/y" → "x/y"
+  m = m.split("/").pop() ?? m; // drop provider path
+  m = m.replace(/-\d{8}$/, ""); // drop date suffix
+  return m;
+}
+
 export function formatCurrency(num: number): string {
   return num.toLocaleString('en-US', {
     minimumFractionDigits: 2,

--- a/supabase/migrations/006_raw_submissions.sql
+++ b/supabase/migrations/006_raw_submissions.sql
@@ -1,0 +1,31 @@
+-- Migration 006: raw submission payload archive.
+--
+-- normalizeCcData collapses every ccusage report shape into one canonical
+-- form at ingest time — and then the original payload is gone. Every ccusage
+-- format change (e.g. the v20 period/agent rename, issue #49) is a one-way
+-- door for data submitted before the parser learned about it.
+--
+-- This table keeps the pre-normalization payload (deduped by content hash)
+-- together with the parser version that processed it, so history can be
+-- re-parsed/backfilled when the normalizer improves. Service-role only:
+-- RLS is enabled with no policies, so the anon browser key can neither read
+-- nor write raw payloads.
+
+CREATE TABLE IF NOT EXISTS raw_submissions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- sha256 of the JSON payload; identical re-submits are dropped on conflict.
+  payload_sha256 TEXT NOT NULL UNIQUE,
+  username TEXT NOT NULL,
+  source TEXT NOT NULL CHECK (source IN ('cli', 'oauth')),
+  machine_id TEXT,
+  cli_version TEXT,
+  -- Version of the normalizer that ingested this payload (see ccusage.ts).
+  parser_version TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_raw_submissions_username ON raw_submissions(username);
+CREATE INDEX IF NOT EXISTS idx_raw_submissions_created_at ON raw_submissions(created_at DESC);
+
+ALTER TABLE raw_submissions ENABLE ROW LEVEL SECURITY;

--- a/supabase/migrations/007_site_stats.sql
+++ b/supabase/migrations/007_site_stats.sql
@@ -45,6 +45,7 @@ AS $$
         SELECT m.model, COUNT(DISTINCT s.username) AS users
         FROM submissions s, unnest(s.models_used) AS m(model)
         WHERE s.flagged_for_review IS NOT TRUE
+          AND m.model IS NOT NULL AND m.model <> ''
         GROUP BY m.model
         ORDER BY COUNT(DISTINCT s.username) DESC
         LIMIT 20
@@ -59,6 +60,7 @@ AS $$
         LATERAL jsonb_array_elements(d.model_breakdowns) mb
         WHERE s.flagged_for_review IS NOT TRUE
           AND d.model_breakdowns IS NOT NULL
+          AND mb->>'modelName' IS NOT NULL
         GROUP BY 1
         ORDER BY 2 DESC
         LIMIT 20

--- a/supabase/migrations/007_site_stats.sql
+++ b/supabase/migrations/007_site_stats.sql
@@ -1,0 +1,71 @@
+-- Migration 007: exact site-wide stats for the /stats page.
+--
+-- getGlobalStats() approximates from the top 500 submissions by cost, which
+-- undercounts everyone below the cutoff. This function computes exact
+-- aggregates in one round trip so the public /stats page can show real
+-- totals, a token-type split, and per-model / per-tool adoption. The page is
+-- ISR-cached (1h), so the full scans here run rarely.
+
+CREATE OR REPLACE FUNCTION get_site_stats()
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'totalUsers', (SELECT COUNT(*) FROM profiles),
+    'totalSubmissions', (SELECT COUNT(*) FROM submissions WHERE flagged_for_review IS NOT TRUE),
+    'totalCost', COALESCE((SELECT SUM(total_cost) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'totalTokens', COALESCE((SELECT SUM(total_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'inputTokens', COALESCE((SELECT SUM(input_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'outputTokens', COALESCE((SELECT SUM(output_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'cacheReadTokens', COALESCE((SELECT SUM(cache_read_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'cacheCreationTokens', COALESCE((SELECT SUM(cache_creation_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'firstDate', (SELECT MIN(date_range_start) FROM submissions WHERE flagged_for_review IS NOT TRUE),
+    'lastDate', (SELECT MAX(date_range_end) FROM submissions WHERE flagged_for_review IS NOT TRUE),
+    'activeDays', (
+      SELECT COUNT(DISTINCT d.date)
+      FROM daily_breakdowns d
+      JOIN submissions s ON s.id = d.submission_id
+      WHERE s.flagged_for_review IS NOT TRUE
+    ),
+    'tools', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('tool', tool, 'users', users) ORDER BY users DESC)
+      FROM (
+        SELECT t.tool, COUNT(DISTINCT s.username) AS users
+        FROM submissions s, unnest(s.tools) AS t(tool)
+        WHERE s.flagged_for_review IS NOT TRUE
+        GROUP BY t.tool
+      ) x
+    ), '[]'::jsonb),
+    'models', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('model', model, 'users', users) ORDER BY users DESC)
+      FROM (
+        SELECT m.model, COUNT(DISTINCT s.username) AS users
+        FROM submissions s, unnest(s.models_used) AS m(model)
+        WHERE s.flagged_for_review IS NOT TRUE
+        GROUP BY m.model
+        ORDER BY COUNT(DISTINCT s.username) DESC
+        LIMIT 20
+      ) x
+    ), '[]'::jsonb),
+    'modelSpend', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('model', model, 'cost', cost) ORDER BY cost DESC)
+      FROM (
+        SELECT mb->>'modelName' AS model, SUM((mb->>'cost')::numeric) AS cost
+        FROM daily_breakdowns d
+        JOIN submissions s ON s.id = d.submission_id,
+        LATERAL jsonb_array_elements(d.model_breakdowns) mb
+        WHERE s.flagged_for_review IS NOT TRUE
+          AND d.model_breakdowns IS NOT NULL
+        GROUP BY 1
+        ORDER BY 2 DESC
+        LIMIT 20
+      ) x
+    ), '[]'::jsonb)
+  );
+$$;
+
+-- Read-only aggregates over already-public data; callable by everyone.
+GRANT EXECUTE ON FUNCTION get_site_stats() TO anon, authenticated, service_role;

--- a/test/streaks.test.mts
+++ b/test/streaks.test.mts
@@ -1,0 +1,86 @@
+/**
+ * Tests for streak computation.
+ * Run: node test/streaks.test.mts
+ *
+ * No test framework in this repo, so this is a tiny self-contained harness.
+ */
+// Dynamic import: Node's native .ts loader reparses as ESM at runtime, so a
+// static `import {…} from "….ts"` fails name resolution; dynamic import works.
+const { computeStreaks } = await import("../src/lib/streaks.ts");
+
+let passed = 0;
+let failed = 0;
+
+function ok(name: string, cond: boolean, detail = "") {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } else {
+    failed++;
+    console.log(`  ✗ ${name} ${detail}`);
+  }
+}
+
+function eq(name: string, actual: unknown, expected: unknown) {
+  ok(name, JSON.stringify(actual) === JSON.stringify(expected), `(got ${JSON.stringify(actual)}, want ${JSON.stringify(expected)})`);
+}
+
+const TODAY = "2026-07-24";
+
+console.log("computeStreaks");
+
+eq("empty input", computeStreaks([], TODAY), { current: 0, longest: 0 });
+
+eq(
+  "single day today",
+  computeStreaks(["2026-07-24"], TODAY),
+  { current: 1, longest: 1 }
+);
+
+eq(
+  "streak alive when last active day is yesterday",
+  computeStreaks(["2026-07-21", "2026-07-22", "2026-07-23"], TODAY),
+  { current: 3, longest: 3 }
+);
+
+eq(
+  "streak dead when last active day is two days ago",
+  computeStreaks(["2026-07-20", "2026-07-21", "2026-07-22"], TODAY),
+  { current: 0, longest: 3 }
+);
+
+eq(
+  "longest run can predate the current one",
+  computeStreaks(
+    ["2026-07-01", "2026-07-02", "2026-07-03", "2026-07-04", "2026-07-05", "2026-07-23", "2026-07-24"],
+    TODAY
+  ),
+  { current: 2, longest: 5 }
+);
+
+eq(
+  "duplicate and unsorted dates are tolerated",
+  computeStreaks(["2026-07-24", "2026-07-23", "2026-07-23", "2026-07-22"], TODAY),
+  { current: 3, longest: 3 }
+);
+
+eq(
+  "gap of one missing day breaks the run",
+  computeStreaks(["2026-07-20", "2026-07-22", "2026-07-23", "2026-07-24"], TODAY),
+  { current: 3, longest: 3 }
+);
+
+eq(
+  "month boundary is contiguous",
+  computeStreaks(["2026-06-29", "2026-06-30", "2026-07-01"], "2026-07-01"),
+  { current: 3, longest: 3 }
+);
+
+eq(
+  "invalid dates are dropped",
+  computeStreaks(["not-a-date", "2026-07-24"], TODAY),
+  { current: 1, longest: 1 }
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Upgrades borrowed from studying [tokenmaxxing](https://github.com/851-labs/tokenmaxxing) (a competing usage leaderboard), adapted to viberank's stack.

## Profile page
- **Streaks** — current + longest daily-usage streak stat cards (one-day grace since usage uploads lag a day); current streak also shows on the OG share card. New `src/lib/streaks.ts` with its own test file.
- **Activity heatmap** — GitHub-style contribution calendar of the trailing year's daily spend, server-rendered (no client JS), per-profile quartile color scale.
- **Rhythm charts** — most-active-weekday bars and last-12-months spend bars.
- All per-day dollar figures dedupe overlapping dates across un-merged submissions.

## Leaderboard
- **Shareable filter URLs** — sort / tool / verified / date range mirror into query params (`?tool=codex&sort=tokens`) via `replaceState`; avoids `useSearchParams` so the home page stays statically rendered.

## New: `/stats` page
- Exact site-wide aggregates (not the top-500 approximation): total spend/tokens, developer count, token-type split with cache-read share, popular models by users, top models by spend, tools by users.
- Backed by `get_site_stats()` (migration 007) — one round trip, `SECURITY DEFINER`, anon-executable. Page is ISR-cached 1h and falls back to approximate stats until the migration is applied.

## Backend
- **Raw payload archive** (migration 006) — every accepted submission's pre-normalization payload is stored sha256-deduped with the normalizer version (`raw_submissions`, RLS service-role-only). ccusage format changes stop being one-way doors; history can be re-parsed/backfilled. Best-effort, never blocks a submission.
- **OG image caching** — profile OG URLs now carry a stats fingerprint (`v=`), letting the route serve versioned responses with a 1-year immutable Cache-Control; the URL changes whenever stats do.

## Hardening (from review pass)
- Escape `<` in profile JSON-LD (stored XSS via GitHub display name — pre-existing).
- OG card only fetches GitHub-hosted avatars (was an open image proxy — pre-existing).
- `/stats` skips null/empty model names instead of crashing the ISR render.

## Verification
- `pnpm test` (ccusage + new streaks suites) and `pnpm build` pass.
- All 7 migrations applied in order to a throwaway Postgres 16; `get_site_stats()` output shape matches `SiteStats`, anon can execute it but cannot read `raw_submissions`, archive dedupe verified.

## Deploy note
Apply migrations **006 + 007** (`supabase db push`). Both are additive; the app degrades gracefully without them (archive no-ops with a logged error, /stats falls back to approximate totals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)