### PR TITLE
fix: stale leaderboard responses could repaint newer filter state

### DIFF
--- a/src/lib/data/demo/client.ts
+++ b/src/lib/data/demo/client.ts
@@ -435,6 +435,11 @@ export function createDemoDataLayer(): DataLayer {
       async getSiteStats(): Promise<SiteStats | null> {
         return null;
       },
+      // The demo backend has no cohort to rank against; an empty list makes
+      // /calculator render its no-cohort state rather than invent a curve.
+      async getSpendRows() {
+        return [];
+      },
       async getGlobalStats(): Promise<GlobalStats> {
         const ranked = sortSubmissions(submissions, "cost");
         const totalCost = submissions.reduce((sum, submission) => sum + submission.totalCost, 0);

--- a/src/lib/data/hooks/requestGate.ts
+++ b/src/lib/data/hooks/requestGate.ts
@@ -1,0 +1,33 @@
+/**
+ * Sequencing for hooks that fire a new request whenever their params change.
+ *
+ * Without this, responses are applied in whatever order they arrive. Scroll to
+ * page 2 of the leaderboard and switch the sort before it lands, and the older
+ * page-2 response can resolve after the newer page-0 one and repaint rows that
+ * do not match the filters on screen. The `finally` of the stale request also
+ * clears the loading flag belonging to the newer one.
+ *
+ * Kept as a plain object rather than inlined in each hook so the rule is
+ * written and tested once instead of five times.
+ */
+export interface RequestGate {
+  /** Start a request and get the token identifying it. */
+  begin(): number;
+  /** True only for the most recently started request. */
+  isCurrent(token: number): boolean;
+  /**
+   * Abandon every in-flight request. Used on unmount and when a hook switches
+   * to "skip", so a late arrival cannot set state afterwards.
+   */
+  abandon(): void;
+}
+
+export function createRequestGate(): RequestGate {
+  let latest = 0;
+  return {
+    begin: () => ++latest,
+    isCurrent: (token) => token === latest,
+    // Bumping past every outstanding token invalidates all of them at once.
+    abandon: () => { latest++; },
+  };
+}

--- a/src/lib/data/hooks/useSubmissions.ts
+++ b/src/lib/data/hooks/useSubmissions.ts
@@ -6,7 +6,8 @@
 
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
+import { createRequestGate } from "./requestGate";
 import type {
   Submission,
   LeaderboardParams,
@@ -29,13 +30,19 @@ export function useLeaderboard(params: LeaderboardParams | "skip") {
   const [supabaseData, setSupabaseData] = useState<LeaderboardResult | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
   const [supabaseError, setSupabaseError] = useState<Error | null>(null);
+  const gate = useRef(createRequestGate());
 
   useEffect(() => {
     if (params === "skip") {
+      // Discard anything in flight so a late arrival can't repaint after we
+      // have deliberately cleared the data.
+      gate.current.abandon();
       setSupabaseData(undefined);
       return;
     }
 
+    const g = gate.current;
+    const token = g.begin();
     setSupabaseLoading(true);
     setSupabaseError(null);
 
@@ -44,9 +51,12 @@ export function useLeaderboard(params: LeaderboardParams | "skip") {
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.getLeaderboard(params);
       })
-      .then(setSupabaseData)
-      .catch(setSupabaseError)
-      .finally(() => setSupabaseLoading(false));
+      .then((result) => { if (g.isCurrent(token)) setSupabaseData(result); })
+        .catch((e) => { if (g.isCurrent(token)) setSupabaseError(e as Error); })
+      .finally(() => { if (g.isCurrent(token)) setSupabaseLoading(false); });
+
+    // Unmount (or a param change) abandons whatever is still in flight.
+    return () => g.abandon();
   }, [JSON.stringify(params)]);
 
   return {
@@ -63,13 +73,19 @@ export function useLeaderboardByDateRange(params: DateRangeLeaderboardParams | "
   const [supabaseData, setSupabaseData] = useState<DateRangeLeaderboardResult | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
   const [supabaseError, setSupabaseError] = useState<Error | null>(null);
+  const gate = useRef(createRequestGate());
 
   useEffect(() => {
     if (params === "skip") {
+      // Discard anything in flight so a late arrival can't repaint after we
+      // have deliberately cleared the data.
+      gate.current.abandon();
       setSupabaseData(undefined);
       return;
     }
 
+    const g = gate.current;
+    const token = g.begin();
     setSupabaseLoading(true);
     setSupabaseError(null);
 
@@ -78,9 +94,12 @@ export function useLeaderboardByDateRange(params: DateRangeLeaderboardParams | "
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.getLeaderboardByDateRange(params);
       })
-      .then(setSupabaseData)
-      .catch(setSupabaseError)
-      .finally(() => setSupabaseLoading(false));
+      .then((result) => { if (g.isCurrent(token)) setSupabaseData(result); })
+        .catch((e) => { if (g.isCurrent(token)) setSupabaseError(e as Error); })
+      .finally(() => { if (g.isCurrent(token)) setSupabaseLoading(false); });
+
+    // Unmount (or a param change) abandons whatever is still in flight.
+    return () => g.abandon();
   }, [JSON.stringify(params)]);
 
   return {
@@ -134,13 +153,19 @@ export function useSubmit() {
 export function useSubmission(id: string | undefined) {
   const [supabaseData, setSupabaseData] = useState<Submission | null | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
+  const gate = useRef(createRequestGate());
 
   useEffect(() => {
     if (!id) {
+      // Discard anything in flight so a late arrival can't repaint after we
+      // have deliberately cleared the data.
+      gate.current.abandon();
       setSupabaseData(undefined);
       return;
     }
 
+    const g = gate.current;
+    const token = g.begin();
     setSupabaseLoading(true);
 
     import("../supabase/client")
@@ -148,8 +173,11 @@ export function useSubmission(id: string | undefined) {
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.getSubmission(id);
       })
-      .then(setSupabaseData)
-      .finally(() => setSupabaseLoading(false));
+      .then((result) => { if (g.isCurrent(token)) setSupabaseData(result); })
+      .finally(() => { if (g.isCurrent(token)) setSupabaseLoading(false); });
+
+    // Unmount (or a param change) abandons whatever is still in flight.
+    return () => g.abandon();
   }, [id]);
 
   return {
@@ -164,14 +192,19 @@ export function useSubmission(id: string | undefined) {
 export function useFlaggedSubmissions(limit?: number, enabled: boolean = true) {
   const [supabaseData, setSupabaseData] = useState<Submission[] | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
+  const gate = useRef(createRequestGate());
 
   useEffect(() => {
     // Don't fetch for non-admin visitors — the data is public-readable but
     // there's no reason to pull it for everyone who lands on /admin.
     if (!enabled) {
+      gate.current.abandon();
       setSupabaseData(undefined);
       return;
     }
+
+    const g = gate.current;
+    const token = g.begin();
     setSupabaseLoading(true);
 
     import("../supabase/client")
@@ -179,8 +212,10 @@ export function useFlaggedSubmissions(limit?: number, enabled: boolean = true) {
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.getFlaggedSubmissions(limit);
       })
-      .then(setSupabaseData)
-      .finally(() => setSupabaseLoading(false));
+      .then((result) => { if (g.isCurrent(token)) setSupabaseData(result); })
+      .finally(() => { if (g.isCurrent(token)) setSupabaseLoading(false); });
+
+    return () => g.abandon();
   }, [limit, enabled]);
 
   return {
@@ -232,13 +267,19 @@ export function useUpdateFlagStatus() {
 export function useCheckClaimableSubmissions(githubUsername: string | undefined) {
   const [supabaseData, setSupabaseData] = useState<ClaimStatus | undefined>();
   const [supabaseLoading, setSupabaseLoading] = useState(false);
+  const gate = useRef(createRequestGate());
 
   useEffect(() => {
     if (!githubUsername) {
+      // Discard anything in flight so a late arrival can't repaint after we
+      // have deliberately cleared the data.
+      gate.current.abandon();
       setSupabaseData(undefined);
       return;
     }
 
+    const g = gate.current;
+    const token = g.begin();
     setSupabaseLoading(true);
 
     import("../supabase/client")
@@ -246,8 +287,11 @@ export function useCheckClaimableSubmissions(githubUsername: string | undefined)
         const dataLayer = createSupabaseDataLayer();
         return dataLayer.submissions.checkClaimableSubmissions(githubUsername);
       })
-      .then(setSupabaseData)
-      .finally(() => setSupabaseLoading(false));
+      .then((result) => { if (g.isCurrent(token)) setSupabaseData(result); })
+      .finally(() => { if (g.isCurrent(token)) setSupabaseLoading(false); });
+
+    // Unmount (or a param change) abandons whatever is still in flight.
+    return () => g.abandon();
   }, [githubUsername]);
 
   return {

--- a/test/request-gate.test.mts
+++ b/test/request-gate.test.mts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+
+const { createRequestGate } = await import("../src/lib/data/hooks/requestGate.ts");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+
+{
+  const gate = createRequestGate();
+  const only = gate.begin();
+  assert.equal(gate.isCurrent(only), true);
+  check("a lone request is current");
+}
+
+{
+  // The actual bug: page 2 starts, sort changes, page 0 starts, page 2 lands
+  // last. Its result must be dropped.
+  const gate = createRequestGate();
+  const page2 = gate.begin();
+  const page0 = gate.begin();
+
+  assert.equal(gate.isCurrent(page0), true, "the newest request wins");
+  assert.equal(gate.isCurrent(page2), false, "a superseded response is dropped");
+  check("a slow earlier response cannot overwrite a newer one");
+}
+
+{
+  // And it must stay dropped — a stale `finally` must not clear the newer
+  // request's loading flag either.
+  const gate = createRequestGate();
+  const stale = gate.begin();
+  gate.begin();
+  for (let i = 0; i < 5; i++) assert.equal(gate.isCurrent(stale), false);
+  check("a superseded request never becomes current again");
+}
+
+{
+  const gate = createRequestGate();
+  const inFlight = gate.begin();
+  gate.abandon();
+  assert.equal(gate.isCurrent(inFlight), false, "unmount must discard in-flight work");
+  const next = gate.begin();
+  assert.equal(gate.isCurrent(next), true, "the gate is reusable after abandoning");
+  check("abandon() discards in-flight requests and stays usable");
+}
+
+{
+  // Many rapid param changes — only the last may apply.
+  const gate = createRequestGate();
+  const tokens = Array.from({ length: 50 }, () => gate.begin());
+  const current = tokens.filter((t) => gate.isCurrent(t));
+  assert.equal(current.length, 1, "exactly one request may be current");
+  assert.equal(current[0], tokens[tokens.length - 1]);
+  check("under rapid changes exactly one request is current");
+}
+
+console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
The data-fetching hooks applied responses in whatever order they arrived.

Scroll to page 2 of the leaderboard and change the sort before it lands: the older page-2 response resolves **after** the newer page-0 one and repaints rows that don't match the filters on screen. The stale request's `finally` also clears the loading flag belonging to the newer request, so the board looks settled while showing the wrong data.

Reported by @B-EtterDigital in #72 alongside three other changes — this is the part of it that's still a live bug, extracted as agreed.

## Approach

Adds a small request gate (`begin` / `isCurrent` / `abandon`) and routes **all five** fetching hooks through it, rather than inlining the same guard five times. A response is applied only if it's still the newest request for that hook; unmounting or switching to `"skip"` abandons what's in flight so a late arrival can't set state afterwards.

The gate is a plain object rather than hook-internal state specifically so the ordering rule is **unit-testable without React**. The tests cover the page-2-lands-after-page-0 case directly, plus abandonment on unmount and rapid param changes.

`useFlaggedSubmissions` had a slightly different effect shape and needed doing by hand — worth noting since it's the one a bulk rewrite would silently skip.

## Also

Adds `getSpendRows` to the demo backend. It went missing when #104 merged after #105 changed the `StatsService` interface — `tsc` caught it, the Next build did **not**, which is a good argument for keeping the typecheck in the loop.

## Verification

`npm test` — 102 tests across 8 files, green. `tsc` clean with zero new errors. `eslint` on the hooks directory: same 4 pre-existing warnings as `main`, none introduced. `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)