### PR TITLE
chore: link /calculator from nav, footer and sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -16,6 +16,7 @@ const staticEntries: MetadataRoute.Sitemap = [
   ...toolEntries,
   { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/stats`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+  { url: `${SITE}/calculator`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
   { url: `${SITE}/blog/what-is-tokenmaxxing`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
   { url: `${SITE}/blog/codex-token-usage-leaderboard`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
 
 const RESOURCES = [
+  { name: "Cost calculator", href: "/calculator" },
   { name: "Blog", href: "/blog" },
   { name: "Hire AI-native engineers", href: "/hire" },
   { name: "What is tokenmaxxing?", href: "/blog/what-is-tokenmaxxing" },

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -41,6 +41,7 @@ export default function NavBar() {
 
   const navItems = [
     { name: "Stats", href: "/stats" },
+    { name: "Calculator", href: "/calculator" },
     { name: "Blog", href: "/blog" },
     { name: "Hire", href: "/hire" },
     ...(isAdmin ? [{ name: "Admin", href: "/admin" }] : []),


### PR DESCRIPTION
Follow-up to #105, which shipped `/calculator` as an **orphan page** — reachable only by typing the URL.

That costs it twice: no in-product discovery, and no search visibility, since orphan pages carry no internal link signal no matter how good the content is.

- **NavBar** — next to Stats
- **Footer** — first entry under Resources
- **Sitemap** — priority 0.9, deliberately above `/stats` and the blog posts, because it targets higher-intent queries than anything else on the site

`npm test`, `tsc` and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)