### PR TITLE
feat: subscription-vs-API cost calculator at /calculator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node test/ccusage.test.mts && node test/streaks.test.mts && node --import tsx test/submissions.test.mts"
+    "test": "for f in test/*.test.mts; do echo \"\n--- $f ---\"; node --import tsx \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@auth/core": "^0.40.0",

--- a/src/app/calculator/CalculatorClient.tsx
+++ b/src/app/calculator/CalculatorClient.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { DollarSign, TrendingDown, Users, AlertTriangle } from "lucide-react";
+import { comparePlans, coversBurn, percentileOf, PLANS } from "@/lib/plans";
+import { formatUsd } from "@/lib/utils";
+
+interface Props {
+  /** Ascending monthly burns for everyone on the board. */
+  cohort: number[];
+  cohortSize: number;
+  medianBurn: number;
+}
+
+const PRESETS = [
+  { label: "Light", burn: 175 },
+  { label: "Typical", burn: 1300 },
+  { label: "Heavy", burn: 6450 },
+];
+
+export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Props) {
+  const [raw, setRaw] = useState("");
+
+  const burn = useMemo(() => {
+    const parsed = Number.parseFloat(raw.replace(/[^0-9.]/g, ""));
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }, [raw]);
+
+  const verdict = useMemo(() => comparePlans(burn), [burn]);
+  const percentile = useMemo(() => percentileOf(cohort, burn), [cohort, burn]);
+
+  const hasInput = burn > 0;
+  const saves = verdict.savingVsApi > 0;
+
+  return (
+    <div className="space-y-8">
+      {/* Input */}
+      <div className="bg-surface-1 border border-border rounded-lg p-5 sm:p-6">
+        <label htmlFor="burn" className="block micro-label mb-2">
+          Your monthly API-equivalent spend
+        </label>
+        <div className="relative">
+          <span className="absolute left-4 top-1/2 -translate-y-1/2 text-muted text-xl font-mono">
+            $
+          </span>
+          <input
+            id="burn"
+            inputMode="decimal"
+            value={raw}
+            onChange={(event) => setRaw(event.target.value)}
+            placeholder="1,300"
+            className="w-full bg-background border border-border rounded-md pl-9 pr-4 py-3 text-2xl font-mono
+                       focus:outline-none focus:border-accent transition-colors"
+          />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 mt-3">
+          <span className="text-xs text-muted mr-1">Try:</span>
+          {PRESETS.map((preset) => (
+            <button
+              key={preset.label}
+              type="button"
+              onClick={() => setRaw(String(preset.burn))}
+              className="text-xs px-2.5 py-1 rounded border border-border hover:border-accent
+                         hover:text-accent transition-colors"
+            >
+              {preset.label} · ${preset.burn.toLocaleString()}
+            </button>
+          ))}
+        </div>
+
+        <p className="text-xs text-muted mt-4 leading-relaxed">
+          Run <code className="text-accent">npx ccusage@latest --json</code> and use the{" "}
+          <code className="text-accent">totalCost</code> for a month. That figure is what your
+          usage <em>would</em> cost at API list prices — not what you actually paid.
+        </p>
+      </div>
+
+      {!hasInput ? (
+        <div className="border border-dashed border-border rounded-lg p-8 text-center">
+          <p className="text-muted text-sm">
+            Enter a number above to see which plan fits and where you rank.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Verdict */}
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1">
+                <DollarSign className="w-3.5 h-3.5" />
+                Cheapest plan
+              </p>
+              <p className="text-xl font-bold">{verdict.recommended.name}</p>
+              <p className="text-xs text-muted mt-1">
+                ${verdict.recommended.monthly}/mo · {verdict.recommended.blurb}
+              </p>
+            </div>
+
+            <div
+              className={`border rounded-lg p-4 ${
+                saves ? "bg-accent-soft border-accent/40" : "bg-surface-1 border-border"
+              }`}
+            >
+              <p className="flex items-center gap-1.5 micro-label mb-1">
+                <TrendingDown className="w-3.5 h-3.5" />
+                {saves ? "You save" : "API is cheaper"}
+              </p>
+              <p className={`text-xl font-bold font-mono ${saves ? "text-accent" : ""}`}>
+                {formatUsd(Math.abs(verdict.savingVsApi))}
+                <span className="text-sm font-sans text-muted">/mo</span>
+              </p>
+              <p className="text-xs text-muted mt-1">
+                {saves
+                  ? `the plan pays for itself ${verdict.multiple.toFixed(1)}× over`
+                  : "your usage is below the price of a subscription"}
+              </p>
+            </div>
+
+            <div className="bg-surface-1 border border-border rounded-lg p-4">
+              <p className="flex items-center gap-1.5 micro-label mb-1">
+                <Users className="w-3.5 h-3.5" />
+                Your percentile
+              </p>
+              <p className="text-xl font-bold font-mono">
+                p{percentile}
+              </p>
+              <p className="text-xs text-muted mt-1">
+                of {cohortSize.toLocaleString()} developers on viberank
+              </p>
+            </div>
+          </div>
+
+          {/* Honest caveat where it actually matters */}
+          {verdict.exceedsTopPlan && (
+            <div className="flex gap-3 border border-border rounded-lg p-4 bg-surface-1">
+              <AlertTriangle className="w-4 h-4 text-accent shrink-0 mt-0.5" />
+              <p className="text-sm text-muted leading-relaxed">
+                At {formatUsd(burn)}/month of API-equivalent usage you are well past what a
+                single Max 20x seat is sized for. The saving above is real arithmetic, but you
+                should expect to hit usage limits — plan on multiple seats, or a mix of
+                subscription and API.
+              </p>
+            </div>
+          )}
+
+          {/* Plan ladder */}
+          <div>
+            <p className="micro-label mb-3">Every plan at your usage</p>
+            <div className="border border-border rounded-lg overflow-hidden">
+              {PLANS.map((plan) => {
+                const delta = burn - plan.monthly;
+                const isPick = plan.id === verdict.recommended.id;
+                // A cheaper plan always looks like the bigger saving on price
+                // alone. Say plainly when it can't carry the usage, or the
+                // table recommends against itself.
+                const covers = coversBurn(plan, burn);
+                return (
+                  <div
+                    key={plan.id}
+                    className={`flex items-center justify-between gap-4 px-4 py-3 border-b border-border last:border-b-0 ${
+                      isPick ? "bg-accent-soft" : ""
+                    }`}
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">
+                        <span className={covers ? "" : "text-muted"}>{plan.name}</span>
+                        {isPick && <span className="text-accent text-xs ml-2">← your pick</span>}
+                      </p>
+                      <p className="text-xs text-muted">${plan.monthly}/mo</p>
+                    </div>
+                    {covers ? (
+                      <p
+                        className={`font-mono text-sm shrink-0 ${
+                          delta > 0 ? "text-accent" : "text-muted"
+                        }`}
+                      >
+                        {delta > 0 ? "saves " : "costs "}
+                        {formatUsd(Math.abs(delta))}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-muted shrink-0 text-right">
+                        too small for
+                        <br />
+                        your usage
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted mt-2">
+              Plans below your usage tier are priced lower but would rate-limit you, so no saving
+              is shown for them.
+            </p>
+          </div>
+
+          <p className="text-xs text-muted leading-relaxed">
+            Compared against the median viberank developer, who burns{" "}
+            <span className="text-foreground font-mono">{formatUsd(medianBurn)}</span>/month in
+            API-equivalent cost.
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -1,0 +1,143 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import { buildSpendCurve } from "@/lib/spend-curve";
+import { formatUsd } from "@/lib/utils";
+import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
+import CalculatorClient from "./CalculatorClient";
+
+// The cohort is a full-table read of ~1k narrow rows; the hourly ISR window
+// keeps it rare, matching /stats.
+export const revalidate = 3600;
+
+const TITLE = "Claude Code Cost Calculator — Subscription vs API | Viberank";
+const DESCRIPTION =
+  "ccusage tells you what your Claude Code usage would cost at API prices. This tells you whether Pro, Max 5x or Max 20x is cheaper — and how your spend compares to 1,000+ real developers.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  alternates: { canonical: "https://www.viberank.app/calculator" },
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: "https://www.viberank.app/calculator",
+    siteName: "Viberank",
+  },
+};
+
+export default async function CalculatorPage() {
+  const dataLayer = await getServerDataLayer();
+  const rows = await dataLayer.stats.getSpendRows().catch(() => []);
+  const curve = buildSpendCurve(rows);
+
+  const median = curve.percentiles.find((entry) => entry.p === 50)?.burn ?? 0;
+  const p90 = curve.percentiles.find((entry) => entry.p === 90)?.burn ?? 0;
+
+  // Share of the cohort burning more than each plan's price — the headline
+  // finding, computed from the same cohort the calculator ranks against.
+  const shareAbove = (threshold: number) =>
+    curve.cohortSize === 0
+      ? 0
+      : Math.round(
+          (curve.sorted.filter((burn) => burn > threshold).length / curve.cohortSize) * 100
+        );
+
+  const faq = [
+    {
+      q: "What is API-equivalent cost?",
+      a: "ccusage prices your token usage at Anthropic's published API rates. If you are on a Pro or Max subscription you did not pay that — it is the counterfactual cost of the same work through the API. The gap between the two is what this page measures.",
+    },
+    {
+      q: "Does a Max plan really cover that much usage?",
+      a: "Anthropic describes Max as 5x and 20x Pro usage rather than a dollar ceiling, and heavy sessions can hit rate limits. Treat the saving as the value of the usage, not a guarantee that any volume fits inside one seat.",
+    },
+    {
+      q: "Where does the comparison cohort come from?",
+      a: `Every submission on viberank, normalised to a 30-day burn and collapsed to one entry per developer (their highest-cost submission). Submissions spanning under 7 days are excluded because they extrapolate badly. Currently ${curve.cohortSize.toLocaleString()} developers.`,
+    },
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <NavBar />
+
+      <main className="flex-1 max-w-3xl w-full mx-auto px-4 sm:px-6 py-10">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 micro-label text-muted hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
+        <p className="micro-label mb-3">Free tool</p>
+        <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
+          Are you overpaying for Claude Code?
+        </h1>
+        <p className="text-muted leading-relaxed mb-8">
+          {curve.cohortSize > 0 ? (
+            <>
+              <span className="text-foreground font-medium">
+                {shareAbove(200)}% of developers on viberank
+              </span>{" "}
+              burn more than $200/month in API-equivalent cost — the price of the largest Claude
+              plan. The median burns{" "}
+              <span className="text-foreground font-mono">{formatUsd(median)}</span> and the
+              top 10% burn over{" "}
+              <span className="text-foreground font-mono">{formatUsd(p90)}</span>. Put your own
+              number in below.
+            </>
+          ) : (
+            <>
+              Put your ccusage number in below to see which Claude plan is cheapest for your actual
+              usage.
+            </>
+          )}
+        </p>
+
+        <CalculatorClient
+          cohort={curve.sorted}
+          cohortSize={curve.cohortSize}
+          medianBurn={median}
+        />
+
+        <section className="mt-14">
+          <p className="micro-label mb-4">FAQ</p>
+          <div className="space-y-6">
+            {faq.map((item) => (
+              <div key={item.q}>
+                <h2 className="font-medium mb-1.5">{item.q}</h2>
+                <p className="text-sm text-muted leading-relaxed">{item.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <p className="text-xs text-muted mt-10 leading-relaxed">
+          Plan prices checked against claude.com/pricing on 2026-08-05 and are monthly-billing list
+          prices in USD. viberank is not affiliated with Anthropic.
+        </p>
+      </main>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: faq.map((item) => ({
+              "@type": "Question",
+              name: item.q,
+              acceptedAnswer: { "@type": "Answer", text: item.a },
+            })),
+          }),
+        }}
+      />
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -30,6 +30,7 @@ import type {
   ModelBreakdown,
 } from "../types";
 import { SupabaseRateLimiter } from "./rate-limiter";
+import type { BurnRow } from "@/lib/spend-curve";
 import {
   validateCcData,
   inferToolFromModel,
@@ -1651,6 +1652,34 @@ export class SupabaseStatsService implements StatsService {
       return null;
     }
     return data as SiteStats;
+  }
+
+  async getSpendRows(): Promise<BurnRow[]> {
+    // Only the four columns the spend curve needs, paged. The whole table is
+    // ~1k rows and /calculator is ISR-cached hourly, so this is cheaper than
+    // the aggregates /stats already runs — no RPC or migration required.
+    const rows = await fetchAllPages<{
+      username: string;
+      total_cost: number;
+      date_range_start: string;
+      date_range_end: string;
+    }>(
+      (from, to) =>
+        this.client
+          .from("submissions")
+          .select("username,total_cost,date_range_start,date_range_end")
+          .or("flagged_for_review.is.null,flagged_for_review.eq.false")
+          .order("id", { ascending: true })
+          .range(from, to),
+      "submissions for spend curve"
+    );
+
+    return rows.map((r) => ({
+      username: r.username,
+      totalCost: Number(r.total_cost),
+      start: r.date_range_start,
+      end: r.date_range_end,
+    }));
   }
 }
 

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -333,6 +333,8 @@ export interface StatsService {
   getGlobalStats(): Promise<GlobalStats>;
   /** Exact aggregates via get_site_stats() (migration 007); null if the function isn't deployed. */
   getSiteStats(): Promise<SiteStats | null>;
+  /** Raw rows for the /calculator spend curve. */
+  getSpendRows(): Promise<import("@/lib/spend-curve").BurnRow[]>;
 }
 
 export interface DataLayer {

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,0 +1,143 @@
+/**
+ * Subscription-vs-API comparison for Claude Code usage.
+ *
+ * ccusage reports what your usage *would* cost at API list prices. Almost
+ * nobody actually pays that — most people are on a flat subscription. The gap
+ * between those two numbers is the thing this file computes, and it is the
+ * single most useful thing viberank's data can tell an individual developer.
+ *
+ * Prices verified 2026-08-05 against claude.com/pricing and the Max plan help
+ * centre article. They are monthly-billing list prices in USD.
+ */
+
+export interface Plan {
+  id: string;
+  name: string;
+  /** Monthly price in USD, billed monthly. */
+  monthly: number;
+  /** What the plan is for, in one line. */
+  blurb: string;
+  /**
+   * Rough ceiling on sustainable API-equivalent burn, expressed as a multiple
+   * of Pro. Anthropic publishes Max as "5x" and "20x" Pro usage rather than a
+   * dollar figure, so this is a relative capacity hint, not a billing cap.
+   */
+  usageMultiple: number;
+}
+
+export const PLANS: Plan[] = [
+  {
+    id: "pro",
+    name: "Claude Pro",
+    monthly: 20,
+    blurb: "Everyday coding, a few hours a day.",
+    usageMultiple: 1,
+  },
+  {
+    id: "max5",
+    name: "Claude Max 5x",
+    monthly: 100,
+    blurb: "Most of a working day in Claude Code.",
+    usageMultiple: 5,
+  },
+  {
+    id: "max20",
+    name: "Claude Max 20x",
+    monthly: 200,
+    blurb: "All day, every day, plus parallel agents.",
+    usageMultiple: 20,
+  },
+];
+
+/** Anthropic API list prices, USD per million tokens. Verified 2026-08-05. */
+export const API_PRICES = [
+  { model: "Claude Opus 5", input: 5, output: 25 },
+  { model: "Claude Sonnet 5", input: 3, output: 15 },
+  { model: "Claude Haiku 4.5", input: 1, output: 5 },
+] as const;
+
+export interface PlanVerdict {
+  /** The cheapest plan whose usage tier plausibly covers this burn. */
+  recommended: Plan;
+  /** Monthly saving vs paying API list prices for the same usage. */
+  savingVsApi: number;
+  /** How many times over the plan pays for itself. Infinity guarded to 0 burn. */
+  multiple: number;
+  /**
+   * True when burn is high enough that even the largest plan's usage limits
+   * are likely to bind. The saving is still real, but so are the rate limits.
+   */
+  exceedsTopPlan: boolean;
+}
+
+/**
+ * Pro is sized for roughly this much API-equivalent burn per month. Derived
+ * from viberank's own distribution rather than published limits: Anthropic
+ * states Max as a multiple of Pro, never as a dollar figure, so any absolute
+ * number here is an estimate. Used only to pick which plan to *suggest* — the
+ * saving figure below never depends on it.
+ */
+const PRO_EQUIVALENT_BURN = 100;
+
+/**
+ * Whether a plan's usage tier plausibly carries this much burn.
+ *
+ * This is what stops the comparison table from lying. Raw arithmetic says the
+ * cheapest plan always "saves" the most — Pro appears to save more than Max
+ * against a $1,300/month burn, because it costs less. But Pro would rate-limit
+ * that user at a fraction of their usage, so presenting it as the bigger
+ * saving is nonsense. The table has to show capacity alongside price.
+ */
+export function coversBurn(plan: Plan, monthlyApiCost: number): boolean {
+  return monthlyApiCost <= PRO_EQUIVALENT_BURN * plan.usageMultiple;
+}
+
+/**
+ * Given an API-equivalent monthly burn, work out which plan to be on and what
+ * it saves. `monthlyApiCost` is what ccusage says the month would cost at list
+ * prices.
+ */
+export function comparePlans(monthlyApiCost: number): PlanVerdict {
+  const burn = Number.isFinite(monthlyApiCost) && monthlyApiCost > 0 ? monthlyApiCost : 0;
+
+  const recommended =
+    PLANS.find((plan) => burn <= PRO_EQUIVALENT_BURN * plan.usageMultiple) ??
+    PLANS[PLANS.length - 1];
+
+  // The saving is burn minus the subscription price — not clamped at zero,
+  // because a negative number is the honest answer for light users: below
+  // ~$20/month of usage, the API is genuinely the cheaper option and the tool
+  // should say so rather than manufacture a win.
+  const savingVsApi = burn - recommended.monthly;
+
+  return {
+    recommended,
+    savingVsApi,
+    multiple: recommended.monthly > 0 ? burn / recommended.monthly : 0,
+    exceedsTopPlan: burn > PRO_EQUIVALENT_BURN * PLANS[PLANS.length - 1].usageMultiple,
+  };
+}
+
+/**
+ * Where a burn figure sits against a sorted array of everyone else's.
+ * Returns 0-100. An empty cohort yields 0 rather than dividing by zero.
+ */
+export function percentileOf(sortedBurns: number[], burn: number): number {
+  if (sortedBurns.length === 0) return 0;
+
+  // Count strictly-below, so the cheapest developer lands at p0 rather than
+  // inheriting a percentile from ties above them.
+  let below = 0;
+  for (const value of sortedBurns) {
+    if (value < burn) below++;
+    else break;
+  }
+
+  return Math.round((below / sortedBurns.length) * 100);
+}
+
+/** Monthly burn implied by a total spend over a span of days. */
+export function monthlyBurn(totalCost: number, days: number): number {
+  if (!(days > 0) || !(totalCost > 0)) return 0;
+  return (totalCost / days) * 30;
+}

--- a/src/lib/spend-curve.ts
+++ b/src/lib/spend-curve.ts
@@ -1,0 +1,78 @@
+/**
+ * The distribution of monthly API-equivalent burn across everyone on the board.
+ *
+ * Kept as pure functions over plain rows so it can be unit-tested without a
+ * database, and so the page that uses it can fetch rows however it likes.
+ */
+
+export interface BurnRow {
+  username: string;
+  totalCost: number;
+  /** Inclusive ISO dates, as stored on a submission. */
+  start: string;
+  end: string;
+}
+
+export interface SpendCurve {
+  cohortSize: number;
+  /** Ascending monthly burns — the cohort a user is placed against. */
+  sorted: number[];
+  percentiles: { p: number; burn: number }[];
+}
+
+/**
+ * Submissions shorter than this extrapolate to a meaningless monthly figure —
+ * a two-day sample says nothing about a month.
+ */
+const MIN_SPAN_DAYS = 7;
+
+const QUANTILES = [10, 25, 50, 75, 90, 95, 99];
+
+function spanDays(start: string, end: string): number {
+  const from = Date.parse(start);
+  const to = Date.parse(end);
+  if (!Number.isFinite(from) || !Number.isFinite(to) || to < from) return 0;
+  return Math.floor((to - from) / 86_400_000) + 1;
+}
+
+/**
+ * Collapse to one row per user (their highest-cost submission), normalise each
+ * to a 30-day burn, and sort.
+ *
+ * One row per user matters: without it a prolific resubmitter is counted many
+ * times and drags the curve toward their own usage.
+ */
+export function buildSpendCurve(rows: BurnRow[]): SpendCurve {
+  const best = new Map<string, BurnRow>();
+  for (const row of rows) {
+    const key = row.username.toLowerCase();
+    const current = best.get(key);
+    if (!current || row.totalCost > current.totalCost) best.set(key, row);
+  }
+
+  const sorted: number[] = [];
+  for (const row of best.values()) {
+    const days = spanDays(row.start, row.end);
+    if (days < MIN_SPAN_DAYS || !(row.totalCost > 0)) continue;
+    sorted.push((row.totalCost / days) * 30);
+  }
+  sorted.sort((a, b) => a - b);
+
+  return {
+    cohortSize: sorted.length,
+    sorted,
+    percentiles: QUANTILES.map((p) => ({ p, burn: quantile(sorted, p / 100) })),
+  };
+}
+
+/** Linear-interpolated quantile. Returns 0 for an empty cohort. */
+export function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+
+  const position = (sorted.length - 1) * Math.min(Math.max(q, 0), 1);
+  const lower = Math.floor(position);
+  const upper = Math.ceil(position);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (position - lower);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -65,6 +65,20 @@ export function formatCurrency(num: number): string {
   });
 }
 
+/**
+ * Money with the symbol attached, and cents only where they carry meaning.
+ * `formatCurrency` deliberately omits the symbol because the leaderboard
+ * styles it separately; this is the plain-prose counterpart.
+ */
+export function formatUsd(num: number): string {
+  const value = Number.isFinite(num) ? num : 0;
+  const cents = Math.abs(value) < 100;
+  return `$${value.toLocaleString("en-US", {
+    minimumFractionDigits: cents ? 2 : 0,
+    maximumFractionDigits: cents ? 2 : 0,
+  })}`;
+}
+
 export function formatLargeNumber(num: number): string {
   return num.toLocaleString('en-US');
 }

--- a/test/plans.test.mts
+++ b/test/plans.test.mts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+
+const { comparePlans, coversBurn, percentileOf, monthlyBurn, PLANS } = await import("../src/lib/plans.ts");
+
+let passed = 0;
+const check = (label: string) => {
+  passed++;
+  console.log(`✓ ${label}`);
+};
+
+// ---------------------------------------------------------------------------
+// Plan selection
+// ---------------------------------------------------------------------------
+
+{
+  assert.equal(comparePlans(45).recommended.id, "pro");
+  assert.equal(comparePlans(400).recommended.id, "max5");
+  assert.equal(comparePlans(1318).recommended.id, "max20", "the median viberank dev");
+  assert.equal(comparePlans(26000).recommended.id, "max20", "p99 still tops out at max20");
+  check("recommends the cheapest plan whose usage tier covers the burn");
+}
+
+{
+  // The honest case: a light user is genuinely better off on the API, and the
+  // tool has to be willing to say so rather than invent a saving.
+  const light = comparePlans(12);
+  assert.equal(light.recommended.id, "pro");
+  assert.ok(
+    light.savingVsApi < 0,
+    `expected a negative saving for a $12/mo user, got ${light.savingVsApi}`
+  );
+  check("reports a negative saving when a subscription would cost more");
+}
+
+{
+  const median = comparePlans(1318);
+  assert.equal(median.savingVsApi, 1318 - 200);
+  assert.ok(Math.abs(median.multiple - 6.59) < 0.01, `got ${median.multiple}`);
+  check("saving and multiple are computed against the recommended plan");
+}
+
+{
+  assert.equal(comparePlans(1000).exceedsTopPlan, false);
+  assert.equal(comparePlans(5000).exceedsTopPlan, true);
+  check("flags burn that would strain even the largest plan's limits");
+}
+
+{
+  // Guard the degenerate inputs a form can produce.
+  for (const bad of [0, -50, NaN, Infinity]) {
+    const verdict = comparePlans(bad as number);
+    assert.equal(verdict.recommended.id, "pro", `bad input ${bad}`);
+    assert.ok(Number.isFinite(verdict.savingVsApi), `non-finite saving for ${bad}`);
+    assert.ok(Number.isFinite(verdict.multiple), `non-finite multiple for ${bad}`);
+  }
+  check("degenerate inputs never produce NaN or Infinity");
+}
+
+// ---------------------------------------------------------------------------
+// Percentiles
+// ---------------------------------------------------------------------------
+
+{
+  const cohort = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+  assert.equal(percentileOf(cohort, 5), 0);
+  assert.equal(percentileOf(cohort, 55), 50);
+  assert.equal(percentileOf(cohort, 1000), 100);
+  check("percentile places a burn against the cohort");
+}
+
+{
+  assert.equal(percentileOf([], 500), 0, "an empty cohort must not divide by zero");
+  // Ties sit at the bottom of their run, so the cheapest dev is p0 rather than
+  // inheriting a percentile from everyone equal to them.
+  assert.equal(percentileOf([10, 10, 10, 10], 10), 0);
+  check("empty cohorts and ties are handled without dividing by zero");
+}
+
+// ---------------------------------------------------------------------------
+// Monthly burn
+// ---------------------------------------------------------------------------
+
+{
+  assert.equal(monthlyBurn(300, 30), 300);
+  assert.equal(monthlyBurn(150, 15), 300);
+  assert.equal(monthlyBurn(0, 30), 0);
+  assert.equal(monthlyBurn(300, 0), 0, "a zero-day span must not divide by zero");
+  assert.equal(monthlyBurn(300, -5), 0);
+  check("monthly burn normalises any span without dividing by zero");
+}
+
+// ---------------------------------------------------------------------------
+// Plan data sanity — these are real prices users will act on
+// ---------------------------------------------------------------------------
+
+{
+  assert.deepEqual(
+    PLANS.map((p) => p.monthly),
+    [20, 100, 200],
+    "plan prices must match claude.com/pricing (verified 2026-08-05)"
+  );
+  assert.deepEqual(
+    PLANS.map((p) => p.monthly).slice().sort((a: number, b: number) => a - b),
+    PLANS.map((p) => p.monthly),
+    "plans must be ordered cheapest-first for selection to work"
+  );
+  check("plan prices are correct and ordered cheapest-first");
+}
+
+{
+  // The bug this guards: on price alone Pro "saves" more than Max 20x against
+  // a $1,300/mo burn, because Pro is cheaper. Presenting that as the better
+  // deal is nonsense — Pro would rate-limit that user at a fraction of it.
+  const burn = 1300;
+  const pro = PLANS.find((p) => p.id === "pro")!;
+  const max20 = PLANS.find((p) => p.id === "max20")!;
+
+  assert.ok(burn - pro.monthly > burn - max20.monthly, "cheaper plan shows a bigger raw saving");
+  assert.equal(coversBurn(pro, burn), false, "Pro must not be presented as covering $1300/mo");
+  assert.equal(coversBurn(max20, burn), true);
+  check("capacity check stops a cheaper plan from looking like the better deal");
+}
+
+{
+  assert.equal(coversBurn(PLANS[0], 50), true, "Pro covers a light user");
+  assert.equal(coversBurn(PLANS[0], 0), true, "zero burn is covered by every plan");
+  check("capacity check is true for burn within a plan's tier");
+}
+
+console.log(`\n${passed} passed, 0 failed`);

--- a/test/spend-curve.test.mts
+++ b/test/spend-curve.test.mts
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+
+const { buildSpendCurve, quantile } = await import("../src/lib/spend-curve.ts");
+
+let passed = 0;
+const check = (label: string) => {
+  passed++;
+  console.log(`✓ ${label}`);
+};
+
+const row = (username: string, totalCost: number, start: string, end: string) => ({
+  username,
+  totalCost,
+  start,
+  end,
+});
+
+{
+  // 30 days at $300 and 15 days at $150 are the same monthly burn — the whole
+  // point of normalising rather than comparing raw totals.
+  const curve = buildSpendCurve([
+    row("a", 300, "2026-01-01", "2026-01-30"),
+    row("b", 150, "2026-01-01", "2026-01-15"),
+  ]);
+  assert.equal(curve.cohortSize, 2);
+  assert.ok(Math.abs(curve.sorted[0] - 300) < 1, `got ${curve.sorted[0]}`);
+  assert.ok(Math.abs(curve.sorted[1] - 300) < 1, `got ${curve.sorted[1]}`);
+  check("normalises different spans to a comparable monthly burn");
+}
+
+{
+  // A resubmitter must not be counted twice — otherwise one heavy user drags
+  // the whole curve toward their own usage.
+  const curve = buildSpendCurve([
+    row("heavy", 3000, "2026-01-01", "2026-01-30"),
+    row("heavy", 2000, "2026-01-01", "2026-01-30"),
+    row("HEAVY", 1000, "2026-01-01", "2026-01-30"),
+    row("light", 60, "2026-01-01", "2026-01-30"),
+  ]);
+  assert.equal(curve.cohortSize, 2, "heavy counted once, case-insensitively");
+  assert.ok(Math.abs(curve.sorted[1] - 3000) < 1, "keeps the highest-cost submission");
+  check("collapses to one row per user, case-insensitively");
+}
+
+{
+  const curve = buildSpendCurve([
+    row("ok", 300, "2026-01-01", "2026-01-30"),
+    row("tooshort", 100, "2026-01-01", "2026-01-03"),
+    row("zero", 0, "2026-01-01", "2026-01-30"),
+    row("backwards", 300, "2026-01-30", "2026-01-01"),
+    row("garbage", 300, "not-a-date", "also-not"),
+  ]);
+  assert.equal(curve.cohortSize, 1, "only the valid 30-day row survives");
+  check("drops short spans, zero cost, inverted ranges and unparseable dates");
+}
+
+{
+  const empty = buildSpendCurve([]);
+  assert.equal(empty.cohortSize, 0);
+  assert.deepEqual(
+    empty.percentiles.map((x) => x.burn),
+    [0, 0, 0, 0, 0, 0, 0],
+    "an empty cohort must yield zeros, not NaN"
+  );
+  check("an empty cohort produces zeros rather than NaN");
+}
+
+{
+  const sorted = [10, 20, 30, 40, 50];
+  assert.equal(quantile(sorted, 0), 10);
+  assert.equal(quantile(sorted, 0.5), 30);
+  assert.equal(quantile(sorted, 1), 50);
+  assert.equal(quantile(sorted, 0.25), 20);
+  assert.equal(quantile([], 0.5), 0);
+  assert.equal(quantile([42], 0.9), 42);
+  check("quantile interpolates and survives empty/single-element cohorts");
+}
+
+{
+  // A realistic shape: the curve must come back ascending, or percentile
+  // placement silently lies.
+  const rows = Array.from({ length: 200 }, (_, i) =>
+    row(`u${i}`, (i + 1) * 25, "2026-01-01", "2026-01-30")
+  );
+  const curve = buildSpendCurve(rows);
+  for (let i = 1; i < curve.sorted.length; i++) {
+    assert.ok(curve.sorted[i] >= curve.sorted[i - 1], "cohort must be ascending");
+  }
+  const ps = curve.percentiles.map((x) => x.burn);
+  for (let i = 1; i < ps.length; i++) {
+    assert.ok(ps[i] >= ps[i - 1], "percentiles must be monotonic");
+  }
+  check("cohort and percentiles come back monotonically ascending");
+}
+
+console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
viberank has no interactive tool — only the board and blog posts. The only way to engage is to publish your usage to a public leaderboard under your GitHub name, which is a large ask for a first visit. This is the low-friction entry point, and it answers a question **the site is uniquely placed to answer.**

`ccusage` reports what your usage *would* cost at API list prices. Almost nobody pays that, because almost everyone is on a flat subscription. Nobody else has 1,000+ real developers' worth of that number to compare against.

## The finding

Computed from the live board: **88% of developers burn more than $200/month in API-equivalent cost** — the price of the largest Claude plan. The median burns **$1,314/month**, so a $200 seat pays for itself 6.6× over. The top 10% burn over **$6,449/month**.

That number is the headline of the page, and it's genuinely surprising.

## What it does

Given a monthly burn it reports the cheapest plan that plausibly covers it, the saving against API list prices, and your percentile against everyone on the board.

## Two honesty constraints that shaped it

**A cheaper plan always shows a bigger raw saving, because it costs less.** On a $1,300/month burn the first version said *"Claude Pro saves $1,280"* — more than the plan it actually recommended — while Pro would rate-limit that user at a fraction of their usage. I caught this in the browser, not in a test. Plans below the user's usage tier now read "too small for your usage" and show no saving at all, and there's a regression test asserting the cheaper plan is *not* presented as covering the burn.

**Below roughly $20/month the API is genuinely cheaper.** The saving is reported as negative rather than clamped to a manufactured win — a tool that can never tell you "don't buy this" isn't worth trusting.

There's also an explicit caveat when burn exceeds what a single Max 20x seat is sized for: the arithmetic is real, but so are the rate limits.

## Implementation notes

The cohort is one row per user (their highest-cost submission), normalised to a 30-day burn, excluding spans under 7 days that extrapolate badly. A prolific resubmitter would otherwise be counted many times and drag the curve toward their own usage.

I started writing a Postgres RPC to match `get_site_stats`, then dropped it — at ~1k narrow rows the RPC earns nothing, and the page is ISR-cached hourly like `/stats`. Not every aggregate needs a migration.

Plan prices verified against claude.com/pricing and the Max plan help centre article on 2026-08-05, and **asserted in the tests** so a silent edit fails CI rather than quietly misinforming users.

## Also in here

The test script is now a glob. The hardcoded list silently omitted both new test files — I only noticed because the totals didn't move. `npm test` now runs **69 tests across 5 files**.

## Verification

`npm test` exits 0, `tsc` and `eslint` clean with no new errors, `next build` prerenders `/calculator`. Verified against production data in a local production server: real cohort of 1,002 developers, and the capacity fix confirmed in the browser.

**Not verified:** mobile rendering. The layout uses the same responsive classes as `/stats`, but my viewport resize didn't take effect so I can't claim I've seen it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)