### PR TITLE
fix: make long-history submission merges bounded

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts && node test/streaks.test.mts"
+    "test": "node test/ccusage.test.mts && node test/streaks.test.mts && node --import tsx test/submissions.test.mts && node --import tsx --experimental-test-module-mocks test/submit-route.test.mts"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -162,7 +162,7 @@ export async function POST(request: NextRequest) {
       backend,
     });
 
-    // Submit using data layer with timeout handling
+    // Submit using the server-side data layer.
     let submissionId;
     try {
       const dataLayer = await getServerDataLayer();
@@ -172,7 +172,11 @@ export async function POST(request: NextRequest) {
       // uploads and older CLIs omit it and fall back to a shared bucket.
       const machineId = request.headers.get("X-Machine-Id") || undefined;
 
-      const submissionPromise = dataLayer.submissions.submit({
+      // Await the database operation directly. The previous 25-second
+      // Promise.race could report failure while its uncancelled writes kept
+      // running and committed. The merge path is bulked in the data layer so
+      // long histories no longer need a per-day request loop.
+      submissionId = await dataLayer.submissions.submit({
         username: githubUsername,
         githubUsername: githubUsername,
         githubName,
@@ -183,12 +187,6 @@ export async function POST(request: NextRequest) {
         ccData: ccData,
       });
 
-      // Add a timeout of 25 seconds (Vercel has a 30 second timeout for API routes)
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Database operation timed out")), 25000)
-      );
-
-      submissionId = await Promise.race([submissionPromise, timeoutPromise]);
 
       // Archive the original payload for future re-parse/backfill. Best
       // effort — never blocks or fails an accepted submission.
@@ -296,9 +294,6 @@ export async function POST(request: NextRequest) {
         "exceed realistic limits",
         "Cost per token ratio is unrealistic",
         "Token components don't sum correctly",
-        "Failed to query existing submissions",
-        "Failed to update existing submission",
-        "Failed to create new submission"
       ];
 
       if (validationErrors.some(msg => error.message.includes(msg))) {
@@ -309,8 +304,8 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // Check for timeout or database-specific errors
-      if (error.message.includes("timeout") || error.message.includes("deadline")) {
+      // Database clients use both "timeout" and "timed out" spellings.
+      if (/timeout|timed out|deadline/i.test(error.message)) {
         return NextResponse.json(
           { error: "Request timed out. Please try again or submit smaller batches of data." },
           { status: 504 }

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -174,13 +174,16 @@ function convertDbDailyBreakdown(db: DbDailyBreakdown): DailyBreakdown {
 // SUPABASE SUBMISSIONS SERVICE
 // ============================================================================
 
-class SupabaseSubmissionsService implements SubmissionsService {
+export class SupabaseSubmissionsService implements SubmissionsService {
   private client: SupabaseClient;
-  private rateLimiter: SupabaseRateLimiter;
+  private rateLimiter: Pick<SupabaseRateLimiter, "checkLimit">;
 
-  constructor(client: SupabaseClient) {
+  constructor(
+    client: SupabaseClient,
+    rateLimiter: Pick<SupabaseRateLimiter, "checkLimit"> = new SupabaseRateLimiter(client)
+  ) {
     this.client = client;
-    this.rateLimiter = new SupabaseRateLimiter(client);
+    this.rateLimiter = rateLimiter;
   }
 
   async submit(data: SubmitData): Promise<string> {
@@ -215,7 +218,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
 
     // Check for existing submission with overlapping date range
     // Use ilike for case-insensitive username matching
-    const { data: existingSubmissions } = await this.client
+    const { data: existingSubmissions, error: existingSubmissionsError } = await this.client
       .from("submissions")
       .select("*")
       .ilike("username", data.username)
@@ -224,6 +227,13 @@ class SupabaseSubmissionsService implements SubmissionsService {
         `and(date_range_start.lte.${dateRangeEnd},date_range_end.gte.${dateRangeStart})`
       )
       .limit(1);
+
+    if (existingSubmissionsError) {
+      throw new Error(
+        "Failed to query existing submissions: " + existingSubmissionsError.message
+      );
+    }
+    
 
     // Identify the contributing machine so overlapping dates from distinct
     // machines sum while a same-machine re-submit replaces only its slice (#43).
@@ -256,8 +266,14 @@ class SupabaseSubmissionsService implements SubmissionsService {
       );
     }
 
-    // Update or create profile
-    await this.updateProfile(data, submissionId, !existingSubmissions?.length);
+    // The submission is already durable at this point. A profile projection
+    // failure must be logged, but must not turn an accepted submission into a
+    // client-visible failure that encourages a duplicate retry.
+    try {
+      await this.updateProfile(data, submissionId, !existingSubmissions?.length);
+    } catch (error) {
+      console.error("Profile update failed after submission was accepted:", error);
+    }
 
     return submissionId;
   }
@@ -278,20 +294,23 @@ class SupabaseSubmissionsService implements SubmissionsService {
     tools: string[],
     machineId: string
   ): Promise<string> {
-    // Get existing daily breakdowns
-    const { data: existingDaily } = await this.client
+    const { data: existingDaily, error: existingDailyError } = await this.client
       .from("daily_breakdowns")
       .select("*")
       .eq("submission_id", existing.id);
 
-    // Create a map of existing daily data
+    if (existingDailyError) {
+      throw new Error(
+        "Failed to query existing daily breakdowns: " + existingDailyError.message
+      );
+    }
+
     const dailyMap = new Map<string, DbDailyBreakdown>();
     (existingDaily || []).forEach((day) => dailyMap.set(day.date, day));
 
-    // Fold each incoming day into the existing per-machine map. A day from a new
-    // machine adds a slice (sums); a re-submit from the same machine replaces
-    // only its own slice (no double-count). #43
-    for (const day of data.ccData.daily) {
+    // Build every replacement row in memory, then write the incoming history
+    // in one request against the unique (submission_id, date) constraint.
+    const dailyRows = data.ccData.daily.map((day) => {
       const prior = dailyMap.get(day.date);
       const { contributions, aggregate } = mergeMachineContribution(
         prior?.machine_contributions ?? null,
@@ -314,18 +333,18 @@ class SupabaseSubmissionsService implements SubmissionsService {
         machine_contributions: contributions,
       };
 
-      if (prior) {
-        // Update existing
-        await this.client
-          .from("daily_breakdowns")
-          .update(dailyData)
-          .eq("submission_id", existing.id)
-          .eq("date", day.date);
-      } else {
-        // Insert new
-        await this.client.from("daily_breakdowns").insert(dailyData);
-      }
       dailyMap.set(day.date, dailyData as DbDailyBreakdown);
+      return dailyData;
+    });
+
+    const { error: dailyUpsertError } = await this.client
+      .from("daily_breakdowns")
+      .upsert(dailyRows, { onConflict: "submission_id,date" });
+
+    if (dailyUpsertError) {
+      throw new Error(
+        "Failed to update daily breakdowns: " + dailyUpsertError.message
+      );
     }
 
     // Recalculate totals from all daily data
@@ -362,8 +381,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
       new Set([...(existing.tools || []), ...tools])
     ).sort();
 
-    // Update submission
-    await this.client
+    const { error: submissionUpdateError } = await this.client
       .from("submissions")
       .update({
         github_username: data.githubUsername,
@@ -384,6 +402,12 @@ class SupabaseSubmissionsService implements SubmissionsService {
         source: data.source,
       })
       .eq("id", existing.id);
+
+    if (submissionUpdateError) {
+      throw new Error(
+        "Failed to update existing submission: " + submissionUpdateError.message
+      );
+    }
 
     return existing.id;
   }
@@ -460,14 +484,19 @@ class SupabaseSubmissionsService implements SubmissionsService {
     submissionId: string,
     isNewSubmission: boolean
   ): Promise<void> {
-    const { data: existingProfile } = await this.client
+    const { data: existingProfile, error: profileQueryError } = await this.client
       .from("profiles")
       .select("*")
       .eq("username", data.username)
       .single();
 
+    // PostgREST uses PGRST116 for an expected zero-row .single() result.
+    if (profileQueryError && profileQueryError.code !== "PGRST116") {
+      throw new Error("Failed to query profile: " + profileQueryError.message);
+    }
+
     if (existingProfile) {
-      const updates: any = {
+      const updates: Record<string, unknown> = {
         best_submission_id: submissionId,
         github_username: data.githubUsername,
         github_name: data.githubName,
@@ -478,12 +507,16 @@ class SupabaseSubmissionsService implements SubmissionsService {
         updates.total_submissions = existingProfile.total_submissions + 1;
       }
 
-      await this.client
+      const { error: profileUpdateError } = await this.client
         .from("profiles")
         .update(updates)
         .eq("id", existingProfile.id);
+
+      if (profileUpdateError) {
+        throw new Error("Failed to update profile: " + profileUpdateError.message);
+      }
     } else {
-      await this.client.from("profiles").insert({
+      const { error: profileInsertError } = await this.client.from("profiles").insert({
         username: data.username,
         github_username: data.githubUsername,
         github_name: data.githubName,
@@ -491,6 +524,10 @@ class SupabaseSubmissionsService implements SubmissionsService {
         total_submissions: 1,
         best_submission_id: submissionId,
       });
+
+      if (profileInsertError) {
+        throw new Error("Failed to create profile: " + profileInsertError.message);
+      }
     }
   }
 

--- a/test/submissions.test.mts
+++ b/test/submissions.test.mts
@@ -1,0 +1,241 @@
+import assert from "node:assert/strict";
+const { SupabaseSubmissionsService } = await import("../src/lib/data/supabase/client.ts");
+import type { SubmitData } from "../src/lib/data/types.ts";
+
+interface Call {
+  table: string;
+  operation: "select" | "insert" | "update" | "upsert" | "delete";
+  payload?: unknown;
+  options?: unknown;
+}
+
+interface FakeError {
+  message: string;
+  code?: string;
+}
+
+interface FakeResult {
+  data: unknown;
+  error: FakeError | null;
+}
+
+class FakeQuery implements PromiseLike<FakeResult> {
+  private operation: Call["operation"] = "select";
+  private payload: unknown;
+  private options: unknown;
+
+  constructor(
+    private readonly table: string,
+    private readonly calls: Call[],
+    private readonly rows: Record<string, unknown>,
+    private readonly errors: Record<string, FakeError>
+  ) {}
+
+  select(): this {
+    this.operation = "select";
+    return this;
+  }
+
+  insert(payload: unknown): this {
+    this.operation = "insert";
+    this.payload = payload;
+    return this;
+  }
+
+  update(payload: unknown): this {
+    this.operation = "update";
+    this.payload = payload;
+    return this;
+  }
+
+  upsert(payload: unknown, options?: unknown): this {
+    this.operation = "upsert";
+    this.payload = payload;
+    this.options = options;
+    return this;
+  }
+
+  delete(): this {
+    this.operation = "delete";
+    return this;
+  }
+
+  eq(): this { return this; }
+  ilike(): this { return this; }
+  or(): this { return this; }
+  limit(): this { return this; }
+  range(): this { return this; }
+  order(): this { return this; }
+  single(): this { return this; }
+
+  then<TResult1 = FakeResult, TResult2 = never>(
+    onfulfilled?: ((value: FakeResult) => TResult1 | PromiseLike<TResult1>) | null,
+    onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+  ): PromiseLike<TResult1 | TResult2> {
+    this.calls.push({
+      table: this.table,
+      operation: this.operation,
+      payload: this.payload,
+      options: this.options,
+    });
+    const error = this.errors[`${this.table}:${this.operation}`] ?? null;
+    return Promise.resolve({ data: this.rows[this.table] ?? null, error }).then(
+      onfulfilled,
+      onrejected
+    );
+  }
+}
+
+class FakeClient {
+  readonly calls: Call[] = [];
+
+  constructor(
+    private readonly rows: Record<string, unknown>,
+    private readonly errors: Record<string, FakeError> = {}
+  ) {}
+
+  from(table: string): FakeQuery {
+    return new FakeQuery(table, this.calls, this.rows, this.errors);
+  }
+}
+
+const contribution = (n: number) => ({
+  inputTokens: n,
+  outputTokens: n,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  totalTokens: n * 2,
+  totalCost: n / 100,
+  modelsUsed: ["test-model"],
+  agents: ["test"],
+});
+
+const daily = Array.from({ length: 270 }, (_, index) => {
+  const date = new Date(Date.UTC(2025, 0, index + 1)).toISOString().slice(0, 10);
+  return { date, ...contribution(index + 1) };
+});
+
+const existingDaily = daily.map((day, index) => ({
+  id: `day-${index}`,
+  submission_id: "submission-1",
+  date: day.date,
+  input_tokens: 1,
+  output_tokens: 1,
+  cache_creation_tokens: 0,
+  cache_read_tokens: 0,
+  total_tokens: 2,
+  total_cost: 0.01,
+  models_used: ["old-model"],
+  agents: ["old"],
+  model_breakdowns: null,
+  machine_contributions: { old: contribution(1) },
+}));
+
+const rows = {
+  submissions: [{
+    id: "submission-1",
+    models_used: ["old-model"],
+    tools: ["old"],
+  }],
+  daily_breakdowns: existingDaily,
+  profiles: {
+    id: "profile-1",
+    total_submissions: 1,
+  },
+};
+
+const totals = daily.reduce(
+  (sum, day) => ({
+    inputTokens: sum.inputTokens + day.inputTokens,
+    outputTokens: sum.outputTokens + day.outputTokens,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: sum.totalTokens + day.totalTokens,
+    totalCost: sum.totalCost + day.totalCost,
+  }),
+  {
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: 0,
+    totalCost: 0,
+  }
+);
+
+const submission: SubmitData = {
+  username: "long-history",
+  githubUsername: "long-history",
+  source: "cli",
+  verified: false,
+  machineId: "machine-new",
+  ccData: { totals, daily, tools: ["test"] },
+};
+
+const allowedRateLimiter = {
+  checkLimit: async () => ({ allowed: true, remaining: 0 }),
+};
+
+const client = new FakeClient(rows);
+const service = new SupabaseSubmissionsService(client as never, allowedRateLimiter);
+await service.submit(submission);
+
+const dailyWrites = client.calls.filter(
+  (call) => call.table === "daily_breakdowns" && call.operation !== "select"
+);
+assert.equal(
+  dailyWrites.length,
+  1,
+  `expected one bulk daily write, got ${dailyWrites.length}: ${dailyWrites.map((c) => c.operation).join(",")}`
+);
+assert.equal(dailyWrites[0].operation, "upsert");
+assert.deepEqual(dailyWrites[0].options, { onConflict: "submission_id,date" });
+assert.equal((dailyWrites[0].payload as unknown[]).length, 270);
+console.log("✓ 270-day merge uses one conflict-safe bulk daily write");
+
+const failedUpdateClient = new FakeClient(
+  rows,
+  { "submissions:update": { message: "forced parent update failure" } }
+);
+const failedUpdateService = new SupabaseSubmissionsService(
+  failedUpdateClient as never,
+  allowedRateLimiter
+);
+await assert.rejects(
+  () => failedUpdateService.submit(submission),
+  /Failed to update existing submission: forced parent update failure/
+);
+console.log("✓ parent submission update errors are not silently ignored");
+
+const failedDailyClient = new FakeClient(
+  rows,
+  { "daily_breakdowns:upsert": { message: "forced bulk upsert failure" } }
+);
+const failedDailyService = new SupabaseSubmissionsService(
+  failedDailyClient as never,
+  allowedRateLimiter
+);
+await assert.rejects(
+  () => failedDailyService.submit(submission),
+  /Failed to update daily breakdowns: forced bulk upsert failure/
+);
+console.log("✓ bulk daily write errors are not silently ignored");
+
+const failedProfileClient = new FakeClient(
+  rows,
+  { "profiles:update": { message: "forced profile update failure" } }
+);
+const failedProfileService = new SupabaseSubmissionsService(
+  failedProfileClient as never,
+  allowedRateLimiter
+);
+const originalConsoleError = console.error;
+console.error = () => undefined;
+let acceptedSubmissionId: string;
+try {
+  acceptedSubmissionId = await failedProfileService.submit(submission);
+} finally {
+  console.error = originalConsoleError;
+}
+assert.equal(acceptedSubmissionId, "submission-1");
+console.log("✓ post-commit profile errors do not turn success into failure");

--- a/test/submit-route.test.mts
+++ b/test/submit-route.test.mts
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { mock } from "node:test";
+
+const normalized = {
+  totals: {
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: 2,
+    totalCost: 0.01,
+  },
+  daily: [
+    {
+      date: "2026-01-01",
+      inputTokens: 1,
+      outputTokens: 1,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+      totalTokens: 2,
+      totalCost: 0.01,
+      modelsUsed: ["test-model"],
+      agents: ["test"],
+    },
+  ],
+  tools: ["test"],
+};
+
+mock.module("next-auth", {
+  exports: { getServerSession: async () => null },
+});
+mock.module("@/lib/auth", {
+  exports: { authOptions: {} },
+});
+mock.module("@/lib/data", {
+  exports: {
+    getDatabaseBackend: () => "supabase",
+    getServerDataLayer: async () => ({
+      submissions: {
+        submit: async () => {
+          throw new Error("Database operation timed out");
+        },
+      },
+    }),
+  },
+});
+mock.module("@/lib/ccusage", {
+  exports: { normalizeCcData: () => normalized },
+});
+mock.module("@/lib/data/supabase/rawArchive", {
+  exports: { archiveRawSubmission: async () => undefined },
+});
+mock.module("@/lib/sponsor", {
+  exports: { getCliNotice: () => null },
+});
+mock.module("@vercel/analytics/server", {
+  exports: { track: async () => undefined },
+});
+
+const { POST } = await import("../src/app/api/submit/route.ts");
+
+const request = new Request("https://www.viberank.app/api/submit", {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+    "x-github-user": "timeout-regression",
+  },
+  body: JSON.stringify({ daily: [{}], totals: normalized.totals }),
+});
+
+const originalConsoleLog = console.log;
+const originalConsoleError = console.error;
+console.log = () => undefined;
+console.error = () => undefined;
+let response: Awaited<ReturnType<typeof POST>>;
+try {
+  response = await POST(request as never);
+} finally {
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+}
+const body = await response.json();
+
+assert.equal(response.status, 504, `expected 504, got ${response.status}: ${JSON.stringify(body)}`);
+assert.equal(
+  body.error,
+  "Request timed out. Please try again or submit smaller batches of data."
+);
+
+console.log("✓ timed-out submission maps to a 504 timeout response");


### PR DESCRIPTION
> *AI로 작성된 내용입니다.*

## Summary

Fixes #93.

Long-history re-submissions no longer perform one sequential `daily_breakdowns` write per day or race those uncancelled writes against a 25-second application timer. A 270-day merge now performs one conflict-safe bulk upsert, so the API does not report failure while the same submission continues and commits in the background.

This includes the timeout-response correction from #80 and fixes the underlying O(days) merge that triggers it.

## Changes

- replace the per-day update/insert loop with one `upsert` on the existing `(submission_id, date)` unique key
- preserve the existing machine-contribution rules through `mergeMachineContribution`
- remove the uncancellable `Promise.race` that could return a false failure after writes continued
- recognize both `timeout` and `timed out` database error spellings as 504
- surface failed existing-submission reads, bulk daily writes, and parent submission updates
- treat profile projection errors as post-commit/non-fatal so an accepted submission is not reported as failed
- add route and data-layer regressions to the default test command

## Verification

- `pnpm test` — pass
  - ccusage: 34 tests
  - streaks: 9 tests
  - 270-day merge: exactly one bulk daily write
  - bulk/parent DB errors are surfaced
  - post-commit profile error remains a successful submission
  - `Database operation timed out` maps to 504
- `node test/ccusage.test.mts /Users/chsong/cc.json && node --import tsx test/submissions.test.mts` — pass against the real 270-day, 205,565,284,264-token payload from #93 (37 ccusage checks plus merge-path checks)
- `pnpm build` — application compiled successfully; page-data collection then stopped because the local checkout has no `GITHUB_ID`, `GITHUB_SECRET`, `NEXTAUTH_SECRET`, or `NEXTAUTH_URL`

## Notes

The bulk upsert relies on the existing unique constraint; no schema migration is required. It removes the observed timeout mechanism but does not attempt to redesign cross-request transaction/concurrency semantics, which predate this change.
