### PR TITLE
feat: README badge at /api/badge/[username]

### DIFF
--- a/src/app/api/badge/[username]/route.ts
+++ b/src/app/api/badge/[username]/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerDataLayer } from "@/lib/data";
+import {
+  renderBadge,
+  badgeCost,
+  badgeTokens,
+  badgeLabelFor,
+  isBadgeMetric,
+} from "@/lib/badge";
+
+/**
+ * README badge: ![viberank](https://viberank.app/api/badge/<username>)
+ *
+ * Always answers 200 with an SVG, including for unknown users. A README that
+ * renders a broken-image icon because someone typo'd their handle is worse
+ * than one that renders "not found" — and GitHub's camo proxy caches a 404
+ * hard enough that fixing the typo doesn't visibly fix the badge.
+ */
+
+function svg(body: string, maxAge: number) {
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": "image/svg+xml; charset=utf-8",
+      // GitHub proxies through camo, which caches aggressively. An hour keeps
+      // a rank reasonably fresh without making every README view a database
+      // query, and stale-while-revalidate means nobody waits on the refresh.
+      "Cache-Control": `public, max-age=${maxAge}, s-maxage=${maxAge}, stale-while-revalidate=86400`,
+    },
+  });
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ username: string }> }
+) {
+  const { username: raw } = await params;
+  const username = decodeURIComponent(raw).slice(0, 64);
+
+  const metricParam = request.nextUrl.searchParams.get("metric");
+  const metric = isBadgeMetric(metricParam) ? metricParam : "rank";
+  const label = badgeLabelFor(metric);
+
+  try {
+    const dataLayer = await getServerDataLayer();
+    const profile = await dataLayer.profiles.getProfile(username, 1);
+
+    const best = profile?.submissions?.[0];
+    if (!profile || !best) {
+      return svg(renderBadge({ label, value: "not found", color: "#52525b" }), 300);
+    }
+
+    let value: string;
+    if (metric === "cost") {
+      value = badgeCost(best.totalCost);
+    } else if (metric === "tokens") {
+      value = badgeTokens(best.totalTokens);
+    } else {
+      const rank = await dataLayer.submissions.getGlobalRank(best.totalCost);
+      value = rank > 0 ? `#${rank.toLocaleString("en-US")}` : "unranked";
+    }
+
+    return svg(renderBadge({ label, value }), 3600);
+  } catch (error) {
+    console.error("Badge render failed:", error);
+    // Still an image, still 200 — a README must not show a broken image
+    // because our database had a bad minute. Short TTL so it self-heals.
+    return svg(renderBadge({ label, value: "unavailable", color: "#52525b" }), 60);
+  }
+}

--- a/src/app/profile/[username]/BadgeSnippet.tsx
+++ b/src/app/profile/[username]/BadgeSnippet.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+/**
+ * The badge is only useful if people find it, and nobody goes looking for an
+ * undocumented API route — so it lives on the profile it belongs to, as
+ * something you can paste straight into a README.
+ */
+export default function BadgeSnippet({ username }: { username: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handle = encodeURIComponent(username);
+  const markdown = `[![viberank](https://www.viberank.app/api/badge/${handle})](https://www.viberank.app/profile/${handle})`;
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(markdown);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="bg-surface-1 border border-border rounded-lg p-4">
+      <div className="flex items-center justify-between gap-3 mb-3">
+        <p className="micro-label">README badge</p>
+        <button
+          type="button"
+          onClick={copy}
+          className="flex items-center gap-1.5 text-xs px-2.5 py-1 rounded border border-border hover:border-accent hover:text-accent transition-colors"
+        >
+          {copied ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+          {copied ? "Copied" : "Copy markdown"}
+        </button>
+      </div>
+
+      {/* eslint-disable-next-line @next/next/no-img-element -- an SVG badge
+          from our own route; next/image would rasterise and proxy it. */}
+      <img
+        src={`/api/badge/${handle}`}
+        alt={`viberank rank for ${username}`}
+        width={140}
+        height={20}
+        className="mb-3"
+      />
+
+      <code className="block text-[11px] font-mono text-muted bg-background border border-border rounded px-3 py-2 overflow-x-auto whitespace-nowrap">
+        {markdown}
+      </code>
+
+      <p className="text-xs text-muted mt-2">
+        Also <code className="text-accent">?metric=cost</code> and{" "}
+        <code className="text-accent">?metric=tokens</code>.
+      </p>
+    </div>
+  );
+}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -22,6 +22,7 @@ import { computeStreaks } from "@/lib/streaks";
 import { getServerDataLayer } from "@/lib/data";
 import { getProfileCached } from "./getProfile";
 import UsageChart from "./UsageChartLazy";
+import BadgeSnippet from "./BadgeSnippet";
 import ActivityHeatmap from "@/components/ActivityHeatmap";
 import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
@@ -568,6 +569,9 @@ export default async function ProfilePage({ params }: ProfileParams) {
             )}
           </div>
         )}
+      </div>
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 pb-10">
+        <BadgeSnippet username={profileData.username} />
       </div>
       <Footer />
     </div>

--- a/src/lib/badge.ts
+++ b/src/lib/badge.ts
@@ -1,0 +1,107 @@
+/**
+ * Shields-style SVG badges for READMEs.
+ *
+ * Hand-built SVG rather than an ImageResponse: a badge is two rectangles and
+ * two strings, it needs to be a few hundred bytes and cacheable at the edge,
+ * and rasterising it would make it heavier and blurrier than the surrounding
+ * shields.io badges it will sit next to.
+ */
+
+export type BadgeMetric = "rank" | "cost" | "tokens";
+
+export const BADGE_METRICS: BadgeMetric[] = ["rank", "cost", "tokens"];
+
+export function isBadgeMetric(value: string | null): value is BadgeMetric {
+  return value !== null && (BADGE_METRICS as string[]).includes(value);
+}
+
+/**
+ * Approximate text width for the DejaVu/Verdana-ish stack shields uses.
+ *
+ * SVG cannot measure text, so the geometry has to be computed up front. Real
+ * per-character widths would be exact but need a font table; this stays within
+ * a couple of pixels across the digits and short words badges actually
+ * contain, which is the difference between snug and slightly roomy padding —
+ * not between readable and clipped.
+ */
+function textWidth(text: string): number {
+  let width = 0;
+  for (const char of text) {
+    if (/[iIl.,:;'|!]/.test(char)) width += 3.2;
+    else if (/[A-Z@#%&W]/.test(char)) width += 8.4;
+    else if (/[fjrt ]/.test(char)) width += 4.6;
+    else width += 7;
+  }
+  return Math.ceil(width);
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export interface BadgeInput {
+  label: string;
+  value: string;
+  /** Accent for the value half. */
+  color?: string;
+}
+
+export function renderBadge({ label, value, color = "#f97316" }: BadgeInput): string {
+  const safeLabel = escapeXml(label);
+  const safeValue = escapeXml(value);
+
+  const padding = 11;
+  const labelWidth = textWidth(label) + padding * 2;
+  const valueWidth = textWidth(value) + padding * 2;
+  const total = labelWidth + valueWidth;
+
+  // textLength pins each string to the width the geometry was computed from,
+  // so a viewer whose font metrics differ slightly still gets text centred in
+  // its half rather than drifting over the divider.
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" aria-label="${safeLabel}: ${safeValue}">
+  <title>${safeLabel}: ${safeValue}</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r"><rect width="${total}" height="20" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#1a1a1f"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="${color}"/>
+    <rect width="${total}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="14" fill="#010101" fill-opacity=".3" textLength="${labelWidth - padding * 2}">${safeLabel}</text>
+    <text x="${labelWidth / 2}" y="13" textLength="${labelWidth - padding * 2}">${safeLabel}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14" fill="#010101" fill-opacity=".3" textLength="${valueWidth - padding * 2}">${safeValue}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="13" textLength="${valueWidth - padding * 2}">${safeValue}</text>
+  </g>
+</svg>`;
+}
+
+/** Compact money for a badge: $1.2K, $205K, $1.4M. */
+export function badgeCost(cost: number): string {
+  const value = Number.isFinite(cost) && cost > 0 ? cost : 0;
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}K`;
+  return `$${Math.round(value)}`;
+}
+
+/** Compact tokens: 940M, 26.1B, 1.2T. */
+export function badgeTokens(tokens: number): string {
+  const value = Number.isFinite(tokens) && tokens > 0 ? tokens : 0;
+  if (value >= 1e12) return `${(value / 1e12).toFixed(1)}T`;
+  if (value >= 1e9) return `${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `${Math.round(value / 1e6)}M`;
+  if (value >= 1e3) return `${Math.round(value / 1e3)}K`;
+  return String(Math.round(value));
+}
+
+export function badgeLabelFor(metric: BadgeMetric): string {
+  return metric === "rank" ? "viberank" : metric === "cost" ? "ai spend" : "tokens";
+}

--- a/test/badge.test.mts
+++ b/test/badge.test.mts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+
+const { renderBadge, badgeCost, badgeTokens, isBadgeMetric, badgeLabelFor } =
+  await import("../src/lib/badge.ts");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+
+{
+  const svg = renderBadge({ label: "viberank", value: "#42" });
+  assert.match(svg, /^<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+  assert.match(svg, /<\/svg>$/);
+  assert.match(svg, /role="img"/);
+  assert.match(svg, /aria-label="viberank: #42"/, "screen readers need the value");
+  assert.ok(svg.length < 1500, `a badge should be small, got ${svg.length} bytes`);
+  check("renders a small, self-contained, labelled SVG");
+}
+
+{
+  // A badge is rendered from a URL path segment, so a username is untrusted
+  // input that ends up inside markup.
+  const svg = renderBadge({ label: 'a"><script>alert(1)</script>', value: "x" });
+  assert.ok(!svg.includes("<script>"), "must not emit a raw script tag");
+  assert.ok(!/(?<!&quot;)"><script/.test(svg), "must not break out of an attribute");
+  assert.ok(svg.includes("&lt;script&gt;"), "angle brackets are escaped");
+  assert.ok(svg.includes("&quot;"), "quotes are escaped");
+  check("escapes markup so a crafted username cannot inject");
+}
+
+{
+  const svg = renderBadge({ label: "&", value: "<>'\"" });
+  assert.ok(svg.includes("&amp;"));
+  assert.ok(svg.includes("&apos;"));
+  assert.ok(!/[<>]/.test(svg.split("<title>")[1].split("</title>")[0].replace(/&[a-z]+;/g, "")),
+    "title content carries no raw angle brackets");
+  check("all five XML entities are escaped");
+}
+
+{
+  // Wider text must produce a wider badge, or long values overflow the box.
+  const narrow = renderBadge({ label: "a", value: "1" });
+  const wide = renderBadge({ label: "viberank rank", value: "#1,234" });
+  const widthOf = (s: string) => Number(/width="(\d+)"/.exec(s)![1]);
+  assert.ok(widthOf(wide) > widthOf(narrow), "geometry tracks content length");
+  assert.ok(widthOf(narrow) >= 30, "even a tiny badge keeps its padding");
+  check("badge width grows with its content");
+}
+
+{
+  assert.equal(badgeCost(0), "$0");
+  assert.equal(badgeCost(950), "$950");
+  assert.equal(badgeCost(1_500), "$2K");
+  assert.equal(badgeCost(205_112), "$205K");
+  assert.equal(badgeCost(8_500_000), "$8.5M");
+  // Degenerate inputs must not reach a README as "$NaN".
+  for (const bad of [NaN, Infinity, -5]) assert.equal(badgeCost(bad), "$0", `bad: ${bad}`);
+  check("cost formatting is compact and never NaN");
+}
+
+{
+  assert.equal(badgeTokens(0), "0");
+  assert.equal(badgeTokens(940_000_000), "940M");
+  assert.equal(badgeTokens(26_100_000_000), "26.1B");
+  assert.equal(badgeTokens(9_200_000_000_000), "9.2T");
+  for (const bad of [NaN, Infinity, -1]) assert.equal(badgeTokens(bad), "0", `bad: ${bad}`);
+  check("token formatting is compact and never NaN");
+}
+
+{
+  assert.equal(isBadgeMetric("rank"), true);
+  assert.equal(isBadgeMetric("cost"), true);
+  assert.equal(isBadgeMetric("tokens"), true);
+  for (const bad of ["", "RANK", "spend", null]) {
+    assert.equal(isBadgeMetric(bad as string), false, `must reject ${bad}`);
+  }
+  check("only known metrics are accepted");
+}
+
+{
+  assert.equal(badgeLabelFor("rank"), "viberank");
+  assert.equal(badgeLabelFor("cost"), "ai spend");
+  assert.equal(badgeLabelFor("tokens"), "tokens");
+  check("each metric has a label");
+}
+
+console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
The acquisition half of the retention work. A rank badge someone puts in their own README is a persistent reminder to *them*, plus an impression and a backlink from everyone who reads their repo. [tokscale](https://github.com/junhoyeo/tokscale) ships one; tokenmaxxing doesn't.

Three metrics:

```markdown
[![viberank](https://www.viberank.app/api/badge/azamara)](https://www.viberank.app/profile/azamara)
```

| URL | Renders |
|---|---|
| `/api/badge/azamara` | `viberank` · **#1** |
| `/api/badge/azamara?metric=cost` | `ai spend` · **$205K** |
| `/api/badge/azamara?metric=tokens` | `tokens` · **263.1B** |

## Hand-built SVG, not an ImageResponse

A badge is two rectangles and two strings. It needs to be a few hundred bytes and cacheable at the edge, and rasterising it would make it heavier and blurrier than the shields.io badges it'll sit next to. ~900 bytes, `max-age=3600` with `stale-while-revalidate` so a README view is never blocked on a refresh.

## Always 200, even for unknown users

A README showing a **broken-image icon** because someone typo'd their handle is worse than one showing "not found" — and GitHub's camo proxy caches a 404 hard enough that fixing the typo doesn't visibly fix the badge. Database trouble degrades the same way with a 60s TTL so it self-heals.

## Escaping is tested, not assumed

Usernames arrive from a URL path and end up inside markup. All five XML entities are escaped, and the test asserts against an actual attribute-breakout attempt (`a"><script>…`) rather than just checking `<` became `&lt;`.

## Discoverability

Nobody goes looking for an undocumented API route, so the profile page carries the rendered badge plus copy-paste markdown with a copy button.

## Sequencing

Deliberately built **last** of the three. A badge on a rank nobody refreshes advertises a stale number — it only starts paying once `autosubmit` (#114) is adopted. I'd hold off promoting it until the CLI is published.

Verified against real data at all three metrics and the not-found path; rendered with `rsvg-convert` to confirm it looks right. `npm test` — 134 tests across 12 files. `tsc`, `eslint`, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)