### PR TITLE
feat(og): add a light theme to the profile share card

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -102,7 +102,7 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
           height="460"
           viewBox="0 0 24 24"
           fill="none"
-          style={{ position: 'absolute', right: -60, bottom: -90, opacity: 0.07 }}
+          style={{ position: 'absolute', right: -170, bottom: -200, opacity: 0.05 }}
         >
           <rect x="3" y="14" width="5" height="7" rx="1" fill={tier.color} opacity="0.5" />
           <rect x="9.5" y="8" width="5" height="13" rx="1" fill={tier.color} opacity="0.75" />
@@ -138,11 +138,19 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                   borderRadius: 14,
                 }}
               >
-                <span style={{ fontSize: 46, fontWeight: 700, color: '#f97316', fontFamily: 'Geist Mono' }}>
+                <span style={{ fontSize: 40, fontWeight: 700, color: '#f97316', fontFamily: 'Geist Mono' }}>
                   #{rank}
                 </span>
-                <span style={{ fontSize: 19, color: '#9a9aa5', fontFamily: 'Geist Mono', letterSpacing: 3 }}>
-                  GLOBAL
+                <span
+                  style={{
+                    fontSize: 40,
+                    fontWeight: 700,
+                    color: '#c4c4cf',
+                    fontFamily: 'Geist Mono',
+                    letterSpacing: 1,
+                  }}
+                >
+                  GLOBAL RANK
                 </span>
               </div>
             )}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -61,6 +61,28 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
   // rendered column-per-week like the profile heatmap.
   const hm = (searchParams.get('hm') || '').replace(/[^0-4]/g, '').slice(0, 112);
   const tier = getTier(cost);
+  // Dark stays the default — the card is mostly seen as a social preview, and
+  // that is what every existing share URL renders. `theme=light` exists so the
+  // same card can sit in a light-mode README without punching an opaque black
+  // rectangle into the page.
+  const light = searchParams.get('theme') === 'light';
+  const c = {
+    bg: light ? '#ffffff' : '#0a0a0c',
+    // Gradient stops fade to the page colour, not to transparent black.
+    bgFade: light ? 'rgba(255,255,255,0)' : 'rgba(10,10,12,0)',
+    fg: light ? '#09090b' : '#fafafa',
+    muted: light ? '#52525b' : '#9a9aa5',
+    badgeLabel: light ? '#3f3f46' : '#c4c4cf',
+    surface: light ? '#f4f4f5' : '#16161a',
+    border: light ? '#e4e4e7' : '#26262d',
+    heatEmpty: light ? '#ebedf0' : '#1e1e23',
+    // orange-500 is only ~3:1 on white, so light mode drops to orange-600.
+    accent: light ? '#ea580c' : '#f97316',
+    accentSoft: light ? 'rgba(234, 88, 12, 0.10)' : 'rgba(249, 115, 22, 0.10)',
+    accentBorder: light ? 'rgba(234, 88, 12, 0.35)' : 'rgba(249, 115, 22, 0.35)',
+    tier: light ? tier.colorOnLight : tier.color,
+    watermark: light ? 0.06 : 0.05,
+  };
   const costLabel =
     cost >= 1000 ? `$${(cost / 1000).toFixed(cost >= 10000 ? 0 : 1)}K` : `$${Math.round(cost)}`;
   const fonts = await getFonts();
@@ -71,7 +93,7 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
       <span
         style={{
           fontSize: 19,
-          color: '#9a9aa5',
+          color: c.muted,
           fontFamily: 'Geist Mono',
           letterSpacing: 3,
           marginTop: 4,
@@ -90,8 +112,8 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
           width: '100%',
           display: 'flex',
           flexDirection: 'column',
-          backgroundColor: '#0a0a0c',
-          backgroundImage: `radial-gradient(circle at 85% 8%, ${tier.soft.replace('0.1', '0.2')} 0%, rgba(10,10,12,0) 45%), radial-gradient(circle at 0% 100%, rgba(249,115,22,0.10) 0%, rgba(10,10,12,0) 40%)`,
+          backgroundColor: c.bg,
+          backgroundImage: `radial-gradient(circle at 85% 8%, ${tier.soft.replace('0.1', '0.2')} 0%, ${c.bgFade} 45%), radial-gradient(circle at 0% 100%, rgba(249,115,22,0.10) 0%, ${c.bgFade} 40%)`,
           fontFamily: 'Geist',
           position: 'relative',
         }}
@@ -102,11 +124,11 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
           height="460"
           viewBox="0 0 24 24"
           fill="none"
-          style={{ position: 'absolute', right: -170, bottom: -200, opacity: 0.05 }}
+          style={{ position: 'absolute', right: -170, bottom: -200, opacity: c.watermark }}
         >
-          <rect x="3" y="14" width="5" height="7" rx="1" fill={tier.color} opacity="0.5" />
-          <rect x="9.5" y="8" width="5" height="13" rx="1" fill={tier.color} opacity="0.75" />
-          <rect x="16" y="3" width="5" height="18" rx="1" fill={tier.color} />
+          <rect x="3" y="14" width="5" height="7" rx="1" fill={c.tier} opacity="0.5" />
+          <rect x="9.5" y="8" width="5" height="13" rx="1" fill={c.tier} opacity="0.75" />
+          <rect x="16" y="3" width="5" height="18" rx="1" fill={c.tier} />
         </svg>
 
         <div
@@ -122,7 +144,7 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
               <Logo size={40} />
-              <span style={{ fontSize: 34, fontWeight: 700, color: '#fafafa', fontFamily: 'Geist Mono' }}>
+              <span style={{ fontSize: 34, fontWeight: 700, color: c.fg, fontFamily: 'Geist Mono' }}>
                 viberank
               </span>
             </div>
@@ -133,19 +155,19 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                   alignItems: 'baseline',
                   gap: 12,
                   padding: '10px 30px',
-                  backgroundColor: 'rgba(249, 115, 22, 0.10)',
-                  border: '1px solid rgba(249, 115, 22, 0.35)',
+                  backgroundColor: c.accentSoft,
+                  border: `1px solid ${c.accentBorder}`,
                   borderRadius: 14,
                 }}
               >
-                <span style={{ fontSize: 40, fontWeight: 700, color: '#f97316', fontFamily: 'Geist Mono' }}>
+                <span style={{ fontSize: 40, fontWeight: 700, color: c.accent, fontFamily: 'Geist Mono' }}>
                   #{rank}
                 </span>
                 <span
                   style={{
                     fontSize: 40,
                     fontWeight: 700,
-                    color: '#c4c4cf',
+                    color: c.badgeLabel,
                     fontFamily: 'Geist Mono',
                     letterSpacing: 1,
                   }}
@@ -168,13 +190,13 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                 height={172}
                 style={{
                   borderRadius: 86,
-                  border: `5px solid ${tier.color}`,
+                  border: `5px solid ${c.tier}`,
                   boxShadow: `0 0 60px ${tier.soft.replace('0.1', '0.5')}`,
                 }}
               />
             ) : null}
             <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-              <span style={{ fontSize: 72, fontWeight: 700, color: '#fafafa', lineHeight: 1 }}>
+              <span style={{ fontSize: 72, fontWeight: 700, color: c.fg, lineHeight: 1 }}>
                 {username}
               </span>
               <div style={{ display: 'flex', alignItems: 'center', gap: 14 }}>
@@ -184,13 +206,13 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                     padding: '8px 22px',
                     borderRadius: 10,
                     backgroundColor: tier.soft,
-                    border: `1px solid ${tier.color}`,
+                    border: `1px solid ${c.tier}`,
                   }}
                 >
                   <span
                     style={{
                       fontSize: 24,
-                      color: tier.color,
+                      color: c.tier,
                       fontWeight: 700,
                       letterSpacing: 6,
                       fontFamily: 'Geist Mono',
@@ -206,11 +228,11 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                       display: 'flex',
                       padding: '8px 18px',
                       borderRadius: 10,
-                      backgroundColor: '#16161a',
-                      border: '1px solid #26262d',
+                      backgroundColor: c.surface,
+                      border: `1px solid ${c.border}`,
                     }}
                   >
-                    <span style={{ fontSize: 20, color: '#9a9aa5', fontFamily: 'Geist Mono' }}>{t}</span>
+                    <span style={{ fontSize: 20, color: c.muted, fontFamily: 'Geist Mono' }}>{t}</span>
                   </div>
                 ))}
               </div>
@@ -225,11 +247,11 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                     {Array.from({ length: 7 }, (_, d) => {
                       const level = Number(hm[w * 7 + d] ?? 0);
                       const fill = [
-                        '#1e1e23',
+                        c.heatEmpty,
                         'rgba(249,115,22,0.25)',
                         'rgba(249,115,22,0.45)',
                         'rgba(249,115,22,0.7)',
-                        '#f97316',
+                        c.accent,
                       ][level];
                       return (
                         <div
@@ -241,7 +263,7 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                   </div>
                 ))}
               </div>
-              <span style={{ fontSize: 15, color: '#9a9aa5', fontFamily: 'Geist Mono', letterSpacing: 2 }}>
+              <span style={{ fontSize: 15, color: c.muted, fontFamily: 'Geist Mono', letterSpacing: 2 }}>
                 LAST 16 WEEKS
               </span>
             </div>
@@ -251,10 +273,10 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
           {/* stats + CTA */}
           <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
             <div style={{ display: 'flex', gap: streak ? 56 : 72 }}>
-              {stat(costLabel, 'AI CODING USAGE', '#f97316')}
-              {tokens ? stat(tokens, 'TOKENS', '#fafafa') : null}
-              {days ? stat(days, 'ACTIVE DAYS', '#fafafa') : null}
-              {streak ? stat(`${streak}d`, 'STREAK', tier.color) : null}
+              {stat(costLabel, 'AI CODING USAGE', c.accent)}
+              {tokens ? stat(tokens, 'TOKENS', c.fg) : null}
+              {days ? stat(days, 'ACTIVE DAYS', c.fg) : null}
+              {streak ? stat(`${streak}d`, 'STREAK', c.tier) : null}
             </div>
             <div
               style={{
@@ -262,13 +284,13 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                 alignItems: 'center',
                 gap: 10,
                 padding: '12px 24px',
-                backgroundColor: '#16161a',
-                border: '1px solid #26262d',
+                backgroundColor: c.surface,
+                border: `1px solid ${c.border}`,
                 borderRadius: 10,
               }}
             >
-              <span style={{ fontSize: 22, color: '#9a9aa5', fontFamily: 'Geist Mono' }}>$</span>
-              <span style={{ fontSize: 22, color: '#f97316', fontFamily: 'Geist Mono', fontWeight: 700 }}>
+              <span style={{ fontSize: 22, color: c.muted, fontFamily: 'Geist Mono' }}>$</span>
+              <span style={{ fontSize: 22, color: c.accent, fontFamily: 'Geist Mono', fontWeight: 700 }}>
                 npx viberank-cli
               </span>
             </div>
@@ -281,7 +303,7 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
             display: 'flex',
             height: 8,
             width: '100%',
-            backgroundImage: `linear-gradient(90deg, #f97316 0%, ${tier.color} 100%)`,
+            backgroundImage: `linear-gradient(90deg, ${c.accent} 0%, ${c.tier} 100%)`,
           }}
         />
       </div>

--- a/src/lib/tiers.ts
+++ b/src/lib/tiers.ts
@@ -11,18 +11,24 @@ export interface Tier {
   min: number;
   /** Text color on dark surfaces. */
   color: string;
+  /**
+   * Text color on light surfaces. The dark-surface colors are tuned for
+   * contrast against #0a0a0c, so the brighter tiers — Blaze at #fbbf24,
+   * Supernova at #dbeafe — wash out or vanish on white.
+   */
+  colorOnLight: string;
   /** Translucent badge background. */
   soft: string;
 }
 
 // Ascending order — getTier walks this from the top down.
 export const TIERS: Tier[] = [
-  { key: "spark", name: "Spark", glyph: "✧", min: 0, color: "#9aa0a8", soft: "rgba(154, 160, 168, 0.12)" },
-  { key: "ember", name: "Ember", glyph: "✦", min: 100, color: "#c2703f", soft: "rgba(194, 112, 63, 0.14)" },
-  { key: "flame", name: "Flame", glyph: "◆", min: 1_000, color: "#f97316", soft: "rgba(249, 115, 22, 0.14)" },
-  { key: "blaze", name: "Blaze", glyph: "❖", min: 5_000, color: "#fbbf24", soft: "rgba(251, 191, 36, 0.13)" },
-  { key: "inferno", name: "Inferno", glyph: "✶", min: 15_000, color: "#f87171", soft: "rgba(248, 113, 113, 0.13)" },
-  { key: "supernova", name: "Supernova", glyph: "✺", min: 50_000, color: "#dbeafe", soft: "rgba(191, 219, 254, 0.14)" },
+  { key: "spark", name: "Spark", glyph: "✧", min: 0, color: "#9aa0a8", colorOnLight: "#52525b", soft: "rgba(154, 160, 168, 0.12)" },
+  { key: "ember", name: "Ember", glyph: "✦", min: 100, color: "#c2703f", colorOnLight: "#92400e", soft: "rgba(194, 112, 63, 0.14)" },
+  { key: "flame", name: "Flame", glyph: "◆", min: 1_000, color: "#f97316", colorOnLight: "#c2410c", soft: "rgba(249, 115, 22, 0.14)" },
+  { key: "blaze", name: "Blaze", glyph: "❖", min: 5_000, color: "#fbbf24", colorOnLight: "#b45309", soft: "rgba(251, 191, 36, 0.13)" },
+  { key: "inferno", name: "Inferno", glyph: "✶", min: 15_000, color: "#f87171", colorOnLight: "#dc2626", soft: "rgba(248, 113, 113, 0.13)" },
+  { key: "supernova", name: "Supernova", glyph: "✺", min: 50_000, color: "#dbeafe", colorOnLight: "#1d4ed8", soft: "rgba(191, 219, 254, 0.14)" },
 ];
 
 export function getTier(totalCost: number): Tier {


### PR DESCRIPTION
Stacked on top of #89 — that one touches the same badge markup, so this branches off it
rather than off `main`. The diff below therefore includes #89's commit; it drops out once
#89 merges. Happy to rebase onto `main` instead if you'd rather take this one first.

## Why

The profile card renders one opaque dark surface (`#0a0a0c`). That's the right default
for a social preview, but it's currently the *only* option, so a light-mode GitHub README
that embeds the card gets an opaque black rectangle sitting in the page.

This can't be fixed on the embedding side: GitHub strips `style` attributes from markdown,
so there's no way to give the image a background, border, or rounding from the README. It
has to come from the endpoint.

## What

Adds `theme=light`. **Dark stays the default**, so every existing share URL — including
every `og:image` already emitted by profile pages — renders byte-identically to before.

Colours move into a palette resolved once from the theme instead of being inlined at each
use site. Most are a straight swap; two needed judgement:

**Accent.** `#f97316` (orange-500) is about 3:1 on white. Light mode drops to `#ea580c`
(orange-600).

**Tier colours.** These are tuned against `#0a0a0c`, and the bright end doesn't survive on
white — Blaze `#fbbf24` washes out, and Supernova `#dbeafe` disappears completely
(white-on-white). `Tier` gains a `colorOnLight` field:

| tier | dark | light |
|---|---|---|
| Spark | `#9aa0a8` | `#52525b` |
| Ember | `#c2703f` | `#92400e` |
| Flame | `#f97316` | `#c2410c` |
| Blaze | `#fbbf24` | `#b45309` |
| Inferno | `#f87171` | `#dc2626` |
| Supernova | `#dbeafe` | `#1d4ed8` |

Hue is preserved; only lightness moves. `soft` is unchanged — a low-alpha tint reads fine
on either surface.

## Usage

Once this ships, a README can serve the right card per theme:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="https://viberank.app/api/og?type=profile&...">
  <img src="https://viberank.app/api/og?type=profile&...&theme=light">
</picture>
```

## Verification

Rendered both themes across tiers against `next dev`, including Supernova — the worst case
for the old palette. Confirmed the dark rendering is unchanged when `theme` is absent.

`pnpm exec tsc --noEmit` reports the same 14 pre-existing errors as `main`
(`next.config.ts`, `packages/viberank-mcp-server`, `src/app/api/submit/route.ts`,
`UsageChart.tsx`); none are in `og/route.tsx` or `tiers.ts`.
