### PR TITLE
fix: autosubmit baked an npx cache path into the scheduled job

### DIFF
--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -141,6 +141,13 @@ async function autosubmitCommand(arg) {
   const result = autosubmit.enable(hour ?? 9);
   console.log(chalk.green(`\n✓ Submitting daily at ${String(result.hour).padStart(2, '0')}:00 via ${result.scheduler}.`));
   console.log(chalk.gray(`  ${result.path}`));
+  if (!result.durable) {
+    // Scheduled through `npx -y` because this copy lives in npm's throwaway
+    // cache. Say so, rather than let someone wonder why a background job
+    // reaches the network.
+    console.log(chalk.gray('  Runs via npx, so it stays on the latest version.'));
+    console.log(chalk.gray('  For an offline-capable job: npm i -g viberank-cli, then re-run this.'));
+  }
   console.log(chalk.gray('  Turn it off with: npx viberank-cli autosubmit off\n'));
 }
 

--- a/packages/viberank-cli/lib/autosubmit.js
+++ b/packages/viberank-cli/lib/autosubmit.js
@@ -2,6 +2,7 @@ import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { CONFIG_DIR } from './config.js';
 
 /**
@@ -33,14 +34,38 @@ const plistPath = () =>
   path.join(os.homedir(), 'Library', 'LaunchAgents', `${LABEL}.plist`);
 const systemdDir = () => path.join(os.homedir(), '.config', 'systemd', 'user');
 
-/** Absolute node + CLI paths: a scheduler runs with a minimal PATH. */
+/**
+ * The argv a scheduler should run. Absolute, because a launchd or systemd job
+ * starts with a minimal PATH.
+ *
+ * The subtlety is *which* absolute path. `npx viberank-cli autosubmit` runs
+ * this file out of npm's `_npx` cache, which npm garbage-collects — baking
+ * that path into a plist produces a job that works today and silently stops
+ * firing weeks later, which is worse than not scheduling at all because
+ * nothing announces the failure.
+ *
+ * So: use the direct path only when this copy lives somewhere durable (a
+ * global install, or a project's own node_modules). Otherwise schedule
+ * `npx -y viberank-cli@latest`, which re-resolves on every run. That costs a
+ * registry round-trip once a day and keeps the job self-updating.
+ */
 function invocation() {
-  const cli = path.resolve(new URL('../cli.js', import.meta.url).pathname);
-  return { node: process.execPath, cli };
+  const cli = fileURLToPath(new URL('../cli.js', import.meta.url));
+  const ephemeral = cli.includes(`${path.sep}_npx${path.sep}`);
+
+  if (!ephemeral) return { argv: [process.execPath, cli], durable: true };
+
+  // Resolve npx next to the running node so the scheduler doesn't need PATH.
+  const npx = path.join(path.dirname(process.execPath), 'npx');
+  const runner = fs.existsSync(npx) ? npx : 'npx';
+  return { argv: [runner, '-y', 'viberank-cli@latest'], durable: false };
 }
 
 function plist(hour) {
-  const { node, cli } = invocation();
+  const { argv } = invocation();
+  const args = [...argv, 'submit', '--quiet']
+    .map((a) => `    <string>${a}</string>`)
+    .join('\n');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -48,10 +73,7 @@ function plist(hour) {
   <key>Label</key><string>${LABEL}</string>
   <key>ProgramArguments</key>
   <array>
-    <string>${node}</string>
-    <string>${cli}</string>
-    <string>submit</string>
-    <string>--quiet</string>
+${args}
   </array>
   <key>StartCalendarInterval</key>
   <dict><key>Hour</key><integer>${hour}</integer><key>Minute</key><integer>0</integer></dict>
@@ -66,14 +88,15 @@ function plist(hour) {
 }
 
 function systemdUnits(hour) {
-  const { node, cli } = invocation();
+  const { argv } = invocation();
+  const exec = [...argv, 'submit', '--quiet'].join(' ');
   return {
     service: `[Unit]
 Description=Submit AI coding usage to viberank
 
 [Service]
 Type=oneshot
-ExecStart=${node} ${cli} submit --quiet
+ExecStart=${exec}
 `,
     timer: `[Unit]
 Description=Daily viberank submission
@@ -103,7 +126,7 @@ export function enable(hour = 9) {
     // than failing with "already loaded".
     try { execFileSync('launchctl', ['unload', file], { stdio: 'ignore' }); } catch { /* not loaded */ }
     execFileSync('launchctl', ['load', file], { stdio: 'ignore' });
-    return { scheduler: 'launchd', path: file, hour };
+    return { scheduler: 'launchd', path: file, hour, durable: invocation().durable };
   }
 
   if (target === 'systemd') {
@@ -114,16 +137,17 @@ export function enable(hour = 9) {
     fs.writeFileSync(path.join(dir, 'viberank.timer'), units.timer);
     execFileSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'ignore' });
     execFileSync('systemctl', ['--user', 'enable', '--now', 'viberank.timer'], { stdio: 'ignore' });
-    return { scheduler: 'systemd', path: dir, hour };
+    return { scheduler: 'systemd', path: dir, hour, durable: invocation().durable };
   }
 
-  const { node, cli } = invocation();
+  const { argv } = invocation();
+  const tr = [...argv, 'submit', '--quiet'].map((a) => `"${a}"`).join(' ');
   execFileSync('schtasks', [
     '/Create', '/F', '/TN', 'viberank-autosubmit',
-    '/TR', `"${node}" "${cli}" submit --quiet`,
+    '/TR', tr,
     '/SC', 'DAILY', '/ST', `${String(hour).padStart(2, '0')}:00`,
   ], { stdio: 'ignore' });
-  return { scheduler: 'schtasks', path: 'viberank-autosubmit', hour };
+  return { scheduler: 'schtasks', path: 'viberank-autosubmit', hour, durable: invocation().durable };
 }
 
 export function disable() {

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,10 +1,14 @@
 {
   "name": "viberank-cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",
-  "files": ["cli.js", "lib/", "README.md"],
+  "files": [
+    "cli.js",
+    "lib/",
+    "README.md"
+  ],
   "bin": {
     "viberank": "./cli.js"
   },


### PR DESCRIPTION
Found by installing **1.3.0 from npm** and reading the plist it produced — not by testing the local checkout.

## The bug

The scheduler was handed the absolute path of whatever copy of `cli.js` happened to be running:

```
/Users/…/.npm/_npx/deadbeef/node_modules/viberank-cli/cli.js
```

For `npx viberank-cli autosubmit` — the invocation the site and README both recommend — that's npm's **`_npx` cache, which npm garbage-collects**.

So the job works the day you set it up, then silently stops firing. That's worse than never scheduling it: nothing announces the failure, and the user's rank quietly goes stale again — the exact problem autosubmit exists to solve.

## The fix

Use the direct path only when this copy lives somewhere **durable** (global install, or a project's `node_modules`). From an `_npx` path, schedule `npx -y viberank-cli@latest` instead, which re-resolves every run and keeps the job current.

The CLI now says which form it used, so a background job reaching the network is never a surprise, and points at `npm i -g viberank-cli` for anyone who wants it offline-capable.

## Verified both branches on macOS

| Install location | `ProgramArguments` |
|---|---|
| durable (`node_modules/`) | `/opt/homebrew/…/node` + absolute `cli.js` |
| `_npx` cache | `/opt/homebrew/…/npx` `-y` `viberank-cli@latest` |

`launchctl` loads both; `autosubmit off` removes the plist and unloads the job. Test artifacts cleaned off the machine — no plist, no launchd job, no token left behind.

**CLI 1.3.0 → 1.3.1 — needs republishing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)