### PR TITLE
fix: share cards had no image on key pages and advertised stale numbers

### DIFF
--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -3,6 +3,52 @@ import { getTier } from '@/lib/tiers';
 
 export const runtime = 'edge';
 
+
+/**
+ * Live headline figures for the default share card.
+ *
+ * These were hardcoded as "1000+ / $50K+ / 100M+". The board passed those
+ * numbers long ago — it is at $8.5M and 9.2T tokens — so every link shared to
+ * Twitter or Slack was underselling the site by more than two orders of
+ * magnitude. Read them from the same site-stats function /stats uses.
+ *
+ * Best effort: the card must still render if the call fails, so a failure
+ * falls back to conservative floors rather than throwing.
+ */
+async function loadSiteStats(): Promise<{ users: string; spend: string; tokens: string }> {
+  const fallback = { users: '1000+', spend: '$8M+', tokens: '9T+' };
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !key) return fallback;
+
+  try {
+    const res = await fetch(`${url}/rest/v1/rpc/get_site_stats`, {
+      method: 'POST',
+      headers: { apikey: key, Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' },
+      body: '{}',
+      // Share cards are fetched by crawlers far more often than the data
+      // changes; an hour of staleness is invisible and keeps this cheap.
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return fallback;
+    const s = await res.json();
+
+    const compact = (n: number) =>
+      n >= 1e12 ? `${(n / 1e12).toFixed(1)}T`
+      : n >= 1e9 ? `${(n / 1e9).toFixed(0)}B`
+      : n >= 1e6 ? `${(n / 1e6).toFixed(0)}M`
+      : `${Math.round(n / 1e3)}K`;
+
+    return {
+      users: `${Number(s.totalUsers || 0).toLocaleString('en-US')}`,
+      spend: `$${compact(Number(s.totalCost || 0))}`,
+      tokens: compact(Number(s.totalTokens || 0)),
+    };
+  } catch {
+    return fallback;
+  }
+}
+
 const Logo = ({ size = 72 }: { size?: number }) => (
   <svg width={size} height={size} viewBox="0 0 24 24" fill="none">
     <rect x="3" y="14" width="5" height="7" rx="1" fill="#f97316" opacity="0.5" />
@@ -242,7 +288,11 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
 
           {/* stats + CTA */}
           <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
-            <div style={{ display: 'flex', gap: streak ? 56 : 72 }}>
+            {/* With four stats the row outgrew the canvas and pushed the CTA
+                off the right edge — on the profile card, which is the one
+                people actually share. Tighten the gap and stop the CTA from
+                being the thing that gets squeezed out. */}
+            <div style={{ display: 'flex', gap: streak ? 28 : 64, minWidth: 0 }}>
               {stat(costLabel, 'AI CODING USAGE', '#f97316')}
               {tokens ? stat(tokens, 'TOKENS', '#fafafa') : null}
               {days ? stat(days, 'ACTIVE DAYS', '#fafafa') : null}
@@ -257,6 +307,7 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
                 backgroundColor: '#16161a',
                 border: '1px solid #26262d',
                 borderRadius: 10,
+                flexShrink: 0,
               }}
             >
               <span style={{ fontSize: 22, color: '#9a9aa5', fontFamily: 'Geist Mono' }}>$</span>
@@ -301,6 +352,7 @@ export async function GET(request: Request) {
 
     const title = searchParams.get('title') || 'Viberank';
     const description = searchParams.get('description') || 'Claude Code, Codex & AI Coding Leaderboard';
+    const siteStats = await loadSiteStats();
 
     return new ImageResponse(
       (
@@ -324,10 +376,15 @@ export async function GET(request: Request) {
             </svg>
             <h1
               style={{
-                fontSize: 72,
+                // A fixed 72px clipped anything longer than ~30 characters —
+                // both the logo and the closing character ran off the canvas.
+                fontSize: title.length > 44 ? 44 : title.length > 30 ? 56 : 72,
                 fontWeight: 'bold',
                 color: '#fafafa',
                 margin: 0,
+                textAlign: 'center',
+                maxWidth: 1000,
+                lineHeight: 1.15,
               }}
             >
               {title}
@@ -356,15 +413,15 @@ export async function GET(request: Request) {
             }}
           >
             <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <div style={{ fontSize: 40, fontWeight: 'bold', color: '#f97316' }}>1000+</div>
+              <div style={{ fontSize: 40, fontWeight: 'bold', color: '#f97316' }}>{siteStats.users}</div>
               <div style={{ fontSize: 20, color: '#a1a1aa' }}>Developers</div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <div style={{ fontSize: 40, fontWeight: 'bold', color: '#f97316' }}>$50K+</div>
+              <div style={{ fontSize: 40, fontWeight: 'bold', color: '#f97316' }}>{siteStats.spend}</div>
               <div style={{ fontSize: 20, color: '#a1a1aa' }}>Total Spent</div>
             </div>
             <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-              <div style={{ fontSize: 40, fontWeight: 'bold', color: '#f97316' }}>100M+</div>
+              <div style={{ fontSize: 40, fontWeight: 'bold', color: '#f97316' }}>{siteStats.tokens}</div>
               <div style={{ fontSize: 20, color: '#a1a1aa' }}>Tokens Used</div>
             </div>
           </div>

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -25,7 +25,11 @@ export const metadata: Metadata = {
     description: DESCRIPTION,
     url: "https://www.viberank.app/calculator",
     siteName: "Viberank",
+    images: [
+      `/api/og?title=${encodeURIComponent("Are you overpaying for AI coding?")}&description=${encodeURIComponent("88% of developers burn more than $200/month in API-equivalent cost. Find out where you land.")}`,
+    ],
   },
+  twitter: { card: "summary_large_image" },
 };
 
 export default async function CalculatorPage() {

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -23,7 +23,13 @@ export const metadata: Metadata = {
       "Total spend, tokens burned, and the most used models across every coding agent tracked on Viberank.",
     url: "https://www.viberank.app/stats",
     siteName: "Viberank",
+    // Without an explicit image here the page-level openGraph object replaces
+    // the layout's default and the page shares as a bare link.
+    images: [
+      `/api/og?title=${encodeURIComponent("The state of the board")}&description=${encodeURIComponent("Aggregate AI coding spend, tokens and models across every developer on Viberank")}`,
+    ],
   },
+  twitter: { card: "summary_large_image" },
 };
 
 function StatTile({

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -41,7 +41,16 @@ export async function generateMetadata({ params }: ToolParams): Promise<Metadata
       "vibe coding",
     ],
     alternates: { canonical },
-    openGraph: { title, description, url: canonical, siteName: "Viberank", type: "website" },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: "Viberank",
+      type: "website",
+      images: [
+        `/api/og?title=${encodeURIComponent(`${label} leaderboard`)}&description=${encodeURIComponent(`Who spends the most on ${label}, from real ccusage data`)}`,
+      ],
+    },
     twitter: { card: "summary_large_image", title, description },
   };
 }


### PR DESCRIPTION
Three separate problems with the site's share assets, all found by actually rendering the cards and looking at them.

## 1. Three pages had no `og:image` at all

`/calculator`, `/stats` and `/tool/*` each define a page-level `openGraph` object, which **replaces** the layout's default rather than merging with it. So they shared as bare links with no card. The calculator is the most shareable thing on the site and had nothing.

## 2. The default card was advertising numbers from a much smaller site

The headline figures were hardcoded:

| Card said | Reality |
|---|---|
| `1000+` developers | **1,090** |
| `$50K+` total spent | **$8.5M** |
| `100M+` tokens | **9.2T** |

Every link shared to Twitter, Slack or LinkedIn was underselling the site by **more than two orders of magnitude on spend**. They now come from the same `get_site_stats` the `/stats` page uses, cached an hour (crawlers fetch these far more often than the data changes), with conservative fallbacks so a failed call still renders a card rather than throwing.

## 3. Long titles overflowed the canvas

A fixed 72px font clipped anything past ~30 characters. *"Are you overpaying for AI coding?"* lost **both** the logo off the left edge and its closing `?` off the right. Font size now steps down with length and the heading wraps.

## Also: the profile card

The card people actually share. With four stats (cost, tokens, days, streak) the row outgrew the canvas and pushed the `npx viberank-cli` chip **entirely off the right edge**. Tightened the gap and stopped the CTA being the element that gets squeezed out.

Verified by rendering each variant and inspecting the PNG: default, titled, and profile all render correctly at 1200×630.

`npm test`, `tsc`, `eslint` and `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)