### PR TITLE
feat: SEO upgrade — tokenmaxxing + Codex keyword clusters

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -146,8 +146,9 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
                 </span>
               </h1>
               <p className="text-muted text-base sm:text-lg mt-4 max-w-2xl">
-                Developers ranked by API spend and token usage across Claude Code, OpenAI Codex,
-                Gemini CLI, Copilot and every coding agent ccusage tracks.
+                The public tokenmaxxing leaderboard for vibe coding — developers ranked by API spend
+                and token usage across Claude Code, OpenAI Codex, Gemini CLI, Copilot and every
+                coding agent ccusage tracks.
               </p>
 
               {/* CTA — mobile/tablet only; the sidebar card covers desktop */}

--- a/src/app/blog/codex-token-usage-leaderboard/page.tsx
+++ b/src/app/blog/codex-token-usage-leaderboard/page.tsx
@@ -1,0 +1,211 @@
+import Link from "next/link";
+import { ArrowLeft, Clock, Calendar, Terminal, Gauge, Trophy, DollarSign } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard) 2026",
+  description:
+    "Check your OpenAI Codex CLI token usage and costs with ccusage, understand what your sessions burn, and see how you rank against 190+ Codex developers on the public Viberank leaderboard.",
+  alternates: { canonical: "https://www.viberank.app/blog/codex-token-usage-leaderboard" },
+  openGraph: {
+    title: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard)",
+    description:
+      "Read your Codex CLI logs with ccusage, understand what sessions cost, and rank yourself on the public Codex leaderboard.",
+    url: "https://www.viberank.app/blog/codex-token-usage-leaderboard",
+    type: "article",
+    publishedTime: "2026-07-24T00:00:00.000Z",
+    authors: ["Viberank Team"],
+    images: [
+      {
+        url: "/api/og?title=Codex%20Token%20Usage&description=Track%20it%2C%20cost%20it%2C%20rank%20it",
+        width: 1200,
+        height: 630,
+        alt: "Track OpenAI Codex token usage",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard)",
+    description: "Read your Codex CLI logs with ccusage and rank yourself on the public Codex leaderboard.",
+    images: ["/api/og?title=Codex%20Token%20Usage&description=Track%20it%2C%20cost%20it%2C%20rank%20it"],
+  },
+};
+
+const FAQS = [
+  {
+    q: "How do I check my OpenAI Codex token usage?",
+    a: "Codex CLI writes session logs as JSONL under ~/.codex. Run npx ccusage@latest daily to parse them into per-day token counts and API-equivalent costs, alongside any other coding agents you use.",
+  },
+  {
+    q: "Does Codex usage tracked this way match my OpenAI bill?",
+    a: "Not exactly. ccusage computes API-equivalent cost from model list prices. If you use Codex through a ChatGPT plan, you don't pay per token — the number tells you what your usage would cost at API prices, which is the fairest way to compare across tools and plans.",
+  },
+  {
+    q: "Is there a public leaderboard for Codex usage?",
+    a: "Yes — Viberank ranks developers by real usage across Codex, Claude Code, Gemini CLI and more, with a Codex-only view at viberank.app/tool/codex. Run npx viberank-cli to join.",
+  },
+  {
+    q: "Why does Codex burn tokens so fast?",
+    a: "Agentic sessions resend context every turn: system prompt, file contents, tool results. Most of that is prompt-cache reads billed at a fraction of input price, so a big token number is usually a much smaller bill.",
+  },
+];
+
+export default function CodexTokenUsage() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard) 2026",
+      description:
+        "Check your OpenAI Codex CLI token usage and costs with ccusage, and see how you rank on the public Codex leaderboard.",
+      image: "https://www.viberank.app/api/og?title=Codex%20Token%20Usage",
+      datePublished: "2026-07-24T00:00:00.000Z",
+      dateModified: "2026-07-24T00:00:00.000Z",
+      author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
+      publisher: {
+        "@type": "Organization",
+        name: "Viberank",
+        url: "https://www.viberank.app",
+        logo: { "@type": "ImageObject", url: "https://www.viberank.app/icon.svg" },
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
+            How to Track OpenAI Codex Token Usage — and Join the Codex Leaderboard
+          </h1>
+
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              July 24, 2026
+            </span>
+            <span className="flex items-center gap-2">
+              <Clock className="w-4 h-4" />
+              6 min read
+            </span>
+          </div>
+
+          <div className="p-6 bg-card border border-border rounded-lg">
+            <p className="text-lg text-foreground m-0">
+              OpenAI&apos;s Codex CLI doesn&apos;t ship a usage dashboard, but it logs everything you need locally.
+              This guide shows how to turn those logs into daily token counts and dollar figures with{" "}
+              <span className="font-semibold text-accent">ccusage</span>, what the numbers actually mean, and how to
+              stack yours against the 190+ developers tracking Codex on the{" "}
+              <Link href="/tool/codex">public Codex leaderboard</Link>.
+            </p>
+          </div>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Terminal className="w-8 h-8 text-accent" />
+            Reading your Codex usage with ccusage
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Codex CLI writes each session as JSONL under <code>~/.codex</code> (or wherever{" "}
+            <code>CODEX_HOME</code> points). ccusage parses those files, diffs the per-turn token counters, and
+            rolls everything up into daily and monthly reports with API-equivalent costs:
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6 space-y-2">
+            <div>
+              <code className="text-accent font-mono">npx ccusage@latest daily</code>
+              <span className="text-muted text-sm ml-3"># per-day tokens + cost, all agents</span>
+            </div>
+            <div>
+              <code className="text-accent font-mono">npx ccusage@latest monthly</code>
+              <span className="text-muted text-sm ml-3"># monthly rollup</span>
+            </div>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The same command covers Claude Code, Gemini CLI, Copilot CLI and OpenCode, so if you bounce between
+            agents you get one combined view instead of four dashboards. For a deeper comparison of how the big
+            three stack up on cost, see{" "}
+            <Link href="/blog/codex-vs-claude-code-vs-gemini-cli">Codex vs Claude Code vs Gemini CLI</Link>.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Gauge className="w-8 h-8 text-accent" />
+            What the numbers mean (and why they look huge)
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Agentic coding resends context on every turn — system prompt, file contents, tool output — so daily
+            token counts in the tens or hundreds of millions are normal for heavy users. The saving grace is prompt
+            caching: across all usage tracked on <Link href="/stats">Viberank</Link>, roughly 95% of tokens are
+            cache reads billed at a fraction of the input price. That&apos;s also why ccusage reports{" "}
+            <em>API-equivalent</em> cost: if you&apos;re on a ChatGPT plan your marginal cost is $0, and the number
+            tells you what your plan is actually worth — many heavy Codex users clear their subscription price in
+            value within days.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Trophy className="w-8 h-8 text-accent" />
+            The Codex leaderboard
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            196 developers currently track Codex usage on Viberank, alongside 990+ on Claude Code and 76 on Gemini
+            CLI. The <Link href="/tool/codex">Codex board</Link> filters the global leaderboard to submissions that
+            include Codex, ranked by API-equivalent spend and tokens; every profile breaks usage down per model and
+            per tool, with an activity heatmap and streaks. If you&apos;re into{" "}
+            <Link href="/blog/what-is-tokenmaxxing">tokenmaxxing</Link>, this is the scoreboard.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <DollarSign className="w-8 h-8 text-accent" />
+            Join in one command
+          </h2>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx viberank-cli</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            It runs ccusage locally, submits only the usage totals (never your code or prompts), and links the
+            submission to your GitHub handle — sign in on the site for a verified badge. Spending too much? Start
+            with <Link href="/blog/reduce-ai-coding-costs">9 ways to cut your AI coding bill</Link>.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6">Codex usage FAQ</h2>
+          <div className="space-y-6">
+            {FAQS.map((f) => (
+              <div key={f.q} className="bg-card border border-border rounded-lg p-5">
+                <h3 className="text-lg font-semibold text-foreground mt-0 mb-2">{f.q}</h3>
+                <p className="text-muted m-0">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -2,6 +2,20 @@ import Link from "next/link";
 
 const blogPosts = [
   {
+    slug: "what-is-tokenmaxxing",
+    title: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze (2026)",
+    excerpt: "The trend behind Meta's Claudeonomics and Uber's blown AI budget — where the term came from, why corporate token leaderboards failed, and how 1,000+ developers measure theirs.",
+    date: "July 24, 2026",
+    readTime: "7 min read",
+  },
+  {
+    slug: "codex-token-usage-leaderboard",
+    title: "How to Track OpenAI Codex Token Usage — and Join the Codex Leaderboard",
+    excerpt: "Turn Codex CLI's local logs into daily token counts and costs with ccusage, understand why the numbers look huge, and rank yourself against 190+ Codex developers.",
+    date: "July 24, 2026",
+    readTime: "6 min read",
+  },
+  {
     slug: "state-of-ai-coding-2026",
     title: "State of AI Coding Spend 2026: Benchmarks From 800 Developers and $2.3M of Usage",
     excerpt: "Percentiles, daily burn rates, model mix, and power-user benchmarks from 29,000 days of real Claude Code, Codex, and Gemini CLI usage.",

--- a/src/app/blog/what-is-tokenmaxxing/page.tsx
+++ b/src/app/blog/what-is-tokenmaxxing/page.tsx
@@ -1,0 +1,251 @@
+import Link from "next/link";
+import { ArrowLeft, Clock, Calendar, Flame, Building2, Scale, Trophy, Terminal } from "lucide-react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze (2026)",
+  description:
+    "Tokenmaxxing is racking up AI token usage to climb a leaderboard — the trend behind Meta's Claudeonomics, Uber's blown AI budget, and public boards like Viberank. What it means, where it went wrong, and how to measure yours.",
+  alternates: { canonical: "https://www.viberank.app/blog/what-is-tokenmaxxing" },
+  openGraph: {
+    title: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze",
+    description:
+      "The trend behind Meta's Claudeonomics and Uber's blown AI budget — and the public leaderboard where 1,000+ developers track $6.6M of real usage.",
+    url: "https://www.viberank.app/blog/what-is-tokenmaxxing",
+    type: "article",
+    publishedTime: "2026-07-24T00:00:00.000Z",
+    authors: ["Viberank Team"],
+    images: [
+      {
+        url: "/api/og?title=What%20Is%20Tokenmaxxing%3F&description=Inside%20the%20AI%20Token%20Leaderboard%20Craze",
+        width: 1200,
+        height: 630,
+        alt: "What Is Tokenmaxxing?",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze",
+    description:
+      "The trend behind Meta's Claudeonomics and Uber's blown AI budget — and the public board where devs track real usage.",
+    images: ["/api/og?title=What%20Is%20Tokenmaxxing%3F&description=Inside%20the%20AI%20Token%20Leaderboard%20Craze"],
+  },
+};
+
+const FAQS = [
+  {
+    q: "What does tokenmaxxing mean?",
+    a: "Tokenmaxxing is deliberately maximizing your AI token consumption — usually to climb a usage leaderboard. The word follows the '-maxxing' slang pattern and took off in 2026 when companies like Meta and Uber ran internal AI usage leaderboards.",
+  },
+  {
+    q: "Is tokenmaxxing bad?",
+    a: "Raw token count is a terrible target but a useful signal. Internal leaderboards that paid people to burn tokens backfired; public boards where developers voluntarily track real spend are closer to a fitness tracker than a KPI. Judge output, not tokens — but knowing your number beats guessing.",
+  },
+  {
+    q: "How do I see my own token usage?",
+    a: "If you use Claude Code, OpenAI Codex, Gemini CLI or similar agents, run npx ccusage@latest daily to read your local logs, or npx viberank-cli to compute it and rank yourself on the public Viberank leaderboard.",
+  },
+  {
+    q: "What counts as heavy AI usage in 2026?",
+    a: "On Viberank, crossing about $1,000 in API-equivalent spend puts you in the Flame tier; $15,000+ is Inferno, and $50,000+ is Supernova. The median active developer burns tens of millions of tokens per day, most of it cache reads.",
+  },
+];
+
+export default function WhatIsTokenmaxxing() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze (2026)",
+      description:
+        "Tokenmaxxing is racking up AI token usage to climb a leaderboard — the trend behind Meta's Claudeonomics, Uber's blown AI budget, and public boards like Viberank.",
+      image: "https://www.viberank.app/api/og?title=What%20Is%20Tokenmaxxing%3F",
+      datePublished: "2026-07-24T00:00:00.000Z",
+      dateModified: "2026-07-24T00:00:00.000Z",
+      author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
+      publisher: {
+        "@type": "Organization",
+        name: "Viberank",
+        url: "https://www.viberank.app",
+        logo: { "@type": "ImageObject", url: "https://www.viberank.app/icon.svg" },
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
+            What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze
+          </h1>
+
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              July 24, 2026
+            </span>
+            <span className="flex items-center gap-2">
+              <Clock className="w-4 h-4" />
+              7 min read
+            </span>
+          </div>
+
+          <div className="p-6 bg-card border border-border rounded-lg">
+            <p className="text-lg text-foreground m-0">
+              <span className="font-semibold text-accent">Tokenmaxxing</span> is deliberately running up your AI
+              token usage — usually to climb a leaderboard. In 2026 it went from an inside joke among{" "}
+              <Link href="/blog/vibe-coding-revolution">vibe coders</Link> to a corporate phenomenon big enough to
+              get its own Wikipedia entry, wreck at least one company&apos;s AI budget, and get Meta&apos;s internal
+              leaderboard shut down. Here&apos;s where the term came from, why the corporate version failed, and how
+              developers measure it for real.
+            </p>
+          </div>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Flame className="w-8 h-8 text-accent" />
+            Where the word comes from
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The suffix does the work: like every other &quot;-maxxing&quot;, tokenmaxxing means optimizing one number
+            as hard as you can — in this case, the tokens your AI coding agents chew through. A token is the unit
+            LLM providers bill by; a heavy Claude Code or OpenAI Codex user can push hundreds of millions of them in
+            a day once you count prompt-cache reads. When companies started publishing usage leaderboards to push AI
+            adoption, employees did what leaderboards make people do: they maxxed the metric.
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The term spread through developer media in mid-2026 — the{" "}
+            <a href="https://blog.pragmaticengineer.com/the-pulse-tokenmaxxing-as-a-weird-new-trend/" target="_blank" rel="noopener noreferrer">
+              Pragmatic Engineer
+            </a>{" "}
+            called it &quot;a weird new trend,&quot;{" "}
+            <a href="https://www.cio.com/article/4178320/tokenmaxxing-when-ai-adoption-metrics-go-bad.html" target="_blank" rel="noopener noreferrer">
+              CIO
+            </a>{" "}
+            filed it under &quot;AI adoption metrics gone bad,&quot; and{" "}
+            <a href="https://leaddev.com/ai/tokenmaxxing-and-the-search-for-ai-metrics-that-matter" target="_blank" rel="noopener noreferrer">
+              LeadDev
+            </a>{" "}
+            used it as the poster child for measuring the wrong thing.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Building2 className="w-8 h-8 text-accent" />
+            The corporate leaderboard saga
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The reported numbers are staggering. Meta&apos;s internal board — nicknamed
+            &quot;Claudeonomics&quot; — aggregated AI usage across more than 85,000 employees, ranked a top 250, and
+            handed out tiers like &quot;Token Legend.&quot; In one 30-day stretch Meta employees reportedly burned{" "}
+            <strong>60.2 trillion tokens</strong> — roughly $900M at list API prices. One Disney employee logged
+            460,000 Claude interactions in nine days. Uber incentivized AI adoption through an internal leaderboard
+            and burned through its entire 2026 AI budget in four months.
+          </p>
+          <div className="bg-card border-l-4 border-accent p-6 my-8">
+            <p className="text-stone-200 m-0">
+              The pattern is Goodhart&apos;s law on fast-forward: the moment token count became a target, it stopped
+              measuring anything. People routed trivial tasks through frontier models, looped agents overnight, and
+              optimized for the scoreboard instead of shipped software. Meta abolished its leaderboard after the
+              backlash.
+            </p>
+          </div>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Scale className="w-8 h-8 text-accent" />
+            So is tracking tokens pointless? No — targets are the problem
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            There&apos;s a difference between a mandated KPI and a fitness tracker. Nobody at Viberank gets a bonus
+            for burning tokens; developers submit their own <code>ccusage</code> data because knowing your real
+            number beats guessing. The data is genuinely useful: it tells you what your workflow costs at API
+            prices (and therefore what your subscription is actually worth), which models eat your budget, and how
+            your usage compares to other people shipping with the same tools.
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            It also punctures some myths. Across the{" "}
+            <Link href="/stats">7.3 trillion tokens tracked on Viberank</Link>, about 95% are prompt-cache reads —
+            tokens that cost roughly a tenth of the normal input price. A terrifying-looking token count usually
+            translates to a much smaller bill, which is exactly the kind of thing you only learn by measuring.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Trophy className="w-8 h-8 text-accent" />
+            The public tokenmaxxing leaderboard
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            <Link href="/">Viberank</Link> is the opt-in, public version of the thing Meta tried to run internally:
+            1,000+ developers ranked by real, validated usage across{" "}
+            <Link href="/tool/claude">Claude Code</Link>, <Link href="/tool/codex">OpenAI Codex</Link>,{" "}
+            <Link href="/tool/gemini">Gemini CLI</Link>, <Link href="/tool/copilot">Copilot</Link> and every other
+            agent ccusage tracks — $6.6M in API-equivalent spend and counting. Spend earns a tier: Spark, Ember,
+            Flame ($1K+), Blaze ($5K+), Inferno ($15K+), Supernova ($50K+). Submissions are sanity-checked
+            server-side (token math, cost-per-token ratio bounds, date checks), and GitHub sign-in gets you a
+            verified badge.
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Every profile shows a GitHub-style activity heatmap, per-model spend, and daily streaks — a
+            scoreboard for the metric, plus the context that makes it honest.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Terminal className="w-8 h-8 text-accent" />
+            Measure your own tokenmaxxing
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">One command, read from your local logs:</p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx viberank-cli</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            It runs ccusage over Claude Code, Codex, Gemini CLI and friends, sums your real usage, and puts you on
+            the board. Your code and prompts never leave your machine — only the usage totals do. Curious what
+            normal looks like first? Start with{" "}
+            <Link href="/blog/how-much-does-claude-code-cost">what Claude Code actually costs</Link> or the{" "}
+            <Link href="/blog/state-of-ai-coding-2026">State of AI Coding Spend 2026</Link>.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6">Tokenmaxxing FAQ</h2>
+          <div className="space-y-6">
+            {FAQS.map((f) => (
+              <div key={f.q} className="bg-card border border-border rounded-lg p-5">
+                <h3 className="text-lg font-semibold text-foreground mt-0 mb-2">{f.q}</h3>
+                <p className="text-muted m-0">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,8 +16,8 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "Viberank - Claude Code, Codex & AI Coding Usage Leaderboard | Track AI Dev Stats",
-  description: "Track and compare AI coding usage — Claude Code, Codex, Gemini CLI and more — across developers. Upload your ccusage data, view detailed analytics, and see how you rank in the global AI-powered development community.",
-  keywords: ["claude", "claude code", "anthropic", "codex", "gemini cli", "github copilot", "opencode", "ccusage", "ai coding", "ai coding leaderboard", "leaderboard", "developer stats", "code usage", "ai development", "developer ranking", "cc.json", "npx viberank-cli", "vibe coding", "ai pair programming"],
+  description: "The public AI token leaderboard for vibe coding. Track Claude Code, OpenAI Codex, Gemini CLI and more with ccusage data — see real spend, tokens burned, and how your tokenmaxxing ranks against 1,000+ developers.",
+  keywords: ["claude", "claude code", "claude code leaderboard", "anthropic", "codex", "codex leaderboard", "codex token usage", "openai codex", "gemini cli", "github copilot", "opencode", "ccusage", "ai coding", "ai coding leaderboard", "ai token leaderboard", "token leaderboard", "tokenmaxxing", "token maxxing", "leaderboard", "developer stats", "code usage", "token usage tracker", "ai development", "developer ranking", "cc.json", "npx viberank-cli", "vibe coding", "vibe coding leaderboard", "ai pair programming"],
   authors: [{ name: "Viberank Team" }],
   creator: "Viberank",
   publisher: "Viberank",
@@ -79,7 +79,7 @@ export default function RootLayout({
       "@context": "https://schema.org",
       "@type": "WebApplication",
       "name": "Viberank",
-      "description": "Track and compare AI coding usage — Claude Code, Codex, Gemini CLI and more — across developers. View detailed analytics and climb the AI development leaderboard.",
+      "description": "The public AI token leaderboard for vibe coding — track Claude Code, OpenAI Codex, Gemini CLI and more with real ccusage data and see how your tokenmaxxing ranks.",
       "url": "https://www.viberank.app",
       "applicationCategory": "DeveloperApplication",
       "operatingSystem": "Any",

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -17,6 +17,8 @@ const staticEntries: MetadataRoute.Sitemap = [
   { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/stats`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
+  { url: `${SITE}/blog/what-is-tokenmaxxing`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
+  { url: `${SITE}/blog/codex-token-usage-leaderboard`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
   { url: `${SITE}/blog/state-of-ai-coding-2026`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
   { url: `${SITE}/blog/codex-vs-claude-code-vs-gemini-cli`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
   { url: `${SITE}/blog/how-much-does-claude-code-cost`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -30,6 +30,16 @@ export async function generateMetadata({ params }: ToolParams): Promise<Metadata
   return {
     title,
     description,
+    keywords: [
+      `${label.toLowerCase()} leaderboard`,
+      `${label.toLowerCase()} token usage`,
+      `${label.toLowerCase()} usage tracker`,
+      `how to check ${label.toLowerCase()} usage`,
+      "ccusage",
+      "ai token leaderboard",
+      "tokenmaxxing",
+      "vibe coding",
+    ],
     alternates: { canonical },
     openGraph: { title, description, url: canonical, siteName: "Viberank", type: "website" },
     twitter: { card: "summary_large_image", title, description },
@@ -62,6 +72,10 @@ export default async function ToolPage({ params }: ToolParams) {
     {
       q: `How is ${label} usage measured?`,
       a: `ccusage reads ${label}'s local logs and computes tokens and USD cost from model pricing. Viberank aggregates that per developer and ranks it.`,
+    },
+    {
+      q: `How do I check my ${label} token usage without submitting?`,
+      a: `Run npx ccusage@latest daily in your terminal — it parses ${label}'s local session logs into per-day token counts and API-equivalent costs, no account needed.`,
     },
   ];
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,8 @@ import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
 const RESOURCES = [
   { name: "Blog", href: "/blog" },
   { name: "Hire AI-native engineers", href: "/hire" },
+  { name: "What is tokenmaxxing?", href: "/blog/what-is-tokenmaxxing" },
+  { name: "Track Codex token usage", href: "/blog/codex-token-usage-leaderboard" },
   { name: "Codex vs Claude Code vs Gemini", href: "/blog/codex-vs-claude-code-vs-gemini-cli" },
   { name: "What Claude Code costs", href: "/blog/how-much-does-claude-code-cost" },
   { name: "Cut your AI coding bill", href: "/blog/reduce-ai-coding-costs" },

--- a/src/lib/home-faqs.ts
+++ b/src/lib/home-faqs.ts
@@ -18,6 +18,14 @@ export const HOME_FAQS = [
     a: "Submissions are validated server-side (token math, cost/token ratio, date sanity). Signing in with GitHub marks your submission verified with a blue check; unverified CLI rows show a 'cli' badge.",
   },
   {
+    q: "What is tokenmaxxing?",
+    a: "Tokenmaxxing is racking up AI token usage to climb a leaderboard — the trend that gave the world Meta's 'Claudeonomics' board and a Wikipedia entry. viberank is the public, opt-in version: real ccusage data, validated server-side, ranked openly instead of mandated by your employer.",
+  },
+  {
+    q: "How do I check my OpenAI Codex token usage?",
+    a: "Codex CLI logs sessions locally under ~/.codex. Run npx ccusage@latest daily to see per-day tokens and API-equivalent cost, or npx viberank-cli to submit it and see how you rank on the Codex leaderboard.",
+  },
+  {
     q: "What are viberank tiers?",
     a: "Every developer holds a spend tier based on their best submission: Spark ($0+), Ember ($100+), Flame ($1K+), Blaze ($5K+), Inferno ($15K+) and Supernova ($50K+). Tier badges appear on the leaderboard, your profile and your share card — and your profile shows exactly how far you are from the next tier.",
   },


### PR DESCRIPTION
Research-driven SEO pass targeting two keyword clusters we don't rank for yet.

## Why these terms
- **"tokenmaxxing"** went mainstream in mid-2026 — Pragmatic Engineer, CIO, LeadDev coverage, a Wikipedia entry, and the Meta "Claudeonomics" / Uber budget-burn stories. High search volume, directly our topic, and nobody owns the "public leaderboard" angle for it.
- **Codex-usage queries** ("codex token usage", "how to check codex usage", "codex leaderboard") have a crowded field of small competitors (codexti.me, sessionwatcher, ccclub) — we have more data (196 tracked Codex devs) and a real board to point at.

## New content
- **/blog/what-is-tokenmaxxing** — pillar post: definition, the corporate leaderboard saga (sourced), why targets failed but tracking works, viberank's live numbers ($6.6M, 7.3T tokens, 95% cache reads). BlogPosting + FAQPage JSON-LD.
- **/blog/codex-token-usage-leaderboard** — how-to: ccusage over ~/.codex logs, what API-equivalent cost means, join the Codex board. BlogPosting + FAQPage JSON-LD.

## Site-wide
- Homepage meta description, keywords, WebApplication JSON-LD, and hero copy now carry: tokenmaxxing, ai token leaderboard, codex leaderboard, claude code leaderboard, vibe coding leaderboard.
- Two new homepage FAQs (tokenmaxxing definition, Codex usage how-to) — feed the existing FAQPage JSON-LD.
- /tool/* pages: keyword meta + a fourth FAQ ("check your usage without submitting").
- Footer resource links + sitemap entries (priority 0.8) for both posts.

All numbers cited are from the live database (per-tool distinct-user counts, get_site_stats totals). Build passes with both routes prerendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)