### PR TITLE
feat: design upgrades — podium, stats trends, unified palette, OG heatmap

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -57,6 +57,9 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
   const days = searchParams.get('days');
   const streak = searchParams.get('streak');
   const tools = (searchParams.get('tools') || '').split(',').filter(Boolean);
+  // Mini contribution grid: one level digit (0–4) per day, oldest first,
+  // rendered column-per-week like the profile heatmap.
+  const hm = (searchParams.get('hm') || '').replace(/[^0-4]/g, '').slice(0, 112);
   const tier = getTier(cost);
   const costLabel =
     cost >= 1000 ? `$${(cost / 1000).toFixed(cost >= 10000 ? 0 : 1)}K` : `$${Math.round(cost)}`;
@@ -145,7 +148,8 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
             )}
           </div>
 
-          {/* identity */}
+          {/* identity + mini heatmap */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <div style={{ display: 'flex', alignItems: 'center', gap: 44 }}>
             {avatar ? (
               // eslint-disable-next-line @next/next/no-img-element
@@ -203,6 +207,37 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                 ))}
               </div>
             </div>
+          </div>
+
+          {hm.length >= 14 ? (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, alignItems: 'flex-end' }}>
+              <div style={{ display: 'flex', gap: 4 }}>
+                {Array.from({ length: Math.ceil(hm.length / 7) }, (_, w) => (
+                  <div key={w} style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    {Array.from({ length: 7 }, (_, d) => {
+                      const level = Number(hm[w * 7 + d] ?? 0);
+                      const fill = [
+                        '#1e1e23',
+                        'rgba(249,115,22,0.25)',
+                        'rgba(249,115,22,0.45)',
+                        'rgba(249,115,22,0.7)',
+                        '#f97316',
+                      ][level];
+                      return (
+                        <div
+                          key={d}
+                          style={{ display: 'flex', width: 13, height: 13, borderRadius: 3, backgroundColor: fill }}
+                        />
+                      );
+                    })}
+                  </div>
+                ))}
+              </div>
+              <span style={{ fontSize: 15, color: '#9a9aa5', fontFamily: 'Geist Mono', letterSpacing: 2 }}>
+                LAST 16 WEEKS
+              </span>
+            </div>
+          ) : null}
           </div>
 
           {/* stats + CTA */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -233,3 +233,28 @@ body {
 .btn-glow:hover {
   box-shadow: 0 4px 16px rgba(249, 115, 22, 0.25);
 }
+
+/* Instant CSS tooltip (heatmap cells etc.) — styled like the chart tooltip,
+   no client JS. Rendered below the element so it isn't clipped by the
+   scroll container's top edge. */
+[data-tip] {
+  position: relative;
+}
+
+[data-tip]:hover::after {
+  content: attr(data-tip);
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--foreground);
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+  z-index: 50;
+  pointer-events: none;
+}

--- a/src/app/profile/[username]/UsageChart.tsx
+++ b/src/app/profile/[username]/UsageChart.tsx
@@ -13,13 +13,8 @@ import {
   type TooltipProps,
 } from "recharts";
 import { formatCurrency, formatNumber } from "@/lib/utils";
+import { SERIES_COLORS, OTHER_COLOR } from "@/lib/chartColors";
 
-// Categorical palette for the dark surface (#0f0f12), validated with the
-// dataviz six-check script (lightness band, chroma floor, CVD separation,
-// normal-vision floor, contrast). Hues are assigned to models in fixed
-// order of total spend — a model keeps its color across range switches.
-const SERIES_COLORS = ["#d95926", "#3987e5", "#199e70", "#c98500", "#d55181", "#9085e9"];
-const OTHER_COLOR = "#6e6e78";
 const SURFACE = "#0f0f12";
 
 export const OTHER_KEY = "Other";

--- a/src/app/profile/[username]/layout.tsx
+++ b/src/app/profile/[username]/layout.tsx
@@ -65,6 +65,29 @@ export async function generateMetadata({ params }: ProfileParams): Promise<Metad
     );
     const daysActive = activeDates.size;
     const { current: streak } = computeStreaks(activeDates);
+
+    // Mini activity heatmap for the share card: last 112 days as one level
+    // digit (0–4) per day, oldest first. Quartile thresholds over the window's
+    // nonzero days, mirroring the profile page's calendar.
+    const costByDate = new Map<string, number>();
+    for (const s of profile.submissions) {
+      for (const d of s.dailyBreakdown ?? []) {
+        if (!costByDate.has(d.date)) costByDate.set(d.date, d.totalCost);
+      }
+    }
+    const DAY_MS = 86_400_000;
+    const todayUtc = Date.parse(`${new Date().toISOString().slice(0, 10)}T00:00:00Z`);
+    const windowCosts: number[] = [];
+    for (let i = 111; i >= 0; i--) {
+      const date = new Date(todayUtc - i * DAY_MS).toISOString().slice(0, 10);
+      windowCosts.push(costByDate.get(date) ?? 0);
+    }
+    const nonzero = windowCosts.filter((c) => c > 0).sort((a, b) => a - b);
+    const q = (p: number) => nonzero[Math.min(nonzero.length - 1, Math.floor(p * nonzero.length))] ?? 0;
+    const [q1, q2, q3] = [q(0.25), q(0.5), q(0.75)];
+    const heatmap = windowCosts
+      .map((c) => (c <= 0 ? 0 : c <= q1 ? 1 : c <= q2 ? 2 : c <= q3 ? 3 : 4))
+      .join("");
     const ogParams = new URLSearchParams({
       type: "profile",
       username: profile.githubUsername || profile.username,
@@ -76,6 +99,7 @@ export async function generateMetadata({ params }: ProfileParams): Promise<Metad
     if (daysActive > 0) ogParams.set("days", String(daysActive));
     if (streak > 1) ogParams.set("streak", String(streak));
     if (tools.length > 0) ogParams.set("tools", tools.slice(0, 4).join(","));
+    if (nonzero.length > 0) ogParams.set("hm", heatmap);
     // Content fingerprint: the URL changes whenever the underlying stats do,
     // so the OG route can serve versioned responses as immutable and crawlers
     // still pick up fresh cards after each submission.

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -16,6 +16,7 @@ import {
   BarChart3,
 } from "lucide-react";
 import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl, prettyModelName } from "@/lib/utils";
+import { seriesColor } from "@/lib/chartColors";
 import { getTierProgress } from "@/lib/tiers";
 import { computeStreaks } from "@/lib/streaks";
 import { getServerDataLayer } from "@/lib/data";
@@ -495,10 +496,13 @@ export default async function ProfilePage({ params }: ProfileParams) {
                   <span className="micro-label">{hasModelCosts ? "by cost" : "by days used"}</span>
                 </div>
                 <div className="space-y-3">
-                  {topModels.map(([name, value]) => (
+                  {topModels.map(([name, value], i) => (
                     <div key={name}>
                       <div className="flex justify-between items-center mb-1.5 gap-2">
-                        <span className="text-xs font-mono truncate">{name}</span>
+                        <span className="flex items-center gap-1.5 text-xs font-mono truncate">
+                          <span className="w-2 h-2 rounded-[2px] flex-shrink-0" style={{ background: seriesColor(i) }} />
+                          {name}
+                        </span>
                         <span className="font-mono text-xs text-muted flex-shrink-0">
                           {hasModelCosts ? `$${formatCurrency(value)}` : `${value}d`}
                           <span className="text-muted/60"> · {Math.round((value / modelTotal) * 100)}%</span>
@@ -506,8 +510,8 @@ export default async function ProfilePage({ params }: ProfileParams) {
                       </div>
                       <div className="w-full bg-surface-3 rounded-full h-1.5">
                         <div
-                          className="bg-accent h-1.5 rounded-full"
-                          style={{ width: `${Math.max((value / modelTotal) * 100, 1)}%` }}
+                          className="h-1.5 rounded-full"
+                          style={{ width: `${Math.max((value / modelTotal) * 100, 1)}%`, background: seriesColor(i) }}
                         />
                       </div>
                     </div>
@@ -539,18 +543,21 @@ export default async function ProfilePage({ params }: ProfileParams) {
                   <span className="micro-label">by active days</span>
                 </div>
                 <div className="space-y-3">
-                  {toolEntries.map(([tool, days]) => (
+                  {toolEntries.map(([tool, days], i) => (
                     <div key={tool}>
                       <div className="flex justify-between items-center mb-1.5">
-                        <span className="text-xs font-medium">{toolLabel(tool)}</span>
+                        <span className="flex items-center gap-1.5 text-xs font-medium">
+                          <span className="w-2 h-2 rounded-[2px] flex-shrink-0" style={{ background: seriesColor(i) }} />
+                          {toolLabel(tool)}
+                        </span>
                         <span className="font-mono text-xs text-muted">
                           {days}d <span className="text-muted/60">· {Math.round((days / daysActive) * 100)}%</span>
                         </span>
                       </div>
                       <div className="w-full bg-surface-3 rounded-full h-1.5">
                         <div
-                          className="bg-blue-500 h-1.5 rounded-full"
-                          style={{ width: `${Math.max((days / daysActive) * 100, 1)}%` }}
+                          className="h-1.5 rounded-full"
+                          style={{ width: `${Math.max((days / daysActive) * 100, 1)}%`, background: seriesColor(i) }}
                         />
                       </div>
                     </div>

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft, BarChart3, Cpu, DollarSign, Users, Wrench, Zap, CalendarDays, Database } from "lucide-react";
+import { ArrowLeft, BarChart3, Cpu, DollarSign, Users, Wrench, Zap, CalendarDays, Database, Flame } from "lucide-react";
 import { formatNumber, formatCurrency, toolLabel, prettyModelName } from "@/lib/utils";
+import { seriesColor } from "@/lib/chartColors";
+import { TIERS } from "@/lib/tiers";
 import { getServerDataLayer } from "@/lib/data";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
@@ -52,23 +54,27 @@ function StatTile({
 function BarList({
   rows,
   format,
-  barClass = "bg-accent",
 }: {
   rows: { label: string; value: number }[];
   format: (value: number) => string;
-  barClass?: string;
 }) {
   const max = Math.max(...rows.map((r) => r.value), 1);
   return (
     <div className="space-y-3">
-      {rows.map(({ label, value }) => (
+      {rows.map(({ label, value }, i) => (
         <div key={label}>
           <div className="flex justify-between items-center mb-1.5 gap-2">
-            <span className="text-xs font-mono truncate">{label}</span>
+            <span className="flex items-center gap-1.5 text-xs font-mono truncate">
+              <span className="w-2 h-2 rounded-[2px] flex-shrink-0" style={{ background: seriesColor(i) }} />
+              {label}
+            </span>
             <span className="font-mono text-xs text-muted flex-shrink-0">{format(value)}</span>
           </div>
           <div className="w-full bg-surface-3 rounded-full h-1.5">
-            <div className={`${barClass} h-1.5 rounded-full`} style={{ width: `${Math.max((value / max) * 100, 1)}%` }} />
+            <div
+              className="h-1.5 rounded-full"
+              style={{ width: `${Math.max((value / max) * 100, 1)}%`, background: seriesColor(i) }}
+            />
           </div>
         </div>
       ))}
@@ -124,6 +130,15 @@ export default async function StatsPage() {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 10);
   const toolRows = (site?.tools ?? []).slice(0, 10);
+
+  const monthly = (site?.monthly ?? []).map((m) => ({ ...m, cost: Number(m.cost) }));
+  const maxMonthlyCost = Math.max(...monthly.map((m) => m.cost), 1);
+  const monthLabel = (ym: string) => {
+    const [y, m] = ym.split("-").map(Number);
+    return `${["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"][m - 1]} '${String(y).slice(2)}`;
+  };
+  const tierCounts = new Map((site?.tiers ?? []).map((t) => [t.tier, t.users]));
+  const tierTotal = (site?.tiers ?? []).reduce((s, t) => s + t.users, 0);
 
   return (
     <div className="min-h-screen bg-background">
@@ -208,6 +223,80 @@ export default async function StatsPage() {
           </div>
         )}
 
+        {/* Monthly trend + tier distribution */}
+        {(monthly.length > 1 || tierTotal > 0) && (
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mb-4">
+            {monthly.length > 1 && (
+              <div className="bg-surface-1 border border-border rounded-lg p-5 lg:col-span-2">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-base font-medium flex items-center gap-2">
+                    <BarChart3 className="w-4 h-4 text-accent" />
+                    Monthly spend
+                  </h2>
+                  <span className="micro-label">last {monthly.length} months · all developers</span>
+                </div>
+                <div className="flex items-end gap-1.5 sm:gap-2 h-44">
+                  {monthly.map((m, i) => (
+                    <div
+                      key={m.month}
+                      data-tip={`${monthLabel(m.month)} · $${formatNumber(m.cost)} · ${m.users} devs`}
+                      className="flex-1 flex flex-col items-center justify-end gap-1.5 min-w-0 h-full"
+                    >
+                      <div
+                        className="w-full bg-accent/80 hover:bg-accent transition-colors rounded-t-sm"
+                        style={{ height: `${Math.max((m.cost / maxMonthlyCost) * 130, 3)}px` }}
+                      />
+                      <span className={`text-[9px] font-mono text-muted/70 truncate ${i % 2 === 1 ? "invisible sm:visible" : ""}`}>
+                        {monthLabel(m.month)}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {tierTotal > 0 && (
+              <div className="bg-surface-1 border border-border rounded-lg p-5">
+                <div className="flex items-center justify-between mb-4">
+                  <h2 className="text-base font-medium flex items-center gap-2">
+                    <Flame className="w-4 h-4 text-accent" />
+                    Tier ladder
+                  </h2>
+                  <span className="micro-label">by best submission</span>
+                </div>
+                <div className="flex h-2 rounded-full overflow-hidden mb-4">
+                  {TIERS.map((t) => {
+                    const users = tierCounts.get(t.key) ?? 0;
+                    if (users === 0) return null;
+                    return (
+                      <div
+                        key={t.key}
+                        style={{ width: `${(users / tierTotal) * 100}%`, background: t.color, minWidth: 3 }}
+                      />
+                    );
+                  })}
+                </div>
+                <div className="space-y-2">
+                  {[...TIERS].reverse().map((t) => {
+                    const users = tierCounts.get(t.key) ?? 0;
+                    return (
+                      <div key={t.key} className="flex items-center justify-between font-mono text-xs">
+                        <span style={{ color: t.color }}>
+                          {t.glyph} {t.name.toUpperCase()}
+                        </span>
+                        <span className="text-muted">
+                          {formatNumber(users)}
+                          <span className="text-muted/60"> · {tierTotal > 0 ? Math.round((users / tierTotal) * 100) : 0}%</span>
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Models + tools */}
         {(topModelUsers.length > 0 || topModelSpend.length > 0 || toolRows.length > 0) && (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
@@ -249,7 +338,6 @@ export default async function StatsPage() {
                 <BarList
                   rows={toolRows.map((t) => ({ label: toolLabel(t.tool), value: t.users }))}
                   format={(v) => `${formatNumber(v)} devs`}
-                  barClass="bg-blue-500"
                 />
               </div>
             )}

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -113,7 +113,7 @@ export default function ActivityHeatmap({ daily }: ActivityHeatmapProps) {
             ) : (
               <span
                 key={date}
-                title={`${date}: $${formatCurrency(cost)}`}
+                data-tip={`${date} · $${formatCurrency(cost)}`}
                 className={`w-full aspect-square rounded-[2px] ${LEVEL_CLASSES[level]}`}
               />
             )

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -12,7 +12,7 @@ import Avatar from "./Avatar";
 import SponsorSlot from "./SponsorSlot";
 import TierBadge from "./TierBadge";
 import { TIERS } from "@/lib/tiers";
-import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
+import { formatNumber, formatCurrency, toolLabel, sizedAvatarUrl, getGitHubAvatarUrl } from "@/lib/utils";
 import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useSubmissions";
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
 import type { Submission, GlobalStats } from "@/lib/data/types";
@@ -332,16 +332,22 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
               >
                 <div className="relative">
                   <div
-                    className={`rounded-full ${first ? "w-20 h-20" : "w-14 h-14"} overflow-hidden`}
+                    className={`rounded-full ${first ? "w-20 h-20" : "w-14 h-14"} overflow-hidden bg-surface-3`}
                     style={{ boxShadow: `0 0 0 2px ${medal}, 0 0 ${first ? 28 : 16}px ${medal}33` }}
                   >
-                    <Avatar
-                      src={s.githubAvatar}
-                      githubUsername={s.githubUsername}
-                      name={s.githubName || s.username}
-                      size={first ? "lg" : "md"}
-                      priority
-                      className="!w-full !h-full"
+                    {/* Plain img so it fills the medal ring exactly — Avatar
+                        carries its own fixed size classes. */}
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={
+                        s.githubAvatar
+                          ? sizedAvatarUrl(s.githubAvatar, 160)
+                          : getGitHubAvatarUrl(s.githubUsername || s.username, 160)
+                      }
+                      alt={s.githubUsername || s.username}
+                      loading="eager"
+                      decoding="async"
+                      className="w-full h-full object-cover"
                     />
                   </div>
                   <span

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -317,6 +317,62 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
 
       <SponsorSlot />
 
+      {/* Top-3 podium — only on the unfiltered board, where ranks are global */}
+      {!tool && !verifiedOnly && !isDateFiltered && allItems.length >= 3 && (
+        <div className="flex items-end justify-center gap-4 sm:gap-10 mb-8 pt-2">
+          {[allItems[1], allItems[0], allItems[2]].map((s, col) => {
+            const rank = col === 1 ? 1 : col === 0 ? 2 : 3;
+            const medal = rank === 1 ? "#f5b008" : rank === 2 ? "#b8bcc4" : "#c2703f";
+            const first = rank === 1;
+            return (
+              <Link
+                key={s.id}
+                href={`/profile/${encodeURIComponent(s.githubUsername || s.username)}`}
+                className={`group flex flex-col items-center text-center ${first ? "" : "mb-1 sm:mb-2"}`}
+              >
+                <div className="relative">
+                  <div
+                    className={`rounded-full ${first ? "w-20 h-20" : "w-14 h-14"} overflow-hidden`}
+                    style={{ boxShadow: `0 0 0 2px ${medal}, 0 0 ${first ? 28 : 16}px ${medal}33` }}
+                  >
+                    <Avatar
+                      src={s.githubAvatar}
+                      githubUsername={s.githubUsername}
+                      name={s.githubName || s.username}
+                      size={first ? "lg" : "md"}
+                      priority
+                      className="!w-full !h-full"
+                    />
+                  </div>
+                  <span
+                    className="absolute -bottom-2 left-1/2 -translate-x-1/2 font-mono text-[10px] font-bold px-1.5 py-px rounded-full bg-background border"
+                    style={{ color: medal, borderColor: medal }}
+                  >
+                    {rank}
+                  </span>
+                </div>
+                <span className={`mt-3.5 font-medium truncate max-w-[7rem] sm:max-w-[10rem] group-hover:text-accent transition-colors ${first ? "text-sm" : "text-xs"}`}>
+                  {s.githubUsername || s.username}
+                </span>
+                <span className={`font-mono font-semibold text-accent ${first ? "text-base" : "text-sm"}`}>
+                  {sortBy === "tokens" ? (
+                    <>
+                      {formatNumber(s.totalTokens)}
+                      <span className="text-muted text-[10px] font-normal"> tok</span>
+                    </>
+                  ) : (
+                    <>${formatNumber(s.totalCost)}</>
+                  )}
+                </span>
+                <span className="mt-1">
+                  <TierBadge totalCost={s.totalCost} size="xs" bare />
+                </span>
+              </Link>
+            );
+          })}
+        </div>
+      )}
+
       {/* Tier ladder key — desktop gets the sidebar ladder instead */}
       <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 mb-5 px-0.5 lg:hidden">
         <span className="micro-label">Tiers</span>

--- a/src/lib/chartColors.ts
+++ b/src/lib/chartColors.ts
@@ -1,0 +1,15 @@
+// Categorical palette for the dark surface (#0f0f12), validated with the
+// dataviz six-check script (lightness band, chroma floor, CVD separation,
+// normal-vision floor, contrast vs surface). Used everywhere a series needs
+// identity — the stacked usage chart, model bar lists, tool bar lists — so a
+// model keeps one color across the whole site. Assign by list rank, never
+// cycled past OTHER.
+export const SERIES_COLORS = ["#d95926", "#3987e5", "#199e70", "#c98500", "#d55181", "#9085e9"];
+
+/** Neutral bucket for "everything else" — never a categorical hue. */
+export const OTHER_COLOR = "#6e6e78";
+
+/** Color for the nth-ranked series in a list; overflow folds into gray. */
+export function seriesColor(index: number): string {
+  return index < SERIES_COLORS.length ? SERIES_COLORS[index] : OTHER_COLOR;
+}

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -218,6 +218,10 @@ export interface SiteStats {
   firstDate: string | null;
   lastDate: string | null;
   activeDays: number;
+  /** 12-month site-wide rollup (migration 008); absent before it's applied. */
+  monthly?: { month: string; cost: number; users: number }[];
+  /** Developers per spend tier, bucketed on best submission (migration 008). */
+  tiers?: { tier: string; users: number }[];
   tools: { tool: string; users: number }[];
   models: { model: string; users: number }[];
   modelSpend: { model: string; cost: number }[];

--- a/supabase/migrations/008_site_stats_monthly_tiers.sql
+++ b/supabase/migrations/008_site_stats_monthly_tiers.sql
@@ -1,0 +1,106 @@
+-- Migration 008: monthly trend + tier distribution for /stats.
+--
+-- Extends get_site_stats() (007) with two aggregates the page can't derive
+-- client-side: a 12-month site-wide spend/active-devs rollup and the count of
+-- developers per spend tier (bucketed on each user's best submission, the
+-- same rule the UI's tier badges use). Everything else is unchanged from 007.
+
+CREATE OR REPLACE FUNCTION get_site_stats()
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT jsonb_build_object(
+    'totalUsers', (SELECT COUNT(*) FROM profiles),
+    'totalSubmissions', (SELECT COUNT(*) FROM submissions WHERE flagged_for_review IS NOT TRUE),
+    'totalCost', COALESCE((SELECT SUM(total_cost) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'totalTokens', COALESCE((SELECT SUM(total_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'inputTokens', COALESCE((SELECT SUM(input_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'outputTokens', COALESCE((SELECT SUM(output_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'cacheReadTokens', COALESCE((SELECT SUM(cache_read_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'cacheCreationTokens', COALESCE((SELECT SUM(cache_creation_tokens) FROM submissions WHERE flagged_for_review IS NOT TRUE), 0),
+    'firstDate', (SELECT MIN(date_range_start) FROM submissions WHERE flagged_for_review IS NOT TRUE),
+    'lastDate', (SELECT MAX(date_range_end) FROM submissions WHERE flagged_for_review IS NOT TRUE),
+    'activeDays', (
+      SELECT COUNT(DISTINCT d.date)
+      FROM daily_breakdowns d
+      JOIN submissions s ON s.id = d.submission_id
+      WHERE s.flagged_for_review IS NOT TRUE
+    ),
+    'monthly', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('month', month, 'cost', cost, 'users', users) ORDER BY month)
+      FROM (
+        SELECT to_char(d.date, 'YYYY-MM') AS month,
+               SUM(d.total_cost) AS cost,
+               COUNT(DISTINCT s.username) AS users
+        FROM daily_breakdowns d
+        JOIN submissions s ON s.id = d.submission_id
+        WHERE s.flagged_for_review IS NOT TRUE
+        GROUP BY 1
+        ORDER BY 1 DESC
+        LIMIT 12
+      ) x
+    ), '[]'::jsonb),
+    'tiers', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('tier', tier, 'users', users))
+      FROM (
+        SELECT CASE
+                 WHEN best >= 50000 THEN 'supernova'
+                 WHEN best >= 15000 THEN 'inferno'
+                 WHEN best >= 5000  THEN 'blaze'
+                 WHEN best >= 1000  THEN 'flame'
+                 WHEN best >= 100   THEN 'ember'
+                 ELSE 'spark'
+               END AS tier,
+               COUNT(*) AS users
+        FROM (
+          SELECT username, MAX(total_cost) AS best
+          FROM submissions
+          WHERE flagged_for_review IS NOT TRUE
+          GROUP BY 1
+        ) u
+        GROUP BY 1
+      ) x
+    ), '[]'::jsonb),
+    'tools', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('tool', tool, 'users', users) ORDER BY users DESC)
+      FROM (
+        SELECT t.tool, COUNT(DISTINCT s.username) AS users
+        FROM submissions s, unnest(s.tools) AS t(tool)
+        WHERE s.flagged_for_review IS NOT TRUE
+        GROUP BY t.tool
+      ) x
+    ), '[]'::jsonb),
+    'models', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('model', model, 'users', users) ORDER BY users DESC)
+      FROM (
+        SELECT m.model, COUNT(DISTINCT s.username) AS users
+        FROM submissions s, unnest(s.models_used) AS m(model)
+        WHERE s.flagged_for_review IS NOT TRUE
+          AND m.model IS NOT NULL AND m.model <> ''
+        GROUP BY m.model
+        ORDER BY COUNT(DISTINCT s.username) DESC
+        LIMIT 20
+      ) x
+    ), '[]'::jsonb),
+    'modelSpend', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('model', model, 'cost', cost) ORDER BY cost DESC)
+      FROM (
+        SELECT mb->>'modelName' AS model, SUM((mb->>'cost')::numeric) AS cost
+        FROM daily_breakdowns d
+        JOIN submissions s ON s.id = d.submission_id,
+        LATERAL jsonb_array_elements(d.model_breakdowns) mb
+        WHERE s.flagged_for_review IS NOT TRUE
+          AND d.model_breakdowns IS NOT NULL
+          AND mb->>'modelName' IS NOT NULL
+        GROUP BY 1
+        ORDER BY 2 DESC
+        LIMIT 20
+      ) x
+    ), '[]'::jsonb)
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION get_site_stats() TO anon, authenticated, service_role;


### PR DESCRIPTION
Six design upgrades across the visible pages.

## Leaderboard
- **Top-3 podium** above the table: medal-ringed avatars (gold/silver/bronze glow, #1 elevated) with spend and tier badge. Hidden when any filter is active, since ranks are only global on the default view.

## Color system
- The validated 6-color categorical palette moves to `lib/chartColors` and now colors the profile **Models/Tools** bar lists and the /stats **Popular models / Top models / Tools** lists (with legend chips) — a series keeps one identity from the stacked chart to every list on the site.

## /stats (migration 008)
- **Monthly spend trend** — 12-month site-wide rollup (cost + active devs) as a bar chart with hover tooltips. Live data shows the hockey stick: $2.1M in July alone.
- **Tier ladder distribution** — segmented tier-colored bar + per-tier counts (373 Flame · 290 Ember · 155 Blaze · 79 Inferno · 21 Supernova · 85 Spark).
- `get_site_stats()` extended with `monthly` and `tiers`; **already applied to prod** (verified via anon RPC) and tested end-to-end on a throwaway Postgres. Page degrades gracefully if absent.

## OG share card
- **Mini activity heatmap** — the last 16 weeks render as a contribution grid next to the identity block. Every shared profile is now visually distinctive.

## Heatmap tooltips
- Native `title` tooltips replaced with instant CSS `data-tip` tooltips styled like the chart tooltip — no client JS.

All verified visually on a local prod build (podium, stats trend/tier bar, colored lists, OG PNG render). `pnpm test` + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)