### PR TITLE
fix: submission and leaderboard data integrity

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts && node test/streaks.test.mts"
+    "test": "node test/ccusage.test.mts && node test/streaks.test.mts && node --import tsx test/submissions.test.mts"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -172,7 +172,13 @@ export async function POST(request: NextRequest) {
       // uploads and older CLIs omit it and fall back to a shared bucket.
       const machineId = request.headers.get("X-Machine-Id") || undefined;
 
-      const submissionPromise = dataLayer.submissions.submit({
+      // Awaited directly, not raced against a timer. A rejected race did not
+      // cancel the underlying writes, so a slow merge reported failure while
+      // its data committed anyway — and the CLI then told the user to fix a
+      // cc.json that was never the problem (#93). The merge path is bulk-
+      // written in the data layer now, so long histories no longer approach
+      // the request budget in the first place.
+      submissionId = await dataLayer.submissions.submit({
         username: githubUsername,
         githubUsername: githubUsername,
         githubName,
@@ -182,13 +188,6 @@ export async function POST(request: NextRequest) {
         machineId,
         ccData: ccData,
       });
-
-      // Add a timeout of 25 seconds (Vercel has a 30 second timeout for API routes)
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("Database operation timed out")), 25000)
-      );
-
-      submissionId = await Promise.race([submissionPromise, timeoutPromise]);
 
       // Archive the original payload for future re-parse/backfill. Best
       // effort — never blocks or fails an accepted submission.
@@ -287,7 +286,10 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // Handle validation errors with 400 status
+      // Handle validation errors with 400 status. Only genuine problems with
+      // the submitted payload belong here — a "Failed to query/update/create"
+      // is our fault, not the user's, and telling them to fix cc.json for it
+      // sends them chasing a file that was always valid (#93).
       const validationErrors = [
         "Token totals don't match",
         "Invalid date format",
@@ -296,9 +298,6 @@ export async function POST(request: NextRequest) {
         "exceed realistic limits",
         "Cost per token ratio is unrealistic",
         "Token components don't sum correctly",
-        "Failed to query existing submissions",
-        "Failed to update existing submission",
-        "Failed to create new submission"
       ];
 
       if (validationErrors.some(msg => error.message.includes(msg))) {
@@ -309,11 +308,27 @@ export async function POST(request: NextRequest) {
         );
       }
 
-      // Check for timeout or database-specific errors
-      if (error.message.includes("timeout") || error.message.includes("deadline")) {
+      // Database clients spell this both ways ("timeout" and "timed out");
+      // matching only the first let genuine timeouts fall through to the
+      // generic 500 that blames the user's file.
+      if (/timeout|timed out|deadline/i.test(error.message)) {
         return NextResponse.json(
           { error: "Request timed out. Please try again or submit smaller batches of data." },
           { status: 504 }
+        );
+      }
+
+      // Our own data-layer failures are retryable infrastructure errors. This
+      // is checked before the looser "mutation"/"query" substring match below,
+      // which would otherwise catch "Failed to query …" and report it as a 500.
+      if (error.message.includes("Failed to query") ||
+          error.message.includes("Failed to update") ||
+          error.message.includes("Failed to create")) {
+        // Don't echo the raw DB message — it can leak schema/table names.
+        console.error("Database operation error:", error.message);
+        return NextResponse.json(
+          { error: "Database operation failed. Please try again later." },
+          { status: 503 }
         );
       }
 
@@ -344,16 +359,6 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(
           { error: "Database operation failed. Please try again later." },
           { status: 500 }
-        );
-      }
-
-      // Handle database-specific errors
-      if (error.message.includes("Failed to query") ||
-          error.message.includes("Failed to update") ||
-          error.message.includes("Failed to create")) {
-        return NextResponse.json(
-          { error: "Database operation failed. Please try again later." },
-          { status: 503 }
         );
       }
     }

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -63,6 +63,9 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   const { data: session } = useSession();
   const loadMoreRef = useRef<HTMLDivElement>(null);
   const firstRender = useRef(true);
+  // Latches on the first real filter change and never resets — see
+  // isSeededDefaultView below.
+  const hasChangedFilters = useRef(false);
   const { data: liveStats } = useGlobalStats();
   const globalStats = liveStats ?? initialStats;
 
@@ -105,7 +108,14 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
 
   // The server already rendered page 0 of the default view — don't re-fetch
   // it on mount. The hook only runs for non-default filters or later pages.
+  //
+  // The seed is only valid until the user touches a filter: the effect below
+  // clears `allItems` on every filter change, so returning to the default view
+  // (filter on, then off) would otherwise match here again, skip the fetch and
+  // leave the board permanently empty. `initialItems` never empties, so it
+  // can't tell "not yet interacted" from "back at the default".
   const isSeededDefaultView =
+    !hasChangedFilters.current &&
     (initialItems?.length ?? 0) > 0 &&
     page === 0 &&
     sortBy === "cost" &&
@@ -139,6 +149,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
       firstRender.current = false;
       return;
     }
+    hasChangedFilters.current = true;
     setAllItems([]);
     setPage(0);
   }, [sortBy, dateFrom, dateTo, tool, verifiedOnly]);

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -1238,9 +1238,20 @@ export class SupabaseProfilesService implements ProfilesService {
   ): Promise<DeleteResult> {
     const { searchField = "githubUsername", caseSensitive = false, dryRun = false } = options;
 
-    const { data: allProfiles } = await this.client.from("profiles").select("*");
+    // Matching happens in memory, so a capped read would silently narrow the
+    // match set — a delete that quietly skips accounts is worse than one that
+    // errors. Page the scan.
+    const allProfiles = await fetchAllPages<DbProfile>(
+      (from, to) =>
+        this.client
+          .from("profiles")
+          .select("*")
+          .order("id", { ascending: true })
+          .range(from, to),
+      "profiles for delete"
+    );
 
-    const matchingProfiles = (allProfiles || []).filter((profile) => {
+    const matchingProfiles = allProfiles.filter((profile) => {
       const githubUsername = profile.github_username || "";
       const username = profile.username || "";
 
@@ -1262,20 +1273,122 @@ export class SupabaseProfilesService implements ProfilesService {
       });
     });
 
-    let deletedCount = 0;
+    // Removing a profile alone does not remove the user from the site. The
+    // leaderboard reads `submissions`, and `raw_submissions` archives the
+    // original payload with no FK to either table — so a profile-only delete
+    // leaves the entry ranked and the raw data stored. Collect every row that
+    // belongs to these accounts, then delete children before parents.
+    const usernames = matchingProfiles.map((p) => p.username);
+
+    const ownedSubmissions = usernames.length
+      ? await fetchAllPages<DbSubmission>(
+          (from, to) =>
+            this.client
+              .from("submissions")
+              .select("*")
+              .in("username", usernames)
+              .order("id", { ascending: true })
+              .range(from, to),
+          "submissions for delete"
+        )
+      : [];
+    const submissionIds = ownedSubmissions.map((s) => s.id);
+
+    const ownedDaily = submissionIds.length
+      ? await fetchAllPages<DbDailyBreakdown>(
+          (from, to) =>
+            this.client
+              .from("daily_breakdowns")
+              .select("*")
+              .in("submission_id", submissionIds)
+              .order("id", { ascending: true })
+              .range(from, to),
+          "daily breakdowns for delete"
+        )
+      : [];
+
+    const ownedRaw = usernames.length
+      ? await fetchAllPages<{ id: string }>(
+          (from, to) =>
+            this.client
+              .from("raw_submissions")
+              .select("id")
+              .in("username", usernames)
+              .order("id", { ascending: true })
+              .range(from, to),
+          "raw submissions for delete"
+        )
+      : [];
+
+    const deletedRows = {
+      profiles: 0,
+      submissions: 0,
+      dailyBreakdowns: 0,
+      rawSubmissions: 0,
+    };
+
     if (!dryRun) {
+      if (submissionIds.length > 0) {
+        // daily_breakdowns is ON DELETE CASCADE, but delete it explicitly so a
+        // failure surfaces here rather than being assumed.
+        const { error: dailyError } = await this.client
+          .from("daily_breakdowns")
+          .delete()
+          .in("submission_id", submissionIds);
+        if (dailyError) {
+          throw new Error(`Failed to delete daily breakdowns: ${dailyError.message}`);
+        }
+        deletedRows.dailyBreakdowns = ownedDaily.length;
+
+        const { error: submissionError } = await this.client
+          .from("submissions")
+          .delete()
+          .in("id", submissionIds);
+        if (submissionError) {
+          throw new Error(`Failed to delete submissions: ${submissionError.message}`);
+        }
+        deletedRows.submissions = submissionIds.length;
+      }
+
+      if (ownedRaw.length > 0) {
+        const { error: rawError } = await this.client
+          .from("raw_submissions")
+          .delete()
+          .in("id", ownedRaw.map((r) => r.id));
+        if (rawError) {
+          throw new Error(`Failed to delete raw submissions: ${rawError.message}`);
+        }
+        deletedRows.rawSubmissions = ownedRaw.length;
+      }
+
       for (const profile of matchingProfiles) {
-        await this.client.from("profiles").delete().eq("id", profile.id);
-        deletedCount++;
+        const { error: profileError } = await this.client
+          .from("profiles")
+          .delete()
+          .eq("id", profile.id);
+        if (profileError) {
+          throw new Error(`Failed to delete profile: ${profileError.message}`);
+        }
+        deletedRows.profiles++;
       }
     }
 
+    const wouldDelete = {
+      profiles: matchingProfiles.length,
+      submissions: submissionIds.length,
+      dailyBreakdowns: ownedDaily.length,
+      rawSubmissions: ownedRaw.length,
+    };
+    const summary = (counts: typeof wouldDelete) =>
+      `${counts.profiles} profiles, ${counts.submissions} submissions, ` +
+      `${counts.dailyBreakdowns} daily rows, ${counts.rawSubmissions} archived payloads`;
+
     return {
       message: dryRun
-        ? `Dry run: Would delete ${matchingProfiles.length} profiles`
-        : `Successfully deleted ${deletedCount} profiles`,
+        ? `Dry run: would delete ${summary(wouldDelete)}`
+        : `Deleted ${summary(deletedRows)}`,
       matchedCount: matchingProfiles.length,
-      deletedCount: dryRun ? 0 : deletedCount,
+      deletedCount: dryRun ? 0 : deletedRows.profiles,
       dryRun,
       patterns,
       searchField,
@@ -1285,6 +1398,7 @@ export class SupabaseProfilesService implements ProfilesService {
         username: p.username,
         createdAt: new Date(p.created_at).getTime(),
       })),
+      deletedRows: dryRun ? { profiles: 0, submissions: 0, dailyBreakdowns: 0, rawSubmissions: 0 } : deletedRows,
     };
   }
 
@@ -1294,9 +1408,20 @@ export class SupabaseProfilesService implements ProfilesService {
   ): Promise<FindProfilesResult> {
     const { searchField = "githubUsername", caseSensitive = false } = options;
 
-    const { data: allProfiles } = await this.client.from("profiles").select("*");
+    // This is the preview for deleteByPattern. It must page for the same
+    // reason the delete does — a capped preview would show fewer accounts
+    // than the delete goes on to remove.
+    const allProfiles = await fetchAllPages<DbProfile>(
+      (from, to) =>
+        this.client
+          .from("profiles")
+          .select("*")
+          .order("id", { ascending: true })
+          .range(from, to),
+      "profiles for search"
+    );
 
-    const matchingProfiles = (allProfiles || []).filter((profile) => {
+    const matchingProfiles = allProfiles.filter((profile) => {
       const githubUsername = profile.github_username || "";
       const username = profile.username || "";
 

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -171,16 +171,74 @@ function convertDbDailyBreakdown(db: DbDailyBreakdown): DailyBreakdown {
 }
 
 // ============================================================================
+// PAGINATION
+// ============================================================================
+
+/**
+ * PostgREST caps every response at the project's `db-max-rows` (1000 by
+ * default), and it does so *silently* — a larger `.limit()` is not an error,
+ * it just returns the cap. Truncation here is worse than a partial result:
+ * callers that group rows by submission see a submission with zero rows and
+ * skip it entirely, so a user disappears rather than showing a low total.
+ *
+ * Page explicitly instead. The caller supplies a builder so the ordering is
+ * applied to its own query — a stable order is what makes paging correct, and
+ * without one it is arbitrary which rows survive.
+ */
+const PAGE_SIZE = 1000;
+const MAX_ROWS = 200_000;
+
+async function fetchAllPages<T>(
+  buildPage: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  context: string
+): Promise<T[]> {
+  const all: T[] = [];
+
+  while (all.length < MAX_ROWS) {
+    const { data, error } = await buildPage(all.length, all.length + PAGE_SIZE - 1);
+
+    // A failed page must not look like the end of the data. Silently breaking
+    // here would reintroduce the truncation this helper exists to prevent.
+    if (error) {
+      throw new Error(`Failed to query ${context}: ${error.message}`);
+    }
+    if (!data || data.length === 0) break;
+
+    // Advance by what the server actually returned, and stop only on an empty
+    // page. Stopping at `length < PAGE_SIZE` would assume `db-max-rows` is at
+    // least PAGE_SIZE — if it were configured lower, every page would come
+    // back short and we'd silently truncate at the first one. The cost is one
+    // extra empty request per query, which is the right trade for a helper
+    // whose entire job is to not lose rows.
+    all.push(...data);
+  }
+
+  if (all.length >= MAX_ROWS) {
+    console.error(
+      `fetchAllPages hit the ${MAX_ROWS}-row ceiling for ${context}; results are truncated.`
+    );
+  }
+
+  return all;
+}
+
+// ============================================================================
 // SUPABASE SUBMISSIONS SERVICE
 // ============================================================================
 
-class SupabaseSubmissionsService implements SubmissionsService {
-  private client: SupabaseClient;
-  private rateLimiter: SupabaseRateLimiter;
+/** The slice of the rate limiter this service needs — injectable for tests. */
+type RateLimitChecker = Pick<SupabaseRateLimiter, "checkLimit">;
 
-  constructor(client: SupabaseClient) {
+export class SupabaseSubmissionsService implements SubmissionsService {
+  private client: SupabaseClient;
+  private rateLimiter: RateLimitChecker;
+
+  constructor(
+    client: SupabaseClient,
+    rateLimiter: RateLimitChecker = new SupabaseRateLimiter(client)
+  ) {
     this.client = client;
-    this.rateLimiter = new SupabaseRateLimiter(client);
+    this.rateLimiter = rateLimiter;
   }
 
   async submit(data: SubmitData): Promise<string> {
@@ -215,7 +273,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
 
     // Check for existing submission with overlapping date range
     // Use ilike for case-insensitive username matching
-    const { data: existingSubmissions } = await this.client
+    const { data: existingSubmissions, error: existingSubmissionsError } = await this.client
       .from("submissions")
       .select("*")
       .ilike("username", data.username)
@@ -224,6 +282,12 @@ class SupabaseSubmissionsService implements SubmissionsService {
         `and(date_range_start.lte.${dateRangeEnd},date_range_end.gte.${dateRangeStart})`
       )
       .limit(1);
+
+    if (existingSubmissionsError) {
+      throw new Error(
+        `Failed to query existing submissions: ${existingSubmissionsError.message}`
+      );
+    }
 
     // Identify the contributing machine so overlapping dates from distinct
     // machines sum while a same-machine re-submit replaces only its slice (#43).
@@ -256,8 +320,18 @@ class SupabaseSubmissionsService implements SubmissionsService {
       );
     }
 
-    // Update or create profile
-    await this.updateProfile(data, submissionId, !existingSubmissions?.length);
+    // The submission is durable by this point. The profile row is a projection
+    // of it, so a failure here must be logged rather than raised: turning an
+    // accepted submission into a client-visible error is what pushes users to
+    // retry a write that already landed (#93).
+    try {
+      await this.updateProfile(data, submissionId, !existingSubmissions?.length);
+    } catch (profileError) {
+      console.error(
+        "Profile update failed after the submission was accepted:",
+        profileError
+      );
+    }
 
     return submissionId;
   }
@@ -278,20 +352,31 @@ class SupabaseSubmissionsService implements SubmissionsService {
     tools: string[],
     machineId: string
   ): Promise<string> {
-    // Get existing daily breakdowns
-    const { data: existingDaily } = await this.client
-      .from("daily_breakdowns")
-      .select("*")
-      .eq("submission_id", existing.id);
+    // Totals below are recomputed from this map and written back to the parent
+    // row, so a truncated read would silently shrink the user's totals. Page it.
+    const existingDaily = await fetchAllPages<DbDailyBreakdown>(
+      (from, to) =>
+        this.client
+          .from("daily_breakdowns")
+          .select("*")
+          .eq("submission_id", existing.id)
+          .order("date", { ascending: true })
+          .range(from, to),
+      "existing daily breakdowns"
+    );
 
     // Create a map of existing daily data
     const dailyMap = new Map<string, DbDailyBreakdown>();
-    (existingDaily || []).forEach((day) => dailyMap.set(day.date, day));
+    existingDaily.forEach((day) => dailyMap.set(day.date, day));
 
     // Fold each incoming day into the existing per-machine map. A day from a new
     // machine adds a slice (sums); a re-submit from the same machine replaces
     // only its own slice (no double-count). #43
-    for (const day of data.ccData.daily) {
+    //
+    // Build every row first, then write them in one request. This used to be a
+    // round-trip per day, which put a multi-year history past the request
+    // budget even though each individual write was fast (#93).
+    const dailyRows = data.ccData.daily.map((day) => {
       const prior = dailyMap.get(day.date);
       const { contributions, aggregate } = mergeMachineContribution(
         prior?.machine_contributions ?? null,
@@ -314,18 +399,22 @@ class SupabaseSubmissionsService implements SubmissionsService {
         machine_contributions: contributions,
       };
 
-      if (prior) {
-        // Update existing
-        await this.client
-          .from("daily_breakdowns")
-          .update(dailyData)
-          .eq("submission_id", existing.id)
-          .eq("date", day.date);
-      } else {
-        // Insert new
-        await this.client.from("daily_breakdowns").insert(dailyData);
-      }
       dailyMap.set(day.date, dailyData as DbDailyBreakdown);
+      return dailyData;
+    });
+
+    // Upserting on the UNIQUE(submission_id, date) constraint collapses the old
+    // insert-or-update branch: the constraint decides, not a prior read.
+    if (dailyRows.length > 0) {
+      const { error: dailyUpsertError } = await this.client
+        .from("daily_breakdowns")
+        .upsert(dailyRows, { onConflict: "submission_id,date" });
+
+      if (dailyUpsertError) {
+        throw new Error(
+          `Failed to update daily breakdowns: ${dailyUpsertError.message}`
+        );
+      }
     }
 
     // Recalculate totals from all daily data
@@ -363,7 +452,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
     ).sort();
 
     // Update submission
-    await this.client
+    const { error: submissionUpdateError } = await this.client
       .from("submissions")
       .update({
         github_username: data.githubUsername,
@@ -384,6 +473,12 @@ class SupabaseSubmissionsService implements SubmissionsService {
         source: data.source,
       })
       .eq("id", existing.id);
+
+    if (submissionUpdateError) {
+      throw new Error(
+        `Failed to update existing submission: ${submissionUpdateError.message}`
+      );
+    }
 
     return existing.id;
   }
@@ -460,14 +555,21 @@ class SupabaseSubmissionsService implements SubmissionsService {
     submissionId: string,
     isNewSubmission: boolean
   ): Promise<void> {
-    const { data: existingProfile } = await this.client
+    const { data: existingProfile, error: profileQueryError } = await this.client
       .from("profiles")
       .select("*")
       .eq("username", data.username)
       .single();
 
+    // PGRST116 is PostgREST's "no rows" for .single() — expected for a first
+    // submission, so it falls through to the insert below. Anything else is a
+    // real failure and must not be mistaken for "this profile doesn't exist".
+    if (profileQueryError && profileQueryError.code !== "PGRST116") {
+      throw new Error(`Failed to query profile: ${profileQueryError.message}`);
+    }
+
     if (existingProfile) {
-      const updates: any = {
+      const updates: Record<string, unknown> = {
         best_submission_id: submissionId,
         github_username: data.githubUsername,
         github_name: data.githubName,
@@ -478,19 +580,29 @@ class SupabaseSubmissionsService implements SubmissionsService {
         updates.total_submissions = existingProfile.total_submissions + 1;
       }
 
-      await this.client
+      const { error: profileUpdateError } = await this.client
         .from("profiles")
         .update(updates)
         .eq("id", existingProfile.id);
+
+      if (profileUpdateError) {
+        throw new Error(`Failed to update profile: ${profileUpdateError.message}`);
+      }
     } else {
-      await this.client.from("profiles").insert({
-        username: data.username,
-        github_username: data.githubUsername,
-        github_name: data.githubName,
-        avatar: data.githubAvatar,
-        total_submissions: 1,
-        best_submission_id: submissionId,
-      });
+      const { error: profileInsertError } = await this.client
+        .from("profiles")
+        .insert({
+          username: data.username,
+          github_username: data.githubUsername,
+          github_name: data.githubName,
+          avatar: data.githubAvatar,
+          total_submissions: 1,
+          best_submission_id: submissionId,
+        });
+
+      if (profileInsertError) {
+        throw new Error(`Failed to create profile: ${profileInsertError.message}`);
+      }
     }
   }
 
@@ -586,16 +698,27 @@ class SupabaseSubmissionsService implements SubmissionsService {
     }
 
     const submissionIds = submissions.map((s) => s.id);
-    const { data: allDailyBreakdowns } = await this.client
-      .from("daily_breakdowns")
-      .select("*")
-      .in("submission_id", submissionIds)
-      .gte("date", params.dateFrom)
-      .lte("date", params.dateTo)
-      .limit(50000);
+
+    // The previous `.limit(50000)` was silently capped at `db-max-rows`, and
+    // because the loop below skips any submission with zero rows in range, the
+    // users past the cut vanished from the board rather than showing a partial
+    // total. With no ORDER BY it was also arbitrary which ones survived.
+    const allDailyBreakdowns = await fetchAllPages<DbDailyBreakdown>(
+      (from, to) =>
+        this.client
+          .from("daily_breakdowns")
+          .select("*")
+          .in("submission_id", submissionIds)
+          .gte("date", params.dateFrom)
+          .lte("date", params.dateTo)
+          .order("submission_id", { ascending: true })
+          .order("date", { ascending: true })
+          .range(from, to),
+      "daily breakdowns for date range"
+    );
 
     const dailyBySubmission = new Map<string, DbDailyBreakdown[]>();
-    (allDailyBreakdowns || []).forEach((db) => {
+    allDailyBreakdowns.forEach((db) => {
       const existing = dailyBySubmission.get(db.submission_id) || [];
       existing.push(db);
       dailyBySubmission.set(db.submission_id, existing);
@@ -987,7 +1110,7 @@ class SupabaseSubmissionsService implements SubmissionsService {
 // SUPABASE PROFILES SERVICE
 // ============================================================================
 
-class SupabaseProfilesService implements ProfilesService {
+export class SupabaseProfilesService implements ProfilesService {
   private client: SupabaseClient;
 
   constructor(client: SupabaseClient) {

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -256,6 +256,18 @@ export interface DeleteResult {
     username?: string;
     createdAt: number;
   }>;
+  /**
+   * Rows removed per table. A profile is only the account record — the
+   * leaderboard itself reads `submissions`, and `raw_submissions` holds the
+   * archived payload with no FK to either. Reporting the breakdown makes a
+   * partial delete visible instead of silently leaving the entry on the board.
+   */
+  deletedRows: {
+    profiles: number;
+    submissions: number;
+    dailyBreakdowns: number;
+    rawSubmissions: number;
+  };
 }
 
 export interface FindProfilesResult {

--- a/test/submissions.test.mts
+++ b/test/submissions.test.mts
@@ -330,4 +330,57 @@ const mergeRows = () => ({
   check("post-commit profile errors do not turn success into failure");
 }
 
+// ---------------------------------------------------------------------------
+// Deleting an account must remove it from the board, not just its profile row
+// ---------------------------------------------------------------------------
+
+const { SupabaseProfilesService } = await import("../src/lib/data/supabase/client.ts");
+
+const deletionRows = () => ({
+  profiles: [{ id: "profile-1", username: "spammer", github_username: "spammer", created_at: "2026-01-01T00:00:00Z" }],
+  submissions: [{ id: "submission-1", username: "spammer" }],
+  daily_breakdowns: [{ id: "day-1", submission_id: "submission-1" }, { id: "day-2", submission_id: "submission-1" }],
+  raw_submissions: [{ id: "raw-1" }, { id: "raw-2" }],
+});
+
+{
+  const client = new FakeClient(deletionRows());
+  const profiles = new SupabaseProfilesService(client as never);
+  const result = await profiles.deleteByPattern(["spammer"], { searchField: "username" });
+
+  const deletedTables = client.calls
+    .filter((c) => c.operation === "delete")
+    .map((c) => c.table);
+
+  assert.ok(
+    deletedTables.includes("submissions"),
+    "deleting an account must delete its submissions — the leaderboard reads that table, not profiles"
+  );
+  assert.ok(deletedTables.includes("raw_submissions"), "the archived payload must go too");
+  assert.ok(deletedTables.includes("profiles"), "the profile row must go");
+
+  assert.deepEqual(result.deletedRows, {
+    profiles: 1,
+    submissions: 1,
+    dailyBreakdowns: 2,
+    rawSubmissions: 2,
+  });
+  check("account delete removes submissions and archive, not just the profile");
+}
+
+{
+  const client = new FakeClient(deletionRows());
+  const profiles = new SupabaseProfilesService(client as never);
+  const result = await profiles.deleteByPattern(["spammer"], { searchField: "username", dryRun: true });
+
+  assert.equal(
+    client.calls.filter((c) => c.operation === "delete").length,
+    0,
+    "a dry run must not delete anything"
+  );
+  assert.equal(result.matchedCount, 1);
+  assert.match(result.message, /would delete 1 profiles, 1 submissions, 2 daily rows, 2 archived payloads/);
+  check("dry run reports the full blast radius without deleting");
+}
+
 console.log(`\n${passed} passed, 0 failed`);

--- a/test/submissions.test.mts
+++ b/test/submissions.test.mts
@@ -1,0 +1,333 @@
+/**
+ * Submission data-layer tests.
+ *
+ * These drive the real SupabaseSubmissionsService against a fake PostgREST
+ * client. Dependencies are injected rather than module-mocked: `mock.module`
+ * does not compose with tsx's CJS interop, so an alias-mocked route test
+ * silently exercises nothing.
+ */
+import assert from "node:assert/strict";
+import type { SubmitData } from "../src/lib/data/types.ts";
+
+// Dynamic import: tsx transpiles the source to CJS, so a static named import
+// fails to bind at instantiation time.
+const { SupabaseSubmissionsService } = await import("../src/lib/data/supabase/client.ts");
+
+let passed = 0;
+const check = (label: string) => {
+  passed++;
+  console.log(`✓ ${label}`);
+};
+
+// ---------------------------------------------------------------------------
+// Fake PostgREST client
+// ---------------------------------------------------------------------------
+
+interface Call {
+  table: string;
+  operation: "select" | "insert" | "update" | "upsert" | "delete";
+  payload?: unknown;
+  options?: unknown;
+  range?: [number, number];
+}
+
+interface FakeError {
+  message: string;
+  code?: string;
+}
+
+type Rows = Record<string, unknown>;
+type Errors = Record<string, FakeError>;
+
+/**
+ * Mimics the parts of PostgREST that matter here: a chainable builder that
+ * resolves to { data, error }, and — critically — a server-side row cap that
+ * silently truncates responses, which is the bug class these tests guard.
+ */
+class FakeQuery implements PromiseLike<{ data: unknown; error: FakeError | null }> {
+  private operation: Call["operation"] = "select";
+  private payload: unknown;
+  private options: unknown;
+  private rangeFrom = 0;
+  private rangeTo = Infinity;
+  private isSingle = false;
+
+  constructor(
+    private readonly table: string,
+    private readonly calls: Call[],
+    private readonly rows: Rows,
+    private readonly errors: Errors,
+    private readonly maxRows: number
+  ) {}
+
+  select(): this { this.operation = "select"; return this; }
+  insert(payload: unknown): this { this.operation = "insert"; this.payload = payload; return this; }
+  update(payload: unknown): this { this.operation = "update"; this.payload = payload; return this; }
+  upsert(payload: unknown, options?: unknown): this {
+    this.operation = "upsert";
+    this.payload = payload;
+    this.options = options;
+    return this;
+  }
+  delete(): this { this.operation = "delete"; return this; }
+
+  range(from: number, to: number): this { this.rangeFrom = from; this.rangeTo = to; return this; }
+  single(): this { this.isSingle = true; return this; }
+
+  eq(): this { return this; }
+  ilike(): this { return this; }
+  or(): this { return this; }
+  in(): this { return this; }
+  gte(): this { return this; }
+  lte(): this { return this; }
+  limit(): this { return this; }
+  order(): this { return this; }
+  contains(): this { return this; }
+
+  then<T1 = { data: unknown; error: FakeError | null }, T2 = never>(
+    onfulfilled?: ((v: { data: unknown; error: FakeError | null }) => T1 | PromiseLike<T1>) | null,
+    onrejected?: ((r: unknown) => T2 | PromiseLike<T2>) | null
+  ): PromiseLike<T1 | T2> {
+    this.calls.push({
+      table: this.table,
+      operation: this.operation,
+      payload: this.payload,
+      options: this.options,
+      range: this.rangeTo === Infinity ? undefined : [this.rangeFrom, this.rangeTo],
+    });
+
+    const error = this.errors[`${this.table}:${this.operation}`] ?? null;
+    let data = this.rows[this.table] ?? null;
+
+    if (!error && Array.isArray(data)) {
+      // Apply the requested window, then the server cap — the cap applies even
+      // when the client asked for more, which is exactly why paging is needed.
+      const windowed = data.slice(this.rangeFrom, this.rangeTo + 1);
+      data = windowed.slice(0, this.maxRows);
+    }
+    if (!error && this.isSingle && Array.isArray(data)) {
+      data = data[0] ?? null;
+    }
+
+    return Promise.resolve({ data, error }).then(onfulfilled, onrejected);
+  }
+}
+
+class FakeClient {
+  readonly calls: Call[] = [];
+
+  constructor(
+    private readonly rows: Rows,
+    private readonly errors: Errors = {},
+    private readonly maxRows = 1000
+  ) {}
+
+  from(table: string): FakeQuery {
+    return new FakeQuery(table, this.calls, this.rows, this.errors, this.maxRows);
+  }
+}
+
+const allowRateLimit = { checkLimit: async () => ({ allowed: true, remaining: 1 }) };
+
+const makeService = (rows: Rows, errors: Errors = {}, maxRows = 1000) => {
+  const client = new FakeClient(rows, errors, maxRows);
+  return { client, service: new SupabaseSubmissionsService(client as never, allowRateLimit) };
+};
+
+// ---------------------------------------------------------------------------
+// Fixtures: a 270-day history, the shape from issue #93
+// ---------------------------------------------------------------------------
+
+const DAY_COUNT = 270;
+
+const daily = Array.from({ length: DAY_COUNT }, (_, i) => ({
+  date: new Date(Date.UTC(2025, 0, i + 1)).toISOString().slice(0, 10),
+  inputTokens: 1000,
+  outputTokens: 500,
+  cacheCreationTokens: 0,
+  cacheReadTokens: 0,
+  totalTokens: 1500,
+  totalCost: 1.25,
+  modelsUsed: ["claude-opus-4"],
+  agents: ["claude"],
+}));
+
+const totals = daily.reduce(
+  (acc, d) => ({
+    inputTokens: acc.inputTokens + d.inputTokens,
+    outputTokens: acc.outputTokens + d.outputTokens,
+    cacheCreationTokens: 0,
+    cacheReadTokens: 0,
+    totalTokens: acc.totalTokens + d.totalTokens,
+    totalCost: acc.totalCost + d.totalCost,
+  }),
+  { inputTokens: 0, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 0, totalCost: 0 }
+);
+
+const submission: SubmitData = {
+  username: "long-history",
+  githubUsername: "long-history",
+  source: "cli",
+  verified: false,
+  machineId: "machine-a",
+  ccData: { totals, daily, tools: ["claude"] },
+};
+
+const existingDailyRows = daily.map((d, i) => ({
+  id: `day-${i}`,
+  submission_id: "submission-1",
+  date: d.date,
+  input_tokens: 10,
+  output_tokens: 5,
+  cache_creation_tokens: 0,
+  cache_read_tokens: 0,
+  total_tokens: 15,
+  total_cost: 0.01,
+  models_used: ["claude-opus-4"],
+  agents: ["claude"],
+  model_breakdowns: null,
+  machine_contributions: null,
+}));
+
+const mergeRows = () => ({
+  submissions: [{ id: "submission-1", models_used: ["claude-opus-4"], tools: ["claude"] }],
+  daily_breakdowns: existingDailyRows,
+  profiles: [{ id: "profile-1", total_submissions: 1 }],
+});
+
+// ---------------------------------------------------------------------------
+// #93 — a long history must not need a round-trip per day
+// ---------------------------------------------------------------------------
+
+{
+  const { client, service } = makeService(mergeRows());
+  await service.submit(submission);
+
+  const dailyWrites = client.calls.filter(
+    (c) => c.table === "daily_breakdowns" && c.operation !== "select"
+  );
+
+  assert.equal(
+    dailyWrites.length,
+    1,
+    `expected a single bulk write, got ${dailyWrites.length}`
+  );
+  assert.equal(dailyWrites[0].operation, "upsert");
+  assert.deepEqual(dailyWrites[0].options, { onConflict: "submission_id,date" });
+  assert.equal((dailyWrites[0].payload as unknown[]).length, DAY_COUNT);
+  check(`${DAY_COUNT}-day merge writes once instead of ${DAY_COUNT} times`);
+}
+
+// ---------------------------------------------------------------------------
+// Truncation guards — the silent-cap bug class (#97)
+// ---------------------------------------------------------------------------
+
+{
+  // A one-day re-submit against a 270-day stored history, under a 100-row
+  // server cap. Totals are recomputed from the rows the merge reads and
+  // written back to the parent, so the days it fails to read are days the
+  // user loses. The incoming payload must be *smaller* than the stored
+  // history for this to discriminate — if it covered all 270 days it would
+  // repopulate the map itself and pass even with a truncated read.
+  const oneDay = daily[0];
+  const resubmit: SubmitData = {
+    ...submission,
+    ccData: {
+      totals: {
+        inputTokens: oneDay.inputTokens,
+        outputTokens: oneDay.outputTokens,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: oneDay.totalTokens,
+        totalCost: oneDay.totalCost,
+      },
+      daily: [oneDay],
+      tools: ["claude"],
+    },
+  };
+
+  // 269 untouched stored days, plus the one day this submission replaces.
+  const expectedCost = (DAY_COUNT - 1) * 0.01 + oneDay.totalCost;
+  const expectedTokens = (DAY_COUNT - 1) * 15 + oneDay.totalTokens;
+
+  const { client, service } = makeService(mergeRows(), {}, 100);
+  await service.submit(resubmit);
+
+  const parentUpdate = client.calls.find(
+    (c) => c.table === "submissions" && c.operation === "update"
+  );
+  const written = parentUpdate!.payload as { total_cost: number; total_tokens: number };
+
+  assert.ok(
+    Math.abs(written.total_cost - expectedCost) < 1e-9,
+    `totals came from a truncated read: got ${written.total_cost}, expected ${expectedCost}`
+  );
+  assert.equal(written.total_tokens, expectedTokens);
+  check("merge pages past the server row cap instead of shrinking totals");
+}
+
+{
+  // A failing page must not look like the end of the data.
+  const { service } = makeService(mergeRows(), {
+    "daily_breakdowns:select": { message: "connection reset" },
+  });
+  await assert.rejects(
+    () => service.submit(submission),
+    /Failed to query existing daily breakdowns: connection reset/
+  );
+  check("a failed page raises instead of silently truncating");
+}
+
+// ---------------------------------------------------------------------------
+// Error propagation — writes must not fail silently
+// ---------------------------------------------------------------------------
+
+{
+  const { service } = makeService(mergeRows(), {
+    "daily_breakdowns:upsert": { message: "constraint violation" },
+  });
+  await assert.rejects(
+    () => service.submit(submission),
+    /Failed to update daily breakdowns: constraint violation/
+  );
+  check("bulk daily write errors surface");
+}
+
+{
+  const { service } = makeService(mergeRows(), {
+    "submissions:update": { message: "deadlock detected" },
+  });
+  await assert.rejects(
+    () => service.submit(submission),
+    /Failed to update existing submission: deadlock detected/
+  );
+  check("parent submission update errors surface");
+}
+
+// ---------------------------------------------------------------------------
+// #93 — a post-commit projection failure must not report failure
+// ---------------------------------------------------------------------------
+
+{
+  const { service } = makeService(mergeRows(), {
+    "profiles:update": { message: "profiles table unavailable" },
+  });
+
+  const originalError = console.error;
+  console.error = () => undefined;
+  let id: string;
+  try {
+    id = await service.submit(submission);
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.equal(
+    id,
+    "submission-1",
+    "a profile failure after the submission committed must not fail the request"
+  );
+  check("post-commit profile errors do not turn success into failure");
+}
+
+console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
Fixes three live data-loss bugs and one broken admin primitive. Every commit is independently green (`npm test`, `tsc`, `eslint`, `next build`).

This supersedes #80, #94 and #97, and takes a different fix for #71. The diagnostic work in those PRs was correct and did most of the thinking here — see the per-PR comments for what changed and why.

## 1. Capped reads silently dropped rows

PostgREST caps every response at `db-max-rows` (1000 by default) and does so *silently*, so `.limit(50000)` in the date-range leaderboard never did what it looked like.

Truncation was worse than a partial result: daily rows are grouped by submission, and any submission with zero rows in range is skipped by the `filteredDaily.length === 0` guard — so users past the cut **vanished from the board entirely** rather than showing a low total. With no `ORDER BY`, it was arbitrary which ones survived.

Added a `fetchAllPages` helper. It advances by the rows actually returned and stops only on an empty page. Stopping at `length < PAGE_SIZE` would assume the server cap is at least `PAGE_SIZE` — if it were configured lower, every page comes back short and you truncate at the first one, which is the bug being fixed.

Also applied to the merge path's existing-rows read, which nobody flagged: totals are recomputed from those rows and written back to the parent submission, so a capped read would silently **shrink a user's lifetime totals**. Latent at ~800 days of history today.

## 2. Committed submissions reported as `cc.json` errors (#93)

The 25s `Promise.race` did not cancel the underlying writes, so data committed while the request reported failure — blaming a `cc.json` that was never the problem. Dropped the race; the merge is bulk-written now so long histories don't approach the request budget.

Behind it, the merge issued **one round-trip per day** (~270 for the reported case). Now built in memory and upserted once against the existing `UNIQUE(submission_id, date)` constraint, which also collapses the insert-or-update branch — the constraint decides, not a prior read.

Error mapping fixed too:
- `"Database operation timed out"` matched neither `includes("timeout")` nor `includes("deadline")`, so real timeouts fell through to the generic 500.
- `"Failed to query/update/create"` were listed as *validation* errors returning 400 — telling users their file was malformed when the fault was ours. Now 503, checked **before** the looser `includes("query")` branch that would otherwise catch them first.
- Supabase errors were discarded around the merge, so failed writes looked like successes. Now propagated — except `updateProfile`, which runs after the submission is already durable and must not turn an accepted submission into a client-facing failure.

## 3. Leaderboard blanked after a filter reset (#71)

`isSeededDefaultView` tested `initialItems.length > 0`, which never becomes false. Filter → clear filter matched the seeded default again and skipped the fetch, while the filter-change effect had already emptied `allItems`.

Gated on a ref that latches on a real filter change. Gating on `firstRender` fixes the blank board but discards the SSR seed on **every** load, since `useSession` and `useGlobalStats` both set state after mount and guarantee a re-render.

## 4. Account deletion didn't delete the account

`deleteByPattern` deleted only `profiles`. The leaderboard reads `submissions`, so a "deleted" account kept its rank; `raw_submissions` has no FK to either table and kept the archived payload indefinitely. It reported success either way.

Now deletes submissions, daily rows and archived payloads alongside the profile, children before parents, errors surfaced, with per-table counts in `DeleteResult` so a partial delete is visible. The profile scan is paged in both `deleteByPattern` and `findByPattern` — the latter is the delete's *preview*, so a capped preview would show fewer accounts than the delete then removed.

Found while servicing #99 by hand: that entry had 1 submission, 32 daily rows and 5 archived payloads, none of which a profile-only delete would have touched.

## Tests

8 new cases, dependency-injected against a fake PostgREST client that models the silent row cap. Each was verified to **fail** against the unfixed code — the truncation case with `got 2.24, expected 3.94`, the delete case with `must delete its submissions`.

They inject dependencies rather than use `mock.module`, which cannot intercept through tsx's CJS interop; an alias-mocked route test silently exercises nothing and fails outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)