### PR TITLE
fix: chunk .in() id lists so oversized filters stop failing silently

### DIFF
--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -222,6 +222,41 @@ async function fetchAllPages<T>(
   return all;
 }
 
+/**
+ * `.in("col", ids)` is serialised into the query string, so a large id list
+ * builds a URL the server refuses. Measured against production: ~350 UUIDs is
+ * the ceiling, and past it the request fails outright rather than degrading.
+ *
+ * That failure was invisible — callers destructured `{ data }` and read a
+ * null as "no rows", so `getGlobalStats` silently reported 0 days tracked and
+ * the date-range leaderboard returned an empty board. Chunk well under the
+ * limit and page each chunk.
+ */
+const IN_FILTER_CHUNK = 200;
+
+async function fetchAllByIds<T>(
+  ids: string[],
+  buildPage: (
+    chunk: string[],
+    from: number,
+    to: number
+  ) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  context: string
+): Promise<T[]> {
+  if (ids.length === 0) return [];
+
+  const all: T[] = [];
+  for (let i = 0; i < ids.length; i += IN_FILTER_CHUNK) {
+    const chunk = ids.slice(i, i + IN_FILTER_CHUNK);
+    const rows = await fetchAllPages<T>(
+      (from, to) => buildPage(chunk, from, to),
+      context
+    );
+    all.push(...rows);
+  }
+  return all;
+}
+
 // ============================================================================
 // SUPABASE SUBMISSIONS SERVICE
 // ============================================================================
@@ -671,29 +706,31 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     // covers a submission's full range, not the requested window) so we have
     // to aggregate `daily_breakdowns`. Push the range filter down to the DB:
     // only fetch submissions whose date_range overlaps the requested window.
-    // Hard cap of 5000 is a safety belt — viberank has ~hundreds of rows.
-    const SUBMISSION_CAP = 5000;
-    let query = this.client
-      .from("submissions")
-      .select("*")
-      .lte("date_range_start", params.dateTo)
-      .gte("date_range_end", params.dateFrom);
+    // A `.limit(5000)` here was silently served as 1000 by db-max-rows, so
+    // submissions past the first thousand were never considered at all. Page it.
+    const submissions = await fetchAllPages<DbSubmission>((from, to) => {
+      let query = this.client
+        .from("submissions")
+        .select("*")
+        .lte("date_range_start", params.dateTo)
+        .gte("date_range_end", params.dateFrom);
 
-    if (!includeFlagged) {
-      query = query.or("flagged_for_review.is.null,flagged_for_review.eq.false");
-    }
+      if (!includeFlagged) {
+        query = query.or("flagged_for_review.is.null,flagged_for_review.eq.false");
+      }
 
-    if (params.tool) {
-      query = query.contains("tools", [params.tool]);
-    }
+      if (params.tool) {
+        query = query.contains("tools", [params.tool]);
+      }
 
-    if (params.verifiedOnly) {
-      query = query.eq("verified", true);
-    }
+      if (params.verifiedOnly) {
+        query = query.eq("verified", true);
+      }
 
-    const { data: submissions } = await query.limit(SUBMISSION_CAP);
+      return query.order("id", { ascending: true }).range(from, to);
+    }, "submissions for date range");
 
-    if (!submissions || submissions.length === 0) {
+    if (submissions.length === 0) {
       return { items: [], hasMore: false };
     }
 
@@ -703,12 +740,17 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     // because the loop below skips any submission with zero rows in range, the
     // users past the cut vanished from the board rather than showing a partial
     // total. With no ORDER BY it was also arbitrary which ones survived.
-    const allDailyBreakdowns = await fetchAllPages<DbDailyBreakdown>(
-      (from, to) =>
+    //
+    // The id list also has to be chunked: past ~350 ids the `.in()` filter
+    // builds a URL the server rejects, which failed the whole query and
+    // emptied the board for any wide range.
+    const allDailyBreakdowns = await fetchAllByIds<DbDailyBreakdown>(
+      submissionIds,
+      (chunk, from, to) =>
         this.client
           .from("daily_breakdowns")
           .select("*")
-          .in("submission_id", submissionIds)
+          .in("submission_id", chunk)
           .gte("date", params.dateFrom)
           .lte("date", params.dateTo)
           .order("submission_id", { ascending: true })
@@ -797,14 +839,24 @@ export class SupabaseSubmissionsService implements SubmissionsService {
 
     if (!submissions) return [];
 
+    // Up to 50 submissions here, but each can carry hundreds of daily rows, so
+    // the total is well past the 1000-row response cap.
     const submissionIds = submissions.map((s) => s.id);
-    const { data: allDailyBreakdowns } = await this.client
-      .from("daily_breakdowns")
-      .select("*")
-      .in("submission_id", submissionIds);
+    const allDailyBreakdowns = await fetchAllByIds<DbDailyBreakdown>(
+      submissionIds,
+      (chunk, from, to) =>
+        this.client
+          .from("daily_breakdowns")
+          .select("*")
+          .in("submission_id", chunk)
+          .order("submission_id", { ascending: true })
+          .order("date", { ascending: true })
+          .range(from, to),
+      "daily breakdowns for flagged submissions"
+    );
 
     const dailyBySubmission = new Map<string, DbDailyBreakdown[]>();
-    (allDailyBreakdowns || []).forEach((db) => {
+    allDailyBreakdowns.forEach((db) => {
       const existing = dailyBySubmission.get(db.submission_id) || [];
       existing.push(db);
       dailyBySubmission.set(db.submission_id, existing);
@@ -885,18 +937,28 @@ export class SupabaseSubmissionsService implements SubmissionsService {
         new Date(b.submitted_at).getTime() - new Date(a.submitted_at).getTime()
       )[0];
 
-    // Get all daily breakdowns
+    // Get all daily breakdowns. The merged result is written back as the
+    // surviving submission, so a capped read here would silently discard the
+    // days it failed to see — data loss during a claim, not just a bad view.
     const submissionIds = submissions.map((s) => s.id);
-    const { data: allDailyBreakdowns } = await this.client
-      .from("daily_breakdowns")
-      .select("*")
-      .in("submission_id", submissionIds);
+    const allDailyBreakdowns = await fetchAllByIds<DbDailyBreakdown>(
+      submissionIds,
+      (chunk, from, to) =>
+        this.client
+          .from("daily_breakdowns")
+          .select("*")
+          .in("submission_id", chunk)
+          .order("submission_id", { ascending: true })
+          .order("date", { ascending: true })
+          .range(from, to),
+      "daily breakdowns for claim merge"
+    );
 
     // Merge daily data (OAuth takes priority)
     const dailyMap = new Map<string, DbDailyBreakdown>();
     for (const submission of submissions) {
       const isOauth = submission.source === "oauth";
-      const daily = (allDailyBreakdowns || []).filter(
+      const daily = allDailyBreakdowns.filter(
         (d) => d.submission_id === submission.id
       );
       for (const day of daily) {
@@ -1139,14 +1201,24 @@ export class SupabaseProfilesService implements ProfilesService {
       .order("submitted_at", { ascending: false })
       .limit(limit);
 
+    // A heavy user's few submissions can still hold thousands of daily rows,
+    // so an uncapped read here truncated the profile's own history.
     const submissionIds = (submissions || []).map((s) => s.id);
-    const { data: allDailyBreakdowns } = await this.client
-      .from("daily_breakdowns")
-      .select("*")
-      .in("submission_id", submissionIds);
+    const allDailyBreakdowns = await fetchAllByIds<DbDailyBreakdown>(
+      submissionIds,
+      (chunk, from, to) =>
+        this.client
+          .from("daily_breakdowns")
+          .select("*")
+          .in("submission_id", chunk)
+          .order("submission_id", { ascending: true })
+          .order("date", { ascending: true })
+          .range(from, to),
+      "daily breakdowns for profile"
+    );
 
     const dailyBySubmission = new Map<string, DbDailyBreakdown[]>();
-    (allDailyBreakdowns || []).forEach((db) => {
+    allDailyBreakdowns.forEach((db) => {
       const existing = dailyBySubmission.get(db.submission_id) || [];
       existing.push(db);
       dailyBySubmission.set(db.submission_id, existing);
@@ -1463,7 +1535,7 @@ export class SupabaseProfilesService implements ProfilesService {
 // SUPABASE STATS SERVICE
 // ============================================================================
 
-class SupabaseStatsService implements StatsService {
+export class SupabaseStatsService implements StatsService {
   private client: SupabaseClient;
 
   constructor(client: SupabaseClient) {
@@ -1492,15 +1564,27 @@ class SupabaseStatsService implements StatsService {
     const modelUsage: Record<string, number> = {};
     let topSubmission: DbSubmission | null = null;
 
-    // Get daily breakdown counts for totalDays
+    // Get daily breakdown counts for totalDays.
+    //
+    // This asked for 500 ids in one `.in()`, which exceeds what the server
+    // will accept in a URL — the request failed, the null was read as "no
+    // rows", and every submission contributed 0 days. The site reported
+    // totalDays: 0 while every other stat looked right.
     const submissionIds = (topByCost || []).map((s) => s.id);
-    const { data: dailyCounts } = await this.client
-      .from("daily_breakdowns")
-      .select("submission_id")
-      .in("submission_id", submissionIds);
+    const dailyCounts = await fetchAllByIds<{ submission_id: string }>(
+      submissionIds,
+      (chunk, from, to) =>
+        this.client
+          .from("daily_breakdowns")
+          .select("submission_id")
+          .in("submission_id", chunk)
+          .order("submission_id", { ascending: true })
+          .range(from, to),
+      "daily counts for global stats"
+    );
 
     const daysPerSubmission = new Map<string, number>();
-    (dailyCounts || []).forEach((d) => {
+    dailyCounts.forEach((d) => {
       daysPerSubmission.set(
         d.submission_id,
         (daysPerSubmission.get(d.submission_id) || 0) + 1

--- a/test/submissions.test.mts
+++ b/test/submissions.test.mts
@@ -45,19 +45,19 @@ type Errors = Record<string, FakeError>;
  * silently truncates responses, which is the bug class these tests guard.
  */
 class FakeQuery implements PromiseLike<{ data: unknown; error: FakeError | null }> {
-  private operation: Call["operation"] = "select";
+  protected operation: Call["operation"] = "select";
   private payload: unknown;
   private options: unknown;
-  private rangeFrom = 0;
-  private rangeTo = Infinity;
+  protected rangeFrom = 0;
+  protected rangeTo = Infinity;
   private isSingle = false;
 
   constructor(
-    private readonly table: string,
-    private readonly calls: Call[],
-    private readonly rows: Rows,
-    private readonly errors: Errors,
-    private readonly maxRows: number
+    protected readonly table: string,
+    protected readonly calls: Call[],
+    protected readonly rows: Rows,
+    protected readonly errors: Errors,
+    protected readonly maxRows: number
   ) {}
 
   select(): this { this.operation = "select"; return this; }
@@ -117,9 +117,9 @@ class FakeClient {
   readonly calls: Call[] = [];
 
   constructor(
-    private readonly rows: Rows,
-    private readonly errors: Errors = {},
-    private readonly maxRows = 1000
+    protected readonly rows: Rows,
+    protected readonly errors: Errors = {},
+    protected readonly maxRows = 1000
   ) {}
 
   from(table: string): FakeQuery {
@@ -381,6 +381,77 @@ const deletionRows = () => ({
   assert.equal(result.matchedCount, 1);
   assert.match(result.message, /would delete 1 profiles, 1 submissions, 2 daily rows, 2 archived payloads/);
   check("dry run reports the full blast radius without deleting");
+}
+
+// ---------------------------------------------------------------------------
+// Large id lists must be chunked — `.in()` fails outright past ~350 uuids
+// ---------------------------------------------------------------------------
+
+const { SupabaseStatsService } = await import("../src/lib/data/supabase/client.ts");
+
+{
+  // Model the real server: reject any request whose `.in()` list is too long,
+  // the way production does past ~350 ids.
+  const IN_LIMIT = 350;
+  const submissions = Array.from({ length: 500 }, (_, i) => ({
+    id: `sub-${i}`,
+    username: `user-${i}`,
+    total_cost: 10,
+    total_tokens: 100,
+    models_used: ["claude-opus-4"],
+    tools: ["claude"],
+  }));
+  // One daily row per submission, so a working query yields 500 days total.
+  const dailyRows = submissions.map((s, i) => ({ id: `d-${i}`, submission_id: s.id }));
+
+  class UrlLimitedQuery extends FakeQuery {
+    private inIds: string[] | null = null;
+    in(_col: string, ids: string[]) {
+      this.inIds = ids;
+      return this;
+    }
+    then(onfulfilled?: never, onrejected?: never) {
+      // Too many ids in the URL: the server rejects the whole request.
+      if (this.inIds && this.inIds.length > IN_LIMIT) {
+        return Promise.resolve({ data: null, error: { message: "Bad Request" } }).then(
+          onfulfilled,
+          onrejected
+        );
+      }
+      // Otherwise actually honour the filter, so chunks return disjoint rows
+      // rather than the whole table each time.
+      if (this.inIds) {
+        const wanted = new Set(this.inIds);
+        const all = (this.rows[this.table] as Array<{ submission_id?: string }>) ?? [];
+        const matched = all.filter((r) => wanted.has(r.submission_id!));
+        const windowed = matched.slice(this.rangeFrom, this.rangeTo + 1).slice(0, this.maxRows);
+        return Promise.resolve({ data: windowed, error: null }).then(onfulfilled, onrejected);
+      }
+      return super.then(onfulfilled, onrejected);
+    }
+  }
+
+  class UrlLimitedClient extends FakeClient {
+    from(table: string) {
+      const q = new UrlLimitedQuery(table, this.calls, this.rows, this.errors, this.maxRows);
+      return q;
+    }
+  }
+
+  const client = new UrlLimitedClient(
+    { submissions, daily_breakdowns: dailyRows },
+    {},
+    1000
+  );
+  const stats = new SupabaseStatsService(client as never);
+  const result = await stats.getGlobalStats();
+
+  assert.equal(
+    result.totalDays,
+    500,
+    `totalDays came back ${result.totalDays} — an over-long .in() failed and the null was read as "no rows"`
+  );
+  check("global stats chunks large id lists instead of reporting 0 days");
 }
 
 console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
Follow-up to #100, found by verifying that fix against production rather than trusting the tests.

**`viberank.app` is currently serving `"totalDays":0` on the homepage.** Not a rounding issue — the query that computes it fails outright and the failure is swallowed.

## The bug

`.in("col", ids)` is serialised into the query string, so a large id list builds a URL the server refuses. Measured directly against the production database, three times per size:

| ids | result |
|---|---|
| 300 | ok |
| 350 | ok |
| 400 | `fetch failed` |
| 500 | `fetch failed` |
| 662 | `Bad Request` |

Every call site destructured `{ data }` and ignored `error`, so a null read as "no rows" rather than "this failed":

- **`getGlobalStats`** passes `.limit(500)` submission ids. The query fails, `daysPerSubmission` stays empty, and every submission contributes 0 days. Confirmed live — `"totalDays":0` in the homepage payload while `avgTokensPerUser` is a real number.
- **`getLeaderboardByDateRange`** passes one id per overlapping submission. A full-year range currently selects 662, so the query fails and the board comes back empty.

Added `fetchAllByIds`, which chunks to 200 and pages each chunk.

## Two related caps, same family

- `getLeaderboardByDateRange` asked for `.limit(5000)` submissions and was silently served **1000** by `db-max-rows`. There are 1131 submissions today, so 131 were never considered at all. Now paged.
- `getProfile` and `getFlaggedSubmissions` bounded their *submission* count but not the daily rows behind it. 25 submissions of a few hundred days each is well past the 1000-row cap, so a heavy user's own profile page was truncating their history.

The claim/merge path gets the same treatment, where truncation is worst: the merged result is written back as the surviving submission, so days it failed to read would be **permanently discarded**, not merely unrendered.

## Why this wasn't caught in #100

#100's fake client modelled the row cap but not the URL-length limit, so the tests passed while production failed. The new test models both — it rejects any request whose `.in()` list exceeds 350 ids, and honours the filter so chunks return disjoint rows instead of the whole table each time. Against unchunked code it fails with `Failed to query daily counts for global stats: Bad Request`.

Worth stating plainly: the tests in #100 were green and the code was still broken in production. The row-cap fix was right, but I only found this by querying the real database afterwards.

## Safety

`getGlobalStats` now throws rather than silently returning zeros. Both server call sites (`page.tsx:22`, `stats/page.tsx:89`) already use `.catch(() => null)` and the client hook catches into error state, so this degrades rather than 500ing the page.

`npm test` (9 cases), `tsc`, `eslint` and `next build` all clean; no new type or lint errors versus `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)