### PR TITLE
fix: a re-submission can no longer lower an already-observed day (#83)

### DIFF
--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -210,16 +210,49 @@ export function mergeMachineContribution(
   existing: Record<string, MachineContribution> | null | undefined,
   machineId: string,
   incoming: MachineContribution
-): { contributions: Record<string, MachineContribution>; aggregate: DailyAggregate } {
+): {
+  contributions: Record<string, MachineContribution>;
+  aggregate: DailyAggregate;
+  /** True when a lower re-report was rejected in favour of the stored slice. */
+  retainedPrior: boolean;
+} {
   let contributions: Record<string, MachineContribution>;
+  let retainedPrior = false;
+
   if (machineId === DEFAULT_MACHINE_ID) {
     // No-id submission: unattributable, so it owns the whole day.
     contributions = { [DEFAULT_MACHINE_ID]: incoming };
   } else {
     const { [DEFAULT_MACHINE_ID]: _unattributed, ...idSlices } = existing ?? {};
-    contributions = { ...idSlices, [machineId]: incoming };
+    const prior = idSlices[machineId];
+
+    // High-water mark per (day, machine).
+    //
+    // Claude Code rewrites its own session JSONLs on resume/compact, so a
+    // later run can report *less* for a day that already happened. #83 has two
+    // independent confirmations: a month-to-date total falling 11% between
+    // submissions 16h apart while the file count rose, and 5 assistant
+    // messages vanishing from one transcript between scans. Replacing the
+    // slice unconditionally meant the board silently took the lower number
+    // and a user's total decayed through no fault of their own.
+    //
+    // A past day can only ever be under-reported by a rewrite, never
+    // over-reported by one, so keeping the larger observation is the accurate
+    // choice rather than a generous one. Today's day still grows normally,
+    // because a later run legitimately reports more and simply wins.
+    //
+    // Compared on cost and swapped whole rather than per-field: taking the max
+    // of each field independently would synthesise a slice that was never
+    // actually observed, with tokens from one run and cost from another.
+    if (prior && prior.totalCost > incoming.totalCost) {
+      contributions = { ...idSlices, [machineId]: prior };
+      retainedPrior = true;
+    } else {
+      contributions = { ...idSlices, [machineId]: incoming };
+    }
   }
-  return { contributions, aggregate: aggregateContributions(contributions) };
+
+  return { contributions, aggregate: aggregateContributions(contributions), retainedPrior };
 }
 
 export interface NormalizedCcData {

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -413,13 +413,20 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     // Build every row first, then write them in one request. This used to be a
     // round-trip per day, which put a multi-year history past the request
     // budget even though each individual write was fast (#93).
+    // Days where a re-report came in lower than what we already had, i.e.
+    // Claude Code rewrote its own transcript between runs (#83). Counted so
+    // the submission response can tell the user rather than silently keeping
+    // the higher number.
+    const driftedDays: string[] = [];
+
     const dailyRows = data.ccData.daily.map((day) => {
       const prior = dailyMap.get(day.date);
-      const { contributions, aggregate } = mergeMachineContribution(
+      const { contributions, aggregate, retainedPrior } = mergeMachineContribution(
         prior?.machine_contributions ?? null,
         machineId,
         dailyEntryToContribution(day)
       );
+      if (retainedPrior) driftedDays.push(day.date);
 
       const dailyData = {
         submission_id: existing.id,
@@ -514,6 +521,13 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     if (submissionUpdateError) {
       throw new Error(
         `Failed to update existing submission: ${submissionUpdateError.message}`
+      );
+    }
+
+    if (driftedDays.length > 0) {
+      console.warn(
+        `Usage drift for ${data.username}: ${driftedDays.length} day(s) re-reported lower than stored and kept at the earlier figure (#83).`,
+        driftedDays.slice(0, 10)
       );
     }
 

--- a/test/usage-drift.test.mts
+++ b/test/usage-drift.test.mts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+
+const { mergeMachineContribution, DEFAULT_MACHINE_ID } = await import("../src/lib/ccusage.ts");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+
+const slice = (cost: number, tokens = Math.round(cost * 1000)) => ({
+  inputTokens: Math.round(tokens * 0.2),
+  outputTokens: Math.round(tokens * 0.1),
+  cacheCreationTokens: 0,
+  cacheReadTokens: tokens - Math.round(tokens * 0.2) - Math.round(tokens * 0.1),
+  totalTokens: tokens,
+  totalCost: cost,
+  modelsUsed: ["claude-opus-4-8"],
+  agents: ["claude"],
+});
+
+// ---------------------------------------------------------------------------
+// #83 — Claude Code rewrites its own transcripts, so a re-report can be lower
+// ---------------------------------------------------------------------------
+
+{
+  // The reported case, scaled to one day: a second submission 16h later
+  // reports 11% less for a day that already happened.
+  const prior = { "machine-a": slice(17117) };
+  const { contributions, aggregate, retainedPrior } = mergeMachineContribution(
+    prior,
+    "machine-a",
+    slice(15226)
+  );
+
+  assert.equal(retainedPrior, true, "the drop must be reported, not silent");
+  assert.equal(contributions["machine-a"].totalCost, 17117, "the observed high stands");
+  assert.equal(aggregate.totalCost, 17117);
+  check("a drifted-lower re-report does not lower an already-observed day");
+}
+
+{
+  // Today's day still grows: a later run legitimately reports more.
+  const prior = { "machine-a": slice(100) };
+  const { contributions, aggregate, retainedPrior } = mergeMachineContribution(
+    prior,
+    "machine-a",
+    slice(250)
+  );
+
+  assert.equal(retainedPrior, false);
+  assert.equal(contributions["machine-a"].totalCost, 250, "a higher re-report wins");
+  assert.equal(aggregate.totalCost, 250);
+  check("a higher re-report still replaces the stored slice");
+}
+
+{
+  // Whole-slice swap, not per-field max: a synthesised record with tokens from
+  // one run and cost from another was never actually observed.
+  const prior = { "m": { ...slice(500), totalTokens: 1_000_000, outputTokens: 900_000 } };
+  const incoming = { ...slice(400), totalTokens: 9_000_000, outputTokens: 10 };
+  const { contributions } = mergeMachineContribution(prior, "m", incoming);
+
+  assert.equal(contributions["m"].totalCost, 500);
+  assert.equal(contributions["m"].totalTokens, 1_000_000, "tokens come from the kept slice");
+  assert.equal(contributions["m"].outputTokens, 900_000, "no field-wise Frankenstein record");
+  check("the winning slice is kept whole rather than merged field-by-field");
+}
+
+// ---------------------------------------------------------------------------
+// The high-water mark must not disturb multi-machine behaviour (#43)
+// ---------------------------------------------------------------------------
+
+{
+  // A different machine still adds its own slice; the guard is per-machine and
+  // must not make one machine's total suppress another's.
+  const prior = { "machine-a": slice(1000) };
+  const { contributions, aggregate, retainedPrior } = mergeMachineContribution(
+    prior,
+    "machine-b",
+    slice(10)
+  );
+
+  assert.equal(retainedPrior, false, "a new machine is not a drop");
+  assert.equal(contributions["machine-a"].totalCost, 1000);
+  assert.equal(contributions["machine-b"].totalCost, 10);
+  assert.equal(aggregate.totalCost, 1010, "machines still sum");
+  check("a lower slice from a different machine is still added, not suppressed");
+}
+
+{
+  // Unattributable submissions still own the whole day (#81) — a web upload or
+  // older CLI can't be high-water compared against an id'd slice.
+  const prior = { "machine-a": slice(9999) };
+  const { contributions, retainedPrior } = mergeMachineContribution(
+    prior,
+    DEFAULT_MACHINE_ID,
+    slice(5)
+  );
+
+  assert.deepEqual(Object.keys(contributions), [DEFAULT_MACHINE_ID]);
+  assert.equal(contributions[DEFAULT_MACHINE_ID].totalCost, 5);
+  assert.equal(retainedPrior, false, "replacing an unattributable day is not a drift signal");
+  check("unattributable submissions still replace the day (#81 preserved)");
+}
+
+{
+  // A legacy row with no per-machine map is not a prior observation.
+  for (const empty of [null, undefined, {}]) {
+    const { contributions, retainedPrior } = mergeMachineContribution(
+      empty as never,
+      "m",
+      slice(42)
+    );
+    assert.equal(contributions["m"].totalCost, 42);
+    assert.equal(retainedPrior, false);
+  }
+  check("legacy rows with no prior map are written normally");
+}
+
+{
+  // Equal cost is not a drop — re-submitting identical data must be a no-op
+  // rather than a drift warning.
+  const prior = { "m": slice(750) };
+  const { contributions, retainedPrior } = mergeMachineContribution(prior, "m", slice(750));
+  assert.equal(retainedPrior, false, "an identical re-submit is not drift");
+  assert.equal(contributions["m"].totalCost, 750);
+  check("an identical re-submit is not reported as drift");
+}
+
+console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
Closes the leaderboard half of #83.

## The bug

Claude Code rewrites its own session JSONLs on resume/compact, so `ccusage` can report **less** for a day that already happened. #83 carries two independent confirmations:

- @yoo-minho: a month-to-date total falling **11%** ($17,117 → $15,226) between submissions 16 hours apart — with the corpus *file count rising*, and the `ccusage` version ruled out by A/B-ing `20.0.18` and `20.0.19` on the same corpus
- @lizhuojunx86: **5 assistant messages** vanishing from a single transcript between two scans of the same file

viberank took the lower number. `mergeMachineContribution` replaced a machine's slice for a day unconditionally, so a user's stored total **decayed through no fault of their own** — and on a leaderboard that reads as the user losing ground, which is the part that matters.

## The fix

A high-water mark per `(day, machine)`.

A past day can only be *under*-reported by a rewrite, never over-reported by one, so keeping the larger observation is the **accurate** choice rather than a generous one. Today's day still grows normally: a later run legitimately reports more and simply wins.

The winning slice is compared on cost and swapped **whole**, not by taking the max of each field — that would synthesise a record that was never observed, with tokens from one run beside cost from another.

## Deliberately narrow

This is the kind of change that quietly breaks a neighbouring rule, so both are pinned by tests:

- **#43 multi-machine summing** — the guard is per-machine, so a lower slice from a *different* machine is still added rather than suppressed
- **#81 unattributable submissions** — still own the whole day; replacing one is not treated as a drift signal

Also tested: identical re-submits aren't reported as drift, legacy rows with no per-machine map write normally, and the whole-slice swap is asserted directly.

## What is *not* in here

The CLI emitting @yoo-minho's [six-field drift record](https://github.com/m1kapp/claude-rank/blob/main/docs/usage-drift-log.md). Without `corpus.files`/`bytes` viberank **cannot distinguish "the runtime rewrote it" from "the user deleted history"**, and only the first should be absorbed this way. Drifted days are counted and logged rather than fixed silently so the behaviour stays auditable in the meantime. I've written that up on the issue.

`npm test` — 109 tests across 9 files, green. `tsc` clean, no new `eslint` errors, `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)