### PR TITLE
feat: cover Codex and Copilot in the calculator, and shrink its payload

### DIFF
--- a/src/app/calculator/CalculatorClient.tsx
+++ b/src/app/calculator/CalculatorClient.tsx
@@ -2,12 +2,13 @@
 
 import { useMemo, useState } from "react";
 import { DollarSign, TrendingDown, Users, AlertTriangle } from "lucide-react";
-import { comparePlans, coversBurn, percentileOf, PLANS } from "@/lib/plans";
+import { comparePlans, coversBurn, toolPlansFor, TOOL_PLANS } from "@/lib/plans";
+import { percentileFromLadder } from "@/lib/spend-curve";
 import { formatUsd } from "@/lib/utils";
 
 interface Props {
-  /** Ascending monthly burns for everyone on the board. */
-  cohort: number[];
+  /** 101 ascending thresholds, p0..p100 — see percentileLadder. */
+  ladder: number[];
   cohortSize: number;
   medianBurn: number;
 }
@@ -18,24 +19,47 @@ const PRESETS = [
   { label: "Heavy", burn: 6450 },
 ];
 
-export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Props) {
+export default function CalculatorClient({ ladder, cohortSize, medianBurn }: Props) {
   const [raw, setRaw] = useState("");
+  const [toolId, setToolId] = useState(TOOL_PLANS[0].id);
+
+  const tool = useMemo(() => toolPlansFor(toolId), [toolId]);
 
   const burn = useMemo(() => {
     const parsed = Number.parseFloat(raw.replace(/[^0-9.]/g, ""));
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
   }, [raw]);
 
-  const verdict = useMemo(() => comparePlans(burn), [burn]);
-  const percentile = useMemo(() => percentileOf(cohort, burn), [cohort, burn]);
+  const verdict = useMemo(() => comparePlans(tool, burn), [tool, burn]);
+  const percentile = useMemo(() => percentileFromLadder(ladder, burn), [ladder, burn]);
 
   const hasInput = burn > 0;
-  const saves = verdict.savingVsApi > 0;
+  const ranked = verdict.recommended !== null;
+  const saves = ranked && verdict.savingVsApi > 0;
 
   return (
     <div className="space-y-8">
       {/* Input */}
       <div className="bg-surface-1 border border-border rounded-lg p-5 sm:p-6">
+        <p className="micro-label mb-2">Which tool?</p>
+        <div className="flex flex-wrap gap-2 mb-5">
+          {TOOL_PLANS.map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              onClick={() => setToolId(entry.id)}
+              aria-pressed={entry.id === toolId}
+              className={`text-sm px-3 py-1.5 rounded border transition-colors ${
+                entry.id === toolId
+                  ? "border-accent text-accent bg-accent-soft"
+                  : "border-border hover:border-accent hover:text-accent"
+              }`}
+            >
+              {entry.label}
+            </button>
+          ))}
+        </div>
+
         <label htmlFor="burn" className="block micro-label mb-2">
           Your monthly API-equivalent spend
         </label>
@@ -89,11 +113,15 @@ export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Pro
             <div className="bg-surface-1 border border-border rounded-lg p-4">
               <p className="flex items-center gap-1.5 micro-label mb-1">
                 <DollarSign className="w-3.5 h-3.5" />
-                Cheapest plan
+                {ranked ? "Cheapest plan that fits" : "Your usage"}
               </p>
-              <p className="text-xl font-bold">{verdict.recommended.name}</p>
+              <p className="text-xl font-bold">
+                {ranked ? verdict.recommended!.name : `${formatUsd(burn)}/mo`}
+              </p>
               <p className="text-xs text-muted mt-1">
-                ${verdict.recommended.monthly}/mo · {verdict.recommended.blurb}
+                {ranked
+                  ? `$${verdict.recommended!.monthly}/mo · ${verdict.recommended!.blurb}`
+                  : "at API list prices"}
               </p>
             </div>
 
@@ -104,16 +132,20 @@ export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Pro
             >
               <p className="flex items-center gap-1.5 micro-label mb-1">
                 <TrendingDown className="w-3.5 h-3.5" />
-                {saves ? "You save" : "API is cheaper"}
+                {!ranked ? "Cheapest seat" : saves ? "You save" : "API is cheaper"}
               </p>
               <p className={`text-xl font-bold font-mono ${saves ? "text-accent" : ""}`}>
-                {formatUsd(Math.abs(verdict.savingVsApi))}
+                {ranked
+                  ? formatUsd(Math.abs(verdict.savingVsApi))
+                  : `$${tool.plans[0].monthly}`}
                 <span className="text-sm font-sans text-muted">/mo</span>
               </p>
               <p className="text-xs text-muted mt-1">
-                {saves
-                  ? `the plan pays for itself ${verdict.multiple.toFixed(1)}× over`
-                  : "your usage is below the price of a subscription"}
+                {!ranked
+                  ? "see the break-even table below"
+                  : saves
+                    ? `the plan pays for itself ${verdict.multiple.toFixed(1)}× over`
+                    : "your usage is below the price of a subscription"}
               </p>
             </div>
 
@@ -137,7 +169,7 @@ export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Pro
               <AlertTriangle className="w-4 h-4 text-accent shrink-0 mt-0.5" />
               <p className="text-sm text-muted leading-relaxed">
                 At {formatUsd(burn)}/month of API-equivalent usage you are well past what a
-                single Max 20x seat is sized for. The saving above is real arithmetic, but you
+                single {verdict.recommended?.name} seat is sized for. The saving above is real arithmetic, but you
                 should expect to hit usage limits — plan on multiple seats, or a mix of
                 subscription and API.
               </p>
@@ -148,13 +180,13 @@ export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Pro
           <div>
             <p className="micro-label mb-3">Every plan at your usage</p>
             <div className="border border-border rounded-lg overflow-hidden">
-              {PLANS.map((plan) => {
+              {tool.plans.map((plan) => {
                 const delta = burn - plan.monthly;
-                const isPick = plan.id === verdict.recommended.id;
+                const isPick = plan.id === verdict.recommended?.id;
                 // A cheaper plan always looks like the bigger saving on price
                 // alone. Say plainly when it can't carry the usage, or the
                 // table recommends against itself.
-                const covers = coversBurn(plan, burn);
+                const covers = coversBurn(tool, plan, burn);
                 return (
                   <div
                     key={plan.id}
@@ -190,9 +222,10 @@ export default function CalculatorClient({ cohort, cohortSize, medianBurn }: Pro
               })}
             </div>
             <p className="text-xs text-muted mt-2">
-              Plans below your usage tier are priced lower but would rate-limit you, so no saving
-              is shown for them.
+              {tool.capacityUnknownNote ??
+                "Plans below your usage tier are priced lower but would rate-limit you, so no saving is shown for them."}
             </p>
+            <p className="text-xs text-muted mt-1">Prices from {tool.source}, checked 2026-08-05.</p>
           </div>
 
           <p className="text-xs text-muted leading-relaxed">

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { getServerDataLayer } from "@/lib/data";
-import { buildSpendCurve } from "@/lib/spend-curve";
+import { buildSpendCurve, percentileLadder } from "@/lib/spend-curve";
 import { formatUsd } from "@/lib/utils";
 import NavBar from "@/components/NavBar";
 import Footer from "@/components/Footer";
@@ -12,9 +12,9 @@ import CalculatorClient from "./CalculatorClient";
 // keeps it rare, matching /stats.
 export const revalidate = 3600;
 
-const TITLE = "Claude Code Cost Calculator — Subscription vs API | Viberank";
+const TITLE = "AI Coding Cost Calculator — Subscription vs API | Viberank";
 const DESCRIPTION =
-  "ccusage tells you what your Claude Code usage would cost at API prices. This tells you whether Pro, Max 5x or Max 20x is cheaper — and how your spend compares to 1,000+ real developers.";
+  "ccusage tells you what your Claude Code, Codex or Copilot usage would cost at API prices. This tells you which subscription plan is actually cheaper — and how your spend compares to 1,000+ real developers.";
 
 export const metadata: Metadata = {
   title: TITLE,
@@ -51,8 +51,8 @@ export default async function CalculatorPage() {
       a: "ccusage prices your token usage at Anthropic's published API rates. If you are on a Pro or Max subscription you did not pay that — it is the counterfactual cost of the same work through the API. The gap between the two is what this page measures.",
     },
     {
-      q: "Does a Max plan really cover that much usage?",
-      a: "Anthropic describes Max as 5x and 20x Pro usage rather than a dollar ceiling, and heavy sessions can hit rate limits. Treat the saving as the value of the usage, not a guarantee that any volume fits inside one seat.",
+      q: "Does the recommended plan really cover that much usage?",
+      a: "Vendors describe capacity relative to their own tiers — Anthropic as 5x and 20x Pro, OpenAI as 5x Plus — never as a dollar ceiling, and heavy sessions can hit rate limits. Treat the saving as the value of the usage, not a guarantee that any volume fits inside one seat. Where a vendor publishes no comparable tiers, no plan is marked too small.",
     },
     {
       q: "Where does the comparison cohort come from?",
@@ -75,7 +75,7 @@ export default async function CalculatorPage() {
 
         <p className="micro-label mb-3">Free tool</p>
         <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-3">
-          Are you overpaying for Claude Code?
+          Are you overpaying for AI coding?
         </h1>
         <p className="text-muted leading-relaxed mb-8">
           {curve.cohortSize > 0 ? (
@@ -99,7 +99,7 @@ export default async function CalculatorPage() {
         </p>
 
         <CalculatorClient
-          cohort={curve.sorted}
+          ladder={percentileLadder(curve.sorted)}
           cohortSize={curve.cohortSize}
           medianBurn={median}
         />
@@ -117,8 +117,11 @@ export default async function CalculatorPage() {
         </section>
 
         <p className="text-xs text-muted mt-10 leading-relaxed">
-          Plan prices checked against claude.com/pricing on 2026-08-05 and are monthly-billing list
-          prices in USD. viberank is not affiliated with Anthropic.
+          Plan prices were checked against each vendor&apos;s own pricing page on 2026-08-05 and are
+          monthly-billing list prices in USD; the source is shown alongside each tool&apos;s plans.
+          Gemini CLI is not covered yet — Google does not publish comparable monthly prices for the
+          tiers that include it, and guessing would be worse than omitting it. viberank is not
+          affiliated with Anthropic, OpenAI or GitHub.
         </p>
       </main>
 

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,121 +1,151 @@
 /**
- * Subscription-vs-API comparison for Claude Code usage.
+ * Subscription-vs-API comparison for AI coding usage.
  *
  * ccusage reports what your usage *would* cost at API list prices. Almost
  * nobody actually pays that — most people are on a flat subscription. The gap
  * between those two numbers is the thing this file computes, and it is the
  * single most useful thing viberank's data can tell an individual developer.
  *
- * Prices verified 2026-08-05 against claude.com/pricing and the Max plan help
- * centre article. They are monthly-billing list prices in USD.
+ * Every price here is a monthly-billing list price in USD, checked against the
+ * vendor's own pricing page on 2026-08-05. They are asserted in the tests, so
+ * an unsourced edit fails CI rather than quietly misinforming someone.
  */
 
 export interface Plan {
   id: string;
   name: string;
-  /** Monthly price in USD, billed monthly. */
   monthly: number;
-  /** What the plan is for, in one line. */
   blurb: string;
   /**
-   * Rough ceiling on sustainable API-equivalent burn, expressed as a multiple
-   * of Pro. Anthropic publishes Max as "5x" and "20x" Pro usage rather than a
-   * dollar figure, so this is a relative capacity hint, not a billing cap.
+   * Usage capacity relative to the tool's entry paid plan, when the vendor
+   * publishes one. `null` means they don't, and we must not invent it — see
+   * `coversBurn` for what that changes.
    */
-  usageMultiple: number;
+  usageMultiple: number | null;
 }
 
-export const PLANS: Plan[] = [
+export interface ToolPlans {
+  id: string;
+  /** Matches the `tools` values stored on a submission. */
+  label: string;
+  plans: Plan[];
+  /**
+   * API-equivalent burn the entry paid plan is sized for. An estimate — every
+   * vendor states capacity relative to their own tiers, never in dollars — so
+   * it only ever picks which plan to *suggest*. No saving figure depends on it.
+   */
+  entryPlanBurn: number;
+  /** Shown verbatim on the page so the numbers are auditable. */
+  source: string;
+  /** Set when the vendor publishes no comparable usage tiers. */
+  capacityUnknownNote?: string;
+}
+
+export const TOOL_PLANS: ToolPlans[] = [
   {
-    id: "pro",
-    name: "Claude Pro",
-    monthly: 20,
-    blurb: "Everyday coding, a few hours a day.",
-    usageMultiple: 1,
+    id: "claude",
+    label: "Claude Code",
+    entryPlanBurn: 100,
+    source: "claude.com/pricing and the Max plan help centre article",
+    plans: [
+      { id: "pro", name: "Claude Pro", monthly: 20, blurb: "Everyday coding, a few hours a day.", usageMultiple: 1 },
+      { id: "max5", name: "Claude Max 5x", monthly: 100, blurb: "Most of a working day in Claude Code.", usageMultiple: 5 },
+      { id: "max20", name: "Claude Max 20x", monthly: 200, blurb: "All day, every day, plus parallel agents.", usageMultiple: 20 },
+    ],
   },
   {
-    id: "max5",
-    name: "Claude Max 5x",
-    monthly: 100,
-    blurb: "Most of a working day in Claude Code.",
-    usageMultiple: 5,
+    id: "codex",
+    label: "Codex",
+    entryPlanBurn: 100,
+    source: "learn.chatgpt.com/docs/pricing",
+    plans: [
+      { id: "go", name: "ChatGPT Go", monthly: 8, blurb: "Lightweight coding tasks.", usageMultiple: 0.4 },
+      { id: "plus", name: "ChatGPT Plus", monthly: 20, blurb: "A few focused coding sessions a week.", usageMultiple: 1 },
+      // OpenAI states Pro as "5x higher rate limits than Plus".
+      { id: "pro", name: "ChatGPT Pro", monthly: 100, blurb: "5× the rate limits of Plus.", usageMultiple: 5 },
+      { id: "pro200", name: "ChatGPT Pro ($200 tier)", monthly: 200, blurb: "Highest limits, plus unlimited voice.", usageMultiple: 5 },
+    ],
   },
   {
-    id: "max20",
-    name: "Claude Max 20x",
-    monthly: 200,
-    blurb: "All day, every day, plus parallel agents.",
-    usageMultiple: 20,
+    id: "copilot",
+    label: "GitHub Copilot",
+    entryPlanBurn: 100,
+    source: "github.com/features/copilot/plans",
+    capacityUnknownNote:
+      "GitHub does not publish usage tiers as multiples of each other, so no plan is marked as too small — only the break-even arithmetic is shown.",
+    plans: [
+      { id: "pro", name: "Copilot Pro", monthly: 10, blurb: "Individual developers.", usageMultiple: null },
+      { id: "proplus", name: "Copilot Pro+", monthly: 39, blurb: "Heavier agent use.", usageMultiple: null },
+      { id: "max", name: "Copilot Max", monthly: 100, blurb: "Sustained, high-volume agent workflows.", usageMultiple: null },
+    ],
   },
 ];
 
-/** Anthropic API list prices, USD per million tokens. Verified 2026-08-05. */
-export const API_PRICES = [
-  { model: "Claude Opus 5", input: 5, output: 25 },
-  { model: "Claude Sonnet 5", input: 3, output: 15 },
-  { model: "Claude Haiku 4.5", input: 1, output: 5 },
-] as const;
+export const DEFAULT_TOOL = TOOL_PLANS[0];
 
-export interface PlanVerdict {
-  /** The cheapest plan whose usage tier plausibly covers this burn. */
-  recommended: Plan;
-  /** Monthly saving vs paying API list prices for the same usage. */
-  savingVsApi: number;
-  /** How many times over the plan pays for itself. Infinity guarded to 0 burn. */
-  multiple: number;
-  /**
-   * True when burn is high enough that even the largest plan's usage limits
-   * are likely to bind. The saving is still real, but so are the rate limits.
-   */
-  exceedsTopPlan: boolean;
+export function toolPlansFor(toolId: string): ToolPlans {
+  return TOOL_PLANS.find((tool) => tool.id === toolId) ?? DEFAULT_TOOL;
 }
-
-/**
- * Pro is sized for roughly this much API-equivalent burn per month. Derived
- * from viberank's own distribution rather than published limits: Anthropic
- * states Max as a multiple of Pro, never as a dollar figure, so any absolute
- * number here is an estimate. Used only to pick which plan to *suggest* — the
- * saving figure below never depends on it.
- */
-const PRO_EQUIVALENT_BURN = 100;
 
 /**
  * Whether a plan's usage tier plausibly carries this much burn.
  *
  * This is what stops the comparison table from lying. Raw arithmetic says the
- * cheapest plan always "saves" the most — Pro appears to save more than Max
+ * cheapest plan always "saves" the most — Claude Pro appears to beat Max
  * against a $1,300/month burn, because it costs less. But Pro would rate-limit
  * that user at a fraction of their usage, so presenting it as the bigger
- * saving is nonsense. The table has to show capacity alongside price.
+ * saving is nonsense.
+ *
+ * When a vendor publishes no usage multiples we return `true` rather than
+ * guess: showing an invented "too small" label would be a different kind of
+ * lie from the one we're fixing.
  */
-export function coversBurn(plan: Plan, monthlyApiCost: number): boolean {
-  return monthlyApiCost <= PRO_EQUIVALENT_BURN * plan.usageMultiple;
+export function coversBurn(tool: ToolPlans, plan: Plan, monthlyApiCost: number): boolean {
+  if (plan.usageMultiple === null) return true;
+  return monthlyApiCost <= tool.entryPlanBurn * plan.usageMultiple;
 }
 
-/**
- * Given an API-equivalent monthly burn, work out which plan to be on and what
- * it saves. `monthlyApiCost` is what ccusage says the month would cost at list
- * prices.
- */
-export function comparePlans(monthlyApiCost: number): PlanVerdict {
+export interface PlanVerdict {
+  /**
+   * `null` when the vendor publishes no usage tiers. Picking the cheapest plan
+   * in that case would claim a $10 seat carries $1,300/month of usage — the
+   * same lie the capacity check exists to prevent, just from the other side.
+   * Better to show the prices and decline to rank them.
+   */
+  recommended: Plan | null;
+  /** Monthly saving vs paying API list prices for the same usage. */
+  savingVsApi: number;
+  multiple: number;
+  /** Burn exceeds what even the largest plan is sized for. */
+  exceedsTopPlan: boolean;
+}
+
+export function comparePlans(tool: ToolPlans, monthlyApiCost: number): PlanVerdict {
   const burn = Number.isFinite(monthlyApiCost) && monthlyApiCost > 0 ? monthlyApiCost : 0;
+  const top = tool.plans[tool.plans.length - 1];
+  const ranked = tool.plans.some((plan) => plan.usageMultiple !== null);
 
-  const recommended =
-    PLANS.find((plan) => burn <= PRO_EQUIVALENT_BURN * plan.usageMultiple) ??
-    PLANS[PLANS.length - 1];
+  const recommended = ranked
+    ? tool.plans.find((plan) => coversBurn(tool, plan, burn)) ?? top
+    : null;
 
-  // The saving is burn minus the subscription price — not clamped at zero,
-  // because a negative number is the honest answer for light users: below
-  // ~$20/month of usage, the API is genuinely the cheaper option and the tool
-  // should say so rather than manufacture a win.
-  const savingVsApi = burn - recommended.monthly;
+  // Not clamped at zero: below the price of the cheapest plan the API is
+  // genuinely cheaper, and the tool should say so rather than manufacture a
+  // win. A calculator that can never tell you "don't buy this" isn't useful.
+  const savingVsApi = recommended ? burn - recommended.monthly : 0;
 
   return {
     recommended,
     savingVsApi,
-    multiple: recommended.monthly > 0 ? burn / recommended.monthly : 0,
-    exceedsTopPlan: burn > PRO_EQUIVALENT_BURN * PLANS[PLANS.length - 1].usageMultiple,
+    multiple: recommended && recommended.monthly > 0 ? burn / recommended.monthly : 0,
+    exceedsTopPlan:
+      top.usageMultiple !== null && burn > tool.entryPlanBurn * top.usageMultiple,
   };
+}
+
+/** Whether this tool publishes enough to rank its plans by capacity. */
+export function hasCapacityData(tool: ToolPlans): boolean {
+  return tool.plans.some((plan) => plan.usageMultiple !== null);
 }
 
 /**

--- a/src/lib/spend-curve.ts
+++ b/src/lib/spend-curve.ts
@@ -65,6 +65,34 @@ export function buildSpendCurve(rows: BurnRow[]): SpendCurve {
   };
 }
 
+/**
+ * 101 thresholds, p0 through p100.
+ *
+ * The page needs to place an arbitrary burn on the curve in the browser.
+ * Shipping the raw cohort to do that meant serialising a float per developer
+ * into the RSC payload — a thousand of them today, growing with the board,
+ * and all of it parsed before the page becomes interactive. This is a fixed
+ * 101 numbers that answers the same question to the nearest percentile.
+ */
+export function percentileLadder(sorted: number[]): number[] {
+  // An empty cohort must produce an empty ladder, not 101 zeros. A zero-filled
+  // ladder ranks every positive burn at p100 — "you out-spend 100% of
+  // developers" on the basis of no developers at all.
+  if (sorted.length === 0) return [];
+  return Array.from({ length: 101 }, (_, p) => quantile(sorted, p / 100));
+}
+
+/**
+ * Percentile for a burn, from the ladder above. Counts thresholds strictly
+ * below the burn so the cheapest developer lands at p0.
+ */
+export function percentileFromLadder(ladder: number[], burn: number): number {
+  if (ladder.length === 0) return 0;
+  let p = 0;
+  while (p < ladder.length && ladder[p] < burn) p++;
+  return Math.min(p, 100);
+}
+
 /** Linear-interpolated quantile. Returns 0 for an empty cohort. */
 export function quantile(sorted: number[], q: number): number {
   if (sorted.length === 0) return 0;

--- a/test/plans.test.mts
+++ b/test/plans.test.mts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 
-const { comparePlans, coversBurn, percentileOf, monthlyBurn, PLANS } = await import("../src/lib/plans.ts");
+const {
+  comparePlans,
+  coversBurn,
+  percentileOf,
+  monthlyBurn,
+  toolPlansFor,
+  hasCapacityData,
+  TOOL_PLANS,
+} = await import("../src/lib/plans.ts");
 
 let passed = 0;
 const check = (label: string) => {
@@ -8,23 +16,61 @@ const check = (label: string) => {
   console.log(`✓ ${label}`);
 };
 
+const claude = toolPlansFor("claude");
+const codex = toolPlansFor("codex");
+const copilot = toolPlansFor("copilot");
+
+// ---------------------------------------------------------------------------
+// Prices — these are real numbers users will act on, so pin them.
+// Any edit without re-checking the vendor's page fails here.
+// ---------------------------------------------------------------------------
+
+{
+  assert.deepEqual(
+    claude.plans.map((p) => [p.name, p.monthly]),
+    [["Claude Pro", 20], ["Claude Max 5x", 100], ["Claude Max 20x", 200]],
+    "claude.com/pricing, checked 2026-08-05"
+  );
+  assert.deepEqual(
+    codex.plans.map((p) => p.monthly),
+    [8, 20, 100, 200],
+    "learn.chatgpt.com/docs/pricing, checked 2026-08-05"
+  );
+  assert.deepEqual(
+    copilot.plans.map((p) => p.monthly),
+    [10, 39, 100],
+    "github.com/features/copilot/plans, checked 2026-08-05"
+  );
+  check("plan prices match the vendor pricing pages");
+}
+
+{
+  for (const tool of TOOL_PLANS) {
+    const prices = tool.plans.map((p) => p.monthly);
+    assert.deepEqual(
+      prices,
+      [...prices].sort((a, b) => a - b),
+      `${tool.id} plans must be ordered cheapest-first for selection to work`
+    );
+    assert.ok(tool.source.length > 0, `${tool.id} must cite a source`);
+  }
+  check("every tool is ordered cheapest-first and cites a source");
+}
+
 // ---------------------------------------------------------------------------
 // Plan selection
 // ---------------------------------------------------------------------------
 
 {
-  assert.equal(comparePlans(45).recommended.id, "pro");
-  assert.equal(comparePlans(400).recommended.id, "max5");
-  assert.equal(comparePlans(1318).recommended.id, "max20", "the median viberank dev");
-  assert.equal(comparePlans(26000).recommended.id, "max20", "p99 still tops out at max20");
+  assert.equal(comparePlans(claude, 45).recommended!.id, "pro");
+  assert.equal(comparePlans(claude, 400).recommended!.id, "max5");
+  assert.equal(comparePlans(claude, 1318).recommended!.id, "max20", "the median viberank dev");
+  assert.equal(comparePlans(claude, 26000).recommended!.id, "max20", "p99 still tops out");
   check("recommends the cheapest plan whose usage tier covers the burn");
 }
 
 {
-  // The honest case: a light user is genuinely better off on the API, and the
-  // tool has to be willing to say so rather than invent a saving.
-  const light = comparePlans(12);
-  assert.equal(light.recommended.id, "pro");
+  const light = comparePlans(claude, 12);
   assert.ok(
     light.savingVsApi < 0,
     `expected a negative saving for a $12/mo user, got ${light.savingVsApi}`
@@ -33,27 +79,92 @@ const check = (label: string) => {
 }
 
 {
-  const median = comparePlans(1318);
+  const median = comparePlans(claude, 1318);
   assert.equal(median.savingVsApi, 1318 - 200);
   assert.ok(Math.abs(median.multiple - 6.59) < 0.01, `got ${median.multiple}`);
   check("saving and multiple are computed against the recommended plan");
 }
 
 {
-  assert.equal(comparePlans(1000).exceedsTopPlan, false);
-  assert.equal(comparePlans(5000).exceedsTopPlan, true);
+  assert.equal(comparePlans(claude, 1000).exceedsTopPlan, false);
+  assert.equal(comparePlans(claude, 5000).exceedsTopPlan, true);
   check("flags burn that would strain even the largest plan's limits");
 }
 
 {
-  // Guard the degenerate inputs a form can produce.
   for (const bad of [0, -50, NaN, Infinity]) {
-    const verdict = comparePlans(bad as number);
-    assert.equal(verdict.recommended.id, "pro", `bad input ${bad}`);
-    assert.ok(Number.isFinite(verdict.savingVsApi), `non-finite saving for ${bad}`);
-    assert.ok(Number.isFinite(verdict.multiple), `non-finite multiple for ${bad}`);
+    for (const tool of TOOL_PLANS) {
+      const verdict = comparePlans(tool, bad as number);
+      // Ranked tools must still name a plan; unranked ones must still not.
+      assert.equal(
+        verdict.recommended !== null,
+        hasCapacityData(tool),
+        `${tool.id} changed its ranking behaviour on input ${bad}`
+      );
+      assert.ok(Number.isFinite(verdict.savingVsApi), `non-finite saving for ${bad}`);
+      assert.ok(Number.isFinite(verdict.multiple), `non-finite multiple for ${bad}`);
+    }
   }
-  check("degenerate inputs never produce NaN or Infinity");
+  check("degenerate inputs never produce NaN or Infinity, for any tool");
+}
+
+// ---------------------------------------------------------------------------
+// Capacity — the guard against the table recommending against itself
+// ---------------------------------------------------------------------------
+
+{
+  // On price alone Pro "saves" more than Max 20x against a $1,300/mo burn,
+  // because Pro is cheaper. Presenting that as the better deal is nonsense —
+  // Pro would rate-limit that user at a fraction of it.
+  const burn = 1300;
+  const pro = claude.plans.find((p) => p.id === "pro")!;
+  const max20 = claude.plans.find((p) => p.id === "max20")!;
+
+  assert.ok(burn - pro.monthly > burn - max20.monthly, "cheaper plan shows a bigger raw saving");
+  assert.equal(coversBurn(claude, pro, burn), false, "Pro must not be shown as covering $1300/mo");
+  assert.equal(coversBurn(claude, max20, burn), true);
+  check("capacity check stops a cheaper plan from looking like the better deal");
+}
+
+{
+  // Copilot publishes no usage multiples. Inventing a "too small" label would
+  // be a different lie from the one the capacity check exists to prevent, so
+  // every plan is treated as covering and the page says why.
+  for (const plan of copilot.plans) {
+    assert.equal(plan.usageMultiple, null, `${plan.id} must not claim an unsourced multiple`);
+    assert.equal(coversBurn(copilot, plan, 99_999), true);
+  }
+  assert.ok(copilot.capacityUnknownNote, "must explain why no plan is marked too small");
+  assert.equal(comparePlans(copilot, 5000).exceedsTopPlan, false, "no unsourced ceiling claim");
+  check("tools without published usage tiers make no capacity claims");
+}
+
+{
+  // The mirror-image bug: with no capacity data, picking the cheapest plan
+  // claimed a $10 Copilot Pro seat carries $1,300/mo of usage and "pays for
+  // itself 130x over". Declining to rank is the only honest option.
+  assert.equal(hasCapacityData(copilot), false);
+  const verdict = comparePlans(copilot, 1300);
+  assert.equal(verdict.recommended, null, "must not name a plan it cannot rank");
+  assert.equal(verdict.savingVsApi, 0, "no saving claim without a recommended plan");
+  assert.equal(verdict.multiple, 0, "no 130x multiple claim");
+
+  // Tools that do publish tiers keep recommending.
+  assert.equal(hasCapacityData(claude), true);
+  assert.equal(hasCapacityData(codex), true);
+  assert.ok(comparePlans(codex, 1300).recommended, "codex still ranks");
+  check("no plan is recommended when the vendor publishes no usage tiers");
+}
+
+{
+  assert.equal(coversBurn(claude, claude.plans[0], 50), true, "Pro covers a light user");
+  assert.equal(coversBurn(claude, claude.plans[0], 0), true, "zero burn is covered by every plan");
+  check("capacity check is true for burn within a plan's tier");
+}
+
+{
+  assert.equal(toolPlansFor("nonsense").id, "claude", "unknown tool falls back, never throws");
+  check("an unknown tool id falls back to the default");
 }
 
 // ---------------------------------------------------------------------------
@@ -70,9 +181,7 @@ const check = (label: string) => {
 
 {
   assert.equal(percentileOf([], 500), 0, "an empty cohort must not divide by zero");
-  // Ties sit at the bottom of their run, so the cheapest dev is p0 rather than
-  // inheriting a percentile from everyone equal to them.
-  assert.equal(percentileOf([10, 10, 10, 10], 10), 0);
+  assert.equal(percentileOf([10, 10, 10, 10], 10), 0, "ties sit at the bottom of their run");
   check("empty cohorts and ties are handled without dividing by zero");
 }
 
@@ -87,44 +196,6 @@ const check = (label: string) => {
   assert.equal(monthlyBurn(300, 0), 0, "a zero-day span must not divide by zero");
   assert.equal(monthlyBurn(300, -5), 0);
   check("monthly burn normalises any span without dividing by zero");
-}
-
-// ---------------------------------------------------------------------------
-// Plan data sanity — these are real prices users will act on
-// ---------------------------------------------------------------------------
-
-{
-  assert.deepEqual(
-    PLANS.map((p) => p.monthly),
-    [20, 100, 200],
-    "plan prices must match claude.com/pricing (verified 2026-08-05)"
-  );
-  assert.deepEqual(
-    PLANS.map((p) => p.monthly).slice().sort((a: number, b: number) => a - b),
-    PLANS.map((p) => p.monthly),
-    "plans must be ordered cheapest-first for selection to work"
-  );
-  check("plan prices are correct and ordered cheapest-first");
-}
-
-{
-  // The bug this guards: on price alone Pro "saves" more than Max 20x against
-  // a $1,300/mo burn, because Pro is cheaper. Presenting that as the better
-  // deal is nonsense — Pro would rate-limit that user at a fraction of it.
-  const burn = 1300;
-  const pro = PLANS.find((p) => p.id === "pro")!;
-  const max20 = PLANS.find((p) => p.id === "max20")!;
-
-  assert.ok(burn - pro.monthly > burn - max20.monthly, "cheaper plan shows a bigger raw saving");
-  assert.equal(coversBurn(pro, burn), false, "Pro must not be presented as covering $1300/mo");
-  assert.equal(coversBurn(max20, burn), true);
-  check("capacity check stops a cheaper plan from looking like the better deal");
-}
-
-{
-  assert.equal(coversBurn(PLANS[0], 50), true, "Pro covers a light user");
-  assert.equal(coversBurn(PLANS[0], 0), true, "zero burn is covered by every plan");
-  check("capacity check is true for burn within a plan's tier");
 }
 
 console.log(`\n${passed} passed, 0 failed`);

--- a/test/spend-curve.test.mts
+++ b/test/spend-curve.test.mts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 
-const { buildSpendCurve, quantile } = await import("../src/lib/spend-curve.ts");
+const { buildSpendCurve, quantile, percentileLadder, percentileFromLadder } = await import("../src/lib/spend-curve.ts");
 
 let passed = 0;
 const check = (label: string) => {
@@ -91,6 +91,51 @@ const row = (username: string, totalCost: number, start: string, end: string) =>
     assert.ok(ps[i] >= ps[i - 1], "percentiles must be monotonic");
   }
   check("cohort and percentiles come back monotonically ascending");
+}
+
+{
+  const rows = Array.from({ length: 500 }, (_, i) =>
+    row(`u${i}`, (i + 1) * 20, "2026-01-01", "2026-01-30")
+  );
+  const curve = buildSpendCurve(rows);
+  const ladder = percentileLadder(curve.sorted);
+
+  assert.equal(ladder.length, 101, "the ladder is a fixed size regardless of cohort size");
+  for (let i = 1; i < ladder.length; i++) {
+    assert.ok(ladder[i] >= ladder[i - 1], "ladder must be ascending");
+  }
+  check("percentile ladder is a fixed 101 ascending thresholds");
+}
+
+{
+  // The ladder must agree with a direct scan of the full cohort, or the
+  // payload saving comes at the cost of a wrong answer.
+  const rows = Array.from({ length: 400 }, (_, i) =>
+    row(`u${i}`, (i + 1) * 15, "2026-01-01", "2026-01-30")
+  );
+  const curve = buildSpendCurve(rows);
+  const ladder = percentileLadder(curve.sorted);
+
+  for (const probe of [0.5, 100, 1000, 4500, 9000, 999999]) {
+    const direct = Math.round(
+      (curve.sorted.filter((b) => b < probe).length / curve.sorted.length) * 100
+    );
+    const viaLadder = percentileFromLadder(ladder, probe);
+    assert.ok(
+      Math.abs(direct - viaLadder) <= 1,
+      `ladder disagreed at ${probe}: direct p${direct}, ladder p${viaLadder}`
+    );
+  }
+  check("ladder percentiles match a full-cohort scan within one point");
+}
+
+{
+  assert.equal(percentileFromLadder([], 500), 0, "empty ladder must not throw");
+  assert.equal(percentileFromLadder(percentileLadder([]), 500), 0);
+  const single = percentileLadder([42]);
+  assert.equal(percentileFromLadder(single, 1), 0);
+  assert.equal(percentileFromLadder(single, 99), 100);
+  check("ladder handles empty and single-element cohorts");
 }
 
 console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
The calculator shipped Claude-only, which excluded the **259 Codex and 93 Gemini users** already on the board.

## Codex and Copilot added

Prices taken from each vendor's own pricing page — [learn.chatgpt.com/docs/pricing](https://learn.chatgpt.com/docs/pricing), [github.com/features/copilot/plans](https://github.com/features/copilot/plans) — and **asserted in the tests**, so an unsourced edit fails CI. Each tool shows its source on the page.

**Gemini CLI is deliberately absent.** Google's own plan page does not publish monthly prices for the tiers that include it. A guessed number in a tool people use to make spending decisions is worse than an honest omission, and the page says so rather than quietly leaving a gap.

## The capacity check needed a second half

#105 fixed one direction: a cheaper plan advertising a bigger saving than the one actually recommended (Claude Pro "saving" more than Max 20x on a $1,300/month burn).

Copilot exposed the mirror image. GitHub publishes no usage tiers, so the fallback picked the cheapest plan and claimed a **$10 Copilot Pro seat carried $1,300/month of usage and "paid for itself 130× over"**. That's the same lie from the opposite direction, and I only saw it by clicking through the new tool in a browser.

Where a vendor publishes no comparable tiers, the page now **declines to rank**: no recommended plan, no saving headline, no multiple — just the break-even arithmetic per plan and a note explaining why nothing is marked too small. Tested in both directions.

## Payload

Replaced the raw cohort in the client payload with a fixed **101-value percentile ladder**. Serialising one float per developer meant the RSC payload grew with the board and had to be parsed before the page became interactive.

Prerendered HTML: **61.8 KB → 48.8 KB (−21%)**. A test asserts the ladder agrees with a full-cohort scan within one percentile point, so the size saving can't come at the cost of a wrong answer.

Writing that test surfaced a bug in it: an empty cohort produced a ladder of 101 zeros, ranking every positive burn at **p100** — "you out-spend 100% of developers" on the basis of no developers at all.

## Mobile

Verified at a real **390px viewport** (Chrome's `resize_window` reports success but leaves `innerWidth` at 1470, so it can't test this — Playwright can): no horizontal overflow on `/calculator` or the homepage, cards stack, plan ladder stays readable. This closes the "not verified" caveat from #105.

`npm test` (74 across 5 files), `tsc`, `eslint` and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)