### PR TITLE
feat: UI polish pass — model-stacked chart, fluid heatmap, modal + mobile upgrades

### DIFF
--- a/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
+++ b/src/app/@modal/(.)profile/[username]/ProfileSheet.tsx
@@ -44,7 +44,7 @@ export default function ProfileSheet(props: ProfileSheetProps) {
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4">
       {/* The loading skeleton already played the big slide-up — real content
           swaps in with a quick fade so the sheet doesn't animate twice. */}
       <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={close} />
@@ -53,12 +53,12 @@ export default function ProfileSheet(props: ProfileSheetProps) {
         initial={{ opacity: 0, y: 12 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.15, ease: "easeOut" }}
-        className="relative w-full max-w-2xl bg-surface-1 border border-border border-b-0 rounded-t-xl shadow-2xl max-h-[85vh] overflow-y-auto"
+        className="relative w-full max-w-2xl bg-surface-1 border border-border border-b-0 sm:border-b rounded-t-2xl sm:rounded-xl shadow-2xl max-h-[85vh] sm:max-h-[80vh] overflow-y-auto pb-[env(safe-area-inset-bottom)] sm:pb-0"
       >
-        {/* Grab handle + close */}
+        {/* Grab handle (mobile sheet affordance) + close */}
         <div className="sticky top-0 bg-surface-1 pt-3 pb-2 px-5 flex items-center justify-between border-b border-border-subtle">
           <div className="w-8" />
-          <div className="w-10 h-1 rounded-full bg-surface-4" aria-hidden />
+          <div className="w-10 h-1 rounded-full bg-surface-4 sm:invisible" aria-hidden />
           <button
             onClick={close}
             aria-label="Close"

--- a/src/app/@modal/(.)profile/[username]/loading.tsx
+++ b/src/app/@modal/(.)profile/[username]/loading.tsx
@@ -2,12 +2,12 @@
 // sheet. Mirrors ProfileSheet's layout so the content swap doesn't jump.
 export default function SheetLoading() {
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4">
       <div className="fixed inset-0 bg-black/60 backdrop-blur-sm backdrop-in" />
 
-      <div className="sheet-up relative w-full max-w-2xl bg-surface-1 border border-border border-b-0 rounded-t-xl shadow-2xl">
+      <div className="sheet-up relative w-full max-w-2xl bg-surface-1 border border-border border-b-0 sm:border-b rounded-t-2xl sm:rounded-xl shadow-2xl">
         <div className="pt-3 pb-2 px-5 flex items-center justify-center border-b border-border-subtle">
-          <div className="w-10 h-1 rounded-full bg-surface-4" aria-hidden />
+          <div className="w-10 h-1 rounded-full bg-surface-4 sm:invisible" aria-hidden />
         </div>
 
         <div className="px-5 py-5 animate-pulse" aria-hidden>

--- a/src/app/profile/[username]/UsageChart.tsx
+++ b/src/app/profile/[username]/UsageChart.tsx
@@ -3,30 +3,106 @@
 import { useState } from "react";
 import { TrendingUp } from "lucide-react";
 import {
-  AreaChart,
-  Area,
+  BarChart,
+  Bar,
   XAxis,
   YAxis,
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  type TooltipProps,
 } from "recharts";
+import { formatCurrency, formatNumber } from "@/lib/utils";
 
-type DailyPoint = { date: string; cost: number; tokens: number };
+// Categorical palette for the dark surface (#0f0f12), validated with the
+// dataviz six-check script (lightness band, chroma floor, CVD separation,
+// normal-vision floor, contrast). Hues are assigned to models in fixed
+// order of total spend — a model keeps its color across range switches.
+const SERIES_COLORS = ["#d95926", "#3987e5", "#199e70", "#c98500", "#d55181", "#9085e9"];
+const OTHER_COLOR = "#6e6e78";
+const SURFACE = "#0f0f12";
 
-export default function UsageChart({ daily }: { daily: DailyPoint[] }) {
+export const OTHER_KEY = "Other";
+
+export interface StackedDay {
+  date: string;
+  total: number;
+  /** Cost per pretty model name; unattributed spend sits under OTHER_KEY. */
+  byModel: Record<string, number>;
+}
+
+interface UsageChartProps {
+  daily: StackedDay[];
+  /** Top models by total cost, in fixed color-assignment order (≤ 5). */
+  modelKeys: string[];
+}
+
+function ChartTooltip({ active, payload, label }: TooltipProps<number, string>) {
+  if (!active || !payload || payload.length === 0) return null;
+  const rows = payload.filter((p) => (p.value ?? 0) > 0);
+  const total = rows.reduce((s, p) => s + (p.value ?? 0), 0);
+  return (
+    <div className="rounded-lg border border-border bg-surface-2 px-3 py-2.5 shadow-xl">
+      <p className="text-[11px] text-muted mb-1.5">
+        {new Date(`${label}T00:00:00Z`).toLocaleDateString("en", {
+          weekday: "short",
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+          timeZone: "UTC",
+        })}
+      </p>
+      <div className="space-y-1">
+        {[...rows].reverse().map((p) => (
+          <div key={p.name} className="flex items-center justify-between gap-4">
+            <span className="flex items-center gap-1.5 text-xs">
+              <span className="w-2 h-2 rounded-[2px] flex-shrink-0" style={{ background: p.color }} />
+              <span className="font-mono truncate max-w-[140px]">{p.name}</span>
+            </span>
+            <span className="font-mono text-xs">${formatCurrency(p.value ?? 0)}</span>
+          </div>
+        ))}
+      </div>
+      {rows.length > 1 && (
+        <div className="flex items-center justify-between gap-4 mt-1.5 pt-1.5 border-t border-border-subtle">
+          <span className="text-xs text-muted">Total</span>
+          <span className="font-mono text-xs font-semibold">${formatCurrency(total)}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function UsageChart({ daily, modelKeys }: UsageChartProps) {
   const [range, setRange] = useState<"7d" | "30d" | "all">("30d");
 
   const data = [...daily]
     .sort((a, b) => a.date.localeCompare(b.date))
     .slice(range === "7d" ? -7 : range === "30d" ? -30 : 0);
 
+  const rangeTotal = data.reduce((s, d) => s + d.total, 0);
+  const hasOther = data.some((d) => (d.byModel[OTHER_KEY] ?? 0) > 0);
+
+  // Series in stack order (bottom→top). With no model splits at all, the
+  // whole chart would be one gray "Other" stack — render it as a single
+  // accent-colored "Spend" series instead.
+  const legacyOnly = modelKeys.length === 0;
+  const series = legacyOnly
+    ? [{ key: OTHER_KEY, label: "Spend", color: SERIES_COLORS[0] }]
+    : [
+        ...modelKeys.map((key, i) => ({ key, label: key, color: SERIES_COLORS[i % SERIES_COLORS.length] })),
+        ...(hasOther ? [{ key: OTHER_KEY, label: OTHER_KEY, color: OTHER_COLOR }] : []),
+      ];
+
   return (
-    <div className="bg-surface-1 border border-border rounded-lg p-5 mb-6">
-      <div className="flex items-center justify-between mb-4">
+    <div className="bg-surface-1 border border-border rounded-lg p-4 sm:p-5 mb-4">
+      <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
         <h2 className="text-base font-medium flex items-center gap-2">
           <TrendingUp className="w-4 h-4 text-accent" />
           Usage over time
+          <span className="hidden sm:inline font-mono text-xs text-muted font-normal">
+            ${formatNumber(rangeTotal)} in range
+          </span>
         </h2>
         <div className="flex gap-1">
           {(["7d", "30d", "all"] as const).map((r) => (
@@ -46,50 +122,60 @@ export default function UsageChart({ daily }: { daily: DailyPoint[] }) {
       </div>
 
       {data.length > 0 ? (
-        <ResponsiveContainer width="100%" height={220}>
-          <AreaChart data={data}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#26262d" strokeOpacity={0.6} />
-            <XAxis
-              dataKey="date"
-              stroke="#9a9aa5"
-              tick={{ fontSize: 11, fill: "#9a9aa5" }}
-              tickFormatter={(date) =>
-                new Date(date).toLocaleDateString("en", { month: "short", day: "numeric" })
-              }
-            />
-            <YAxis
-              stroke="#9a9aa5"
-              tick={{ fontSize: 11, fill: "#9a9aa5" }}
-              tickFormatter={(value) => `$${value}`}
-            />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: "#16161a",
-                border: "1px solid #26262d",
-                borderRadius: "8px",
-                fontSize: "12px",
-              }}
-              formatter={(value: number) => [`$${value.toFixed(2)}`, "Cost"]}
-              labelFormatter={(date) =>
-                new Date(date).toLocaleDateString("en", {
-                  weekday: "short",
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })
-              }
-            />
-            {/* Flat fill (solid colour at low opacity — no gradient) */}
-            <Area
-              type="monotone"
-              dataKey="cost"
-              stroke="#f97316"
-              strokeWidth={2}
-              fill="#f97316"
-              fillOpacity={0.12}
-            />
-          </AreaChart>
-        </ResponsiveContainer>
+        <>
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={data} margin={{ top: 4, right: 0, left: 0, bottom: 0 }} barCategoryGap="20%">
+              <CartesianGrid vertical={false} stroke="#26262d" strokeOpacity={0.6} />
+              <XAxis
+                dataKey="date"
+                stroke="transparent"
+                interval="preserveStartEnd"
+                minTickGap={28}
+                tick={{ fontSize: 10, fill: "#9a9aa5" }}
+                tickFormatter={(date: string) =>
+                  new Date(`${date}T00:00:00Z`).toLocaleDateString("en", {
+                    month: "short",
+                    day: "numeric",
+                    timeZone: "UTC",
+                  })
+                }
+              />
+              <YAxis
+                stroke="transparent"
+                width={44}
+                tick={{ fontSize: 10, fill: "#9a9aa5" }}
+                tickFormatter={(value: number) => `$${formatNumber(value)}`}
+              />
+              <Tooltip content={<ChartTooltip />} cursor={{ fill: "rgba(255,255,255,0.04)" }} />
+              {series.map((s, i) => (
+                <Bar
+                  key={s.key}
+                  name={s.label}
+                  stackId="cost"
+                  maxBarSize={28}
+                  dataKey={(row: StackedDay) => row.byModel[s.key] ?? 0}
+                  fill={s.color}
+                  // 2px surface gap between stacked segments so adjacent
+                  // hues never touch (CVD-safe secondary encoding).
+                  stroke={SURFACE}
+                  strokeWidth={2}
+                  radius={i === series.length - 1 ? [3, 3, 0, 0] : undefined}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+
+          {!legacyOnly && series.length > 1 && (
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 mt-3 px-1">
+              {series.map((s) => (
+                <span key={s.key} className="inline-flex items-center gap-1.5 text-[11px] text-muted">
+                  <span className="w-2.5 h-2.5 rounded-[2px]" style={{ background: s.color }} />
+                  <span className="font-mono">{s.label}</span>
+                </span>
+              ))}
+            </div>
+          )}
+        </>
       ) : (
         <div className="h-[220px] flex items-center justify-center text-muted text-sm">
           No data for selected time range

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -71,15 +71,6 @@ export default async function ProfilePage({ params }: ProfileParams) {
   const daysActive = new Set(allDaily.map((d) => d.date)).size || 1;
   const avgDailyCost = totalCost / daysActive;
 
-  // Per-day chart series (summed across submissions).
-  const dailyMap = allDaily.reduce((acc, d) => {
-    if (!acc[d.date]) acc[d.date] = { date: d.date, cost: 0, tokens: 0 };
-    acc[d.date].cost += d.totalCost;
-    acc[d.date].tokens += d.totalTokens;
-    return acc;
-  }, {} as Record<string, { date: string; cost: number; tokens: number }>);
-  const dailySeries = Object.values(dailyMap);
-
   // Dates can repeat across un-merged submissions (e.g. an unclaimed cli row
   // next to an oauth row), so per-day dollar figures must come from deduped
   // days — prefer the newest submission's row, matching how merge overwrites
@@ -91,6 +82,34 @@ export default async function ProfilePage({ params }: ProfileParams) {
     return true;
   });
   const dedupedSeries = uniqueDaily.map((d) => ({ date: d.date, cost: d.totalCost }));
+
+  // Model-stacked series for the usage chart: top 5 models by total cost keep
+  // their own color; everything else (and legacy days without splits) folds
+  // into "Other".
+  const chartModelTotals = new Map<string, number>();
+  for (const d of uniqueDaily) {
+    for (const mb of d.modelBreakdowns ?? []) {
+      const name = prettyModelName(mb.modelName);
+      chartModelTotals.set(name, (chartModelTotals.get(name) ?? 0) + mb.cost);
+    }
+  }
+  const chartModelKeys = Array.from(chartModelTotals.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5)
+    .map(([name]) => name);
+  const stackedDaily = uniqueDaily.map((d) => {
+    const byModel: Record<string, number> = {};
+    let attributed = 0;
+    for (const mb of d.modelBreakdowns ?? []) {
+      const name = prettyModelName(mb.modelName);
+      const key = chartModelKeys.includes(name) ? name : "Other";
+      byModel[key] = (byModel[key] ?? 0) + mb.cost;
+      attributed += mb.cost;
+    }
+    const rest = d.totalCost - attributed;
+    if (rest > 0.005) byModel["Other"] = (byModel["Other"] ?? 0) + rest;
+    return { date: d.date, total: d.totalCost, byModel };
+  });
 
   // Streaks over days that actually have usage recorded.
   const streaks = computeStreaks(uniqueDaily.map((d) => d.date));
@@ -341,7 +360,7 @@ export default async function ProfilePage({ params }: ProfileParams) {
         </div>
 
         {/* Usage chart (client island) */}
-        <UsageChart daily={dailySeries} />
+        <UsageChart daily={stackedDaily} modelKeys={chartModelKeys} />
 
         {/* Activity heatmap */}
         <div className="bg-surface-1 border border-border rounded-lg p-5 mb-4">
@@ -442,16 +461,20 @@ export default async function ProfilePage({ params }: ProfileParams) {
                 </h2>
                 <span className="micro-label">last {monthEntries.length} months</span>
               </div>
-              <div className="flex items-end gap-2 h-32">
-                {monthEntries.map(([month, cost]) => (
-                  <div key={month} className="flex-1 flex flex-col items-center gap-1.5 min-w-0" title={`${monthLabel(month)}: $${formatCurrency(cost)}`}>
-                    <div className="w-full flex-1 flex items-end">
-                      <div
-                        className="w-full bg-accent/80 rounded-t-sm"
-                        style={{ height: `${Math.max((cost / maxMonthCost) * 100, 2)}%` }}
-                      />
-                    </div>
-                    <span className="text-[9px] font-mono text-muted/70 truncate">{monthLabel(month)}</span>
+              <div className="flex items-end gap-1.5 sm:gap-2 h-32">
+                {monthEntries.map(([month, cost], i) => (
+                  <div key={month} className="flex-1 flex flex-col items-center justify-end gap-1.5 min-w-0 h-full" title={`${monthLabel(month)}: $${formatCurrency(cost)}`}>
+                    {/* px heights — % against a flex-sized parent doesn't
+                        resolve reliably, which left these bars invisible */}
+                    <div
+                      className="w-full bg-accent/80 rounded-t-sm"
+                      style={{ height: `${Math.max((cost / maxMonthCost) * 100, 3)}px` }}
+                    />
+                    {/* 12 labels don't fit a phone; show every other one there
+                        (invisible, not hidden, so bar baselines stay aligned) */}
+                    <span className={`text-[9px] font-mono text-muted/70 truncate ${i % 2 === 1 ? "invisible sm:visible" : ""}`}>
+                      {monthLabel(month)}
+                    </span>
                   </div>
                 ))}
               </div>

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -24,6 +24,8 @@ function toIso(utc: number): string {
 /**
  * GitHub-style contribution calendar of the trailing year's daily spend.
  * Server-rendered: plain divs with native title tooltips, no client JS.
+ * Cells are fluid (1fr columns, square cells) so the grid fills the card;
+ * a min-width keeps it readable on phones via horizontal scroll.
  */
 export default function ActivityHeatmap({ daily }: ActivityHeatmapProps) {
   const costByDate = new Map(daily.map((d) => [d.date, d.cost]));
@@ -81,50 +83,50 @@ export default function ActivityHeatmap({ daily }: ActivityHeatmapProps) {
   }
 
   const activeDays = nonzero.length;
+  const weekColumns = `repeat(${weeks}, minmax(0, 1fr))`;
 
   return (
     <div className="overflow-x-auto">
-      <div className="inline-flex flex-col min-w-max">
+      <div className="min-w-[680px]">
         <div
-          className="grid gap-[3px] text-[9px] text-muted/70 font-mono mb-1 ml-[30px]"
-          style={{ gridTemplateColumns: `repeat(${weeks}, 11px)` }}
+          className="grid gap-[3px] text-[9px] text-muted/70 font-mono mb-1"
+          style={{ gridTemplateColumns: `27px ${weekColumns}` }}
         >
           {monthLabels.map(({ label, week }) => (
-            <span key={`${label}-${week}`} style={{ gridColumnStart: week + 1, gridColumnEnd: "span 3" }}>
+            <span key={`${label}-${week}`} style={{ gridColumnStart: week + 2, gridColumnEnd: "span 3" }}>
               {label}
             </span>
           ))}
         </div>
-        <div className="flex gap-[3px]">
-          <div className="grid grid-rows-7 gap-[3px] w-[27px] text-[9px] text-muted/70 font-mono">
-            {WEEKDAY_LABELS.map((label, i) => (
-              <span key={i} className="h-[11px] leading-[11px]">
-                {label}
-              </span>
-            ))}
-          </div>
-          <div className="grid grid-rows-7 grid-flow-col gap-[3px]">
-            {cells.map(({ date, cost, level }) =>
-              level < 0 ? (
-                <span key={date} className="w-[11px] h-[11px]" />
-              ) : (
-                <span
-                  key={date}
-                  title={`${date}: $${formatCurrency(cost)}`}
-                  className={`w-[11px] h-[11px] rounded-[2px] ${LEVEL_CLASSES[level]}`}
-                />
-              )
-            )}
-          </div>
+        <div
+          className="grid grid-flow-col gap-[3px]"
+          style={{ gridTemplateColumns: `27px ${weekColumns}`, gridTemplateRows: "repeat(7, minmax(0, 1fr))" }}
+        >
+          {WEEKDAY_LABELS.map((label, i) => (
+            <span key={`wd-${i}`} className="text-[9px] text-muted/70 font-mono leading-none self-center">
+              {label}
+            </span>
+          ))}
+          {cells.map(({ date, cost, level }) =>
+            level < 0 ? (
+              <span key={date} className="w-full aspect-square" />
+            ) : (
+              <span
+                key={date}
+                title={`${date}: $${formatCurrency(cost)}`}
+                className={`w-full aspect-square rounded-[2px] ${LEVEL_CLASSES[level]}`}
+              />
+            )
+          )}
         </div>
-        <div className="flex items-center justify-between mt-2 ml-[30px]">
+        <div className="flex items-center justify-between mt-2 pl-[30px]">
           <span className="text-[11px] text-muted">
             {activeDays} active day{activeDays === 1 ? "" : "s"} in the last year
           </span>
           <div className="flex items-center gap-1 text-[9px] text-muted/70 font-mono">
             <span className="mr-0.5">Less</span>
             {LEVEL_CLASSES.map((cls) => (
-              <span key={cls} className={`w-[11px] h-[11px] rounded-[2px] ${cls}`} />
+              <span key={cls} className={`w-[10px] h-[10px] rounded-[2px] ${cls}`} />
             ))}
             <span className="ml-0.5">More</span>
           </div>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -201,8 +201,8 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
     <div>
       {/* Filter bar — sticky under the nav while scrolling the board */}
       <div className="sticky top-14 z-40 py-2.5 bg-background/95 backdrop-blur border-b border-border mb-5">
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex items-center gap-1.5">
+        <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+          <div className="flex flex-wrap items-center gap-1.5">
             <span className="micro-label mr-2 hidden lg:block">Leaderboard</span>
             {[
               { label: "All", days: null },
@@ -389,8 +389,12 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                               </span>
                             )}
                           </div>
+                          {/* Tokens live here on mobile, where the column is hidden */}
+                          <div className="text-xs text-muted font-mono sm:hidden">
+                            {formatNumber(submission.totalTokens)} tokens
+                          </div>
                           {submission.githubName && submission.githubName !== submission.githubUsername && (
-                            <div className="text-xs text-muted truncate">{submission.githubName}</div>
+                            <div className="text-xs text-muted truncate hidden sm:block">{submission.githubName}</div>
                           )}
                         </div>
                       </div>

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -40,7 +40,7 @@ export default function ShareCard({ rank, username, totalCost, totalTokens, date
     <motion.div
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
-      className="bg-surface-1 border border-border rounded-2xl p-5 max-w-md w-full mx-auto"
+      className="bg-surface-1 border border-border rounded-2xl p-4 sm:p-5 w-[min(28rem,calc(100vw-2rem))] max-h-[90vh] overflow-y-auto mx-auto"
     >
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-base font-medium">Share your rank</h3>
@@ -51,8 +51,11 @@ export default function ShareCard({ rank, username, totalCost, totalTokens, date
         )}
       </div>
 
-      {/* Preview card */}
-      <div className="bg-background border border-border rounded-xl p-5 mb-4">
+      {/* Preview card — thin tier-colored cap ties it to the OG share image */}
+      <div
+        className="bg-background border border-border border-t-2 rounded-xl p-4 sm:p-5 mb-4"
+        style={{ borderTopColor: tier.color }}
+      >
         <div className="flex items-start justify-between mb-4">
           <div>
             <p className="micro-label mb-1">viberank.app</p>

--- a/src/components/SubmitModal.tsx
+++ b/src/components/SubmitModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Upload, X, Terminal, Copy, Check } from "lucide-react";
 import { track } from "@vercel/analytics";
@@ -13,6 +13,19 @@ interface SubmitModalProps {
 
 export default function SubmitModal({ open, onClose }: SubmitModalProps) {
   const [copied, setCopied] = useState(false);
+
+  // Esc to close + lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, onClose]);
 
   const copyCommand = () => {
     navigator.clipboard.writeText("npx viberank-cli");
@@ -28,18 +41,22 @@ export default function SubmitModal({ open, onClose }: SubmitModalProps) {
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4"
         >
           <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" onClick={onClose} />
           <motion.div
-            initial={{ opacity: 0, scale: 0.95, y: 10 }}
+            initial={{ opacity: 0, scale: 0.97, y: 16 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
-            exit={{ opacity: 0, scale: 0.95, y: 10 }}
-            className="relative bg-surface-1 border border-border rounded-lg shadow-xl max-w-sm w-full"
+            exit={{ opacity: 0, scale: 0.97, y: 16 }}
+            transition={{ duration: 0.18, ease: "easeOut" }}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Submit stats"
+            className="relative bg-surface-1 border border-border border-b-0 sm:border-b rounded-t-2xl sm:rounded-xl shadow-2xl w-full sm:max-w-sm max-h-[90vh] overflow-y-auto pb-[env(safe-area-inset-bottom)] sm:pb-0"
           >
-            <div className="px-4 py-3 flex items-center justify-between border-b border-border">
+            <div className="px-4 py-3 flex items-center justify-between border-b border-border sticky top-0 bg-surface-1">
               <h3 className="font-medium">Submit Stats</h3>
-              <button onClick={onClose} className="p-1 text-muted hover:text-foreground rounded hover:bg-surface-2">
+              <button onClick={onClose} aria-label="Close" className="p-1.5 text-muted hover:text-foreground rounded-md hover:bg-surface-2 transition-colors">
                 <X className="w-4 h-4" />
               </button>
             </div>

--- a/src/components/UpdatesModal.tsx
+++ b/src/components/UpdatesModal.tsx
@@ -90,7 +90,7 @@ export default function UpdatesModal({ isOpen, onClose }: UpdatesModalProps) {
   return (
     <AnimatePresence>
       {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center sm:p-4">
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -103,7 +103,11 @@ export default function UpdatesModal({ isOpen, onClose }: UpdatesModalProps) {
             initial={{ opacity: 0, scale: 0.95, y: 10 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 10 }}
-            className="relative bg-card border border-border rounded-lg shadow-xl max-w-md w-full max-h-[70vh] overflow-hidden"
+            transition={{ duration: 0.18, ease: "easeOut" }}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Recent updates"
+            className="relative bg-card border border-border border-b-0 sm:border-b rounded-t-2xl sm:rounded-xl shadow-2xl w-full sm:max-w-md max-h-[70vh] overflow-hidden pb-[env(safe-area-inset-bottom)] sm:pb-0"
           >
             {/* Header */}
             <div className="px-4 py-3 border-b border-border flex items-center justify-between">


### PR DESCRIPTION
UI upgrade pass across all visible pages.

## Charts
- **Usage over time → per-day stacked bars colored by model** (top 5 by spend + Other), with a legend, per-day model breakdown tooltip, and a range total in the header. The 6-color categorical palette was validated for the dark surface (colorblind-safe adjacency, lightness band, contrast); stacked segments keep a 2px surface gap so adjacent hues never touch. Profiles without model splits fall back to a single accent-colored series.
- **Activity heatmap now fills its card** — fluid square cells (~17px on desktop) instead of fixed 11px, with a 680px min-width so phones scroll.
- **Fixed invisible Monthly-spend bars** — % heights against a flex-sized parent never resolved; bars now use px heights. Alternating month labels on phones.

## Modals
- Submit + Updates modals become bottom sheets on phones (rounded top, safe-area padding) and centered dialogs on desktop; Submit gains Esc-to-close, body scroll lock, and dialog aria attributes.
- ProfileSheet centers on desktop while staying a bottom sheet on mobile (grab handle hidden at sm+); the loading skeleton matches so the swap doesn't jump.
- ShareCard sizes to the viewport and gets a tier-colored cap on the preview card.

## Responsiveness
- Leaderboard rows show tokens under the username on mobile (where the column is hidden); filter bar wraps instead of squeezing.
- Verified at 375px: no horizontal overflow on home or profile pages.

## Verification
- `pnpm test` + `pnpm build` pass.
- Screenshotted locally at desktop + 375px: stacked chart with real multi-model data, full-width heatmap, monthly bars visible, mobile bottom-sheet modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)