### PR TITLE
fix: sitemap silently omitted every profile past the first thousand

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { createClient } from "@supabase/supabase-js";
 import { FEATURED_TOOLS } from "@/lib/utils";
+import { fetchAllPages } from "@/lib/data/supabase/client";
 
 const SITE = "https://www.viberank.app";
 
@@ -43,14 +44,27 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     // by the unique `github_username` constraint. The data-layer's
     // `getLeaderboard` caps pageSize at 50 to protect the leaderboard UI,
     // which isn't useful for sitemap generation.
+    // `.limit(45000)` here was silently served as 1000 by PostgREST's
+    // db-max-rows, so every profile past the first thousand was missing from
+    // the sitemap entirely — the same silent cap fixed in the data layer.
+    // Page through with the same helper rather than a second implementation.
     const client = createClient(supabaseUrl, serviceKey);
-    const { data: profiles } = await client
-      .from("profiles")
-      .select("username, github_username, updated_at")
-      .order("updated_at", { ascending: false })
-      .limit(45000); // Google's per-sitemap ceiling is 50k URLs.
+    const profiles = await fetchAllPages<{
+      username: string;
+      github_username: string | null;
+      updated_at: string | null;
+    }>(
+      (from, to) =>
+        client
+          .from("profiles")
+          .select("username, github_username, updated_at")
+          .order("updated_at", { ascending: false })
+          .order("username", { ascending: true })
+          .range(from, to),
+      "profiles for sitemap"
+    );
 
-    const profileEntries: MetadataRoute.Sitemap = (profiles ?? []).flatMap((p) => {
+    const profileEntries: MetadataRoute.Sitemap = profiles.flatMap((p) => {
       const handle = p.github_username || p.username;
       if (!handle) return [];
       return [{

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -189,7 +189,7 @@ function convertDbDailyBreakdown(db: DbDailyBreakdown): DailyBreakdown {
 const PAGE_SIZE = 1000;
 const MAX_ROWS = 200_000;
 
-async function fetchAllPages<T>(
+export async function fetchAllPages<T>(
   buildPage: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
   context: string
 ): Promise<T[]> {


### PR DESCRIPTION
Found while auditing SEO: the live sitemap lists **exactly 1000** profile URLs against **1090** profiles.

`.limit(45000)` on the profiles table was silently served as 1000 by PostgREST's `db-max-rows` — the same cap fixed in the data layer in #101, in a place I hadn't audited. Roughly **90 developers' pages carried no sitemap signal at all**.

Profile pages are the site's largest indexable surface (1090 of the ~1110 URLs in the sitemap), so this is the most expensive instance of that bug rather than the least.

Fixed by paging through with the exported `fetchAllPages` rather than writing a second implementation, so the sitemap can't drift from the data layer's paging semantics.

**Verified:** local sitemap goes from 1000 → **1090** profile URLs, matching `SELECT count(*) FROM profiles` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)