### PR TITLE
feat: efficiency leaderboard, ranked by tokens per dollar

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Trophy, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2 } from "lucide-react";
+import { Trophy, DollarSign, Zap, Calendar, Share2, X, BadgeCheck, Loader2, Gauge } from "lucide-react";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -17,7 +17,7 @@ import { useLeaderboard, useLeaderboardByDateRange } from "@/lib/data/hooks/useS
 import { useGlobalStats } from "@/lib/data/hooks/useStats";
 import type { Submission, GlobalStats } from "@/lib/data/types";
 
-type SortBy = "cost" | "tokens";
+type SortBy = "cost" | "tokens" | "efficiency";
 
 interface LeaderboardProps {
   // Server-fetched first page + stats so the board renders in the SSR HTML.
@@ -78,7 +78,8 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   const [urlSynced, setUrlSynced] = useState(false);
   useEffect(() => {
     const p = new URLSearchParams(window.location.search);
-    if (p.get("sort") === "tokens") setSortBy("tokens");
+    const urlSort = p.get("sort");
+    if (urlSort === "tokens" || urlSort === "efficiency") setSortBy(urlSort);
     const urlTool = p.get("tool");
     if (urlTool) setTool(urlTool);
     if (p.get("verified") === "1") setVerifiedOnly(true);
@@ -90,12 +91,18 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
   }, []);
 
   useEffect(() => {
+    // Applying a date filter while on efficiency would otherwise leave the
+    // toggle lit over a cost-ranked board.
+    if (isDateFiltered && sortBy === "efficiency") setSortBy("cost");
+  }, [isDateFiltered, sortBy]);
+
+  useEffect(() => {
     // urlSynced is still false during the mount commit, which keeps this from
     // wiping the URL params before the parse above lands in state.
     if (!urlSynced) return;
     const p = new URLSearchParams(window.location.search);
     const write = (key: string, value: string) => (value ? p.set(key, value) : p.delete(key));
-    write("sort", sortBy === "tokens" ? "tokens" : "");
+    write("sort", sortBy === "cost" ? "" : sortBy);
     write("tool", tool ?? "");
     write("verified", verifiedOnly ? "1" : "");
     write("from", dateFrom);
@@ -133,7 +140,7 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
 
   const { data: dateFilteredResult } = useLeaderboardByDateRange(
     isDateFiltered
-      ? { dateFrom, dateTo, sortBy, limit: 100, tool: tool ?? undefined, verifiedOnly: verifiedOnly || undefined }
+      ? { dateFrom, dateTo, sortBy: sortBy === "efficiency" ? "cost" : sortBy, limit: 100, tool: tool ?? undefined, verifiedOnly: verifiedOnly || undefined }
       : "skip"
   );
 
@@ -290,6 +297,28 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
               <Zap className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">Tokens</span>
             </button>
+            <button
+              onClick={() => !isDateFiltered && setSortBy("efficiency")}
+              disabled={Boolean(isDateFiltered)}
+              title={
+                isDateFiltered
+                  // The date-range board aggregates daily rows and has no
+                  // stored ratio to order by, so offering the toggle here
+                  // would show a cost ranking under an efficiency label.
+                  ? "Efficiency ranks lifetime totals, so it doesn't combine with a date filter"
+                  : "Tokens per dollar, among developers who have spent at least $100"
+              }
+              className={`px-2.5 py-1 text-xs font-mono font-medium rounded flex items-center gap-1 transition-colors ${
+                sortBy === "efficiency"
+                  ? "bg-accent text-white"
+                  : isDateFiltered
+                    ? "text-muted/40 cursor-not-allowed"
+                    : "text-muted hover:text-foreground hover:bg-surface-2"
+              }`}
+            >
+              <Gauge className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">Efficiency</span>
+            </button>
           </div>
         </div>
 
@@ -376,6 +405,11 @@ export default function Leaderboard({ initialItems, initialStats, initialHasMore
                     <>
                       {formatNumber(s.totalTokens)}
                       <span className="text-muted text-[10px] font-normal"> tok</span>
+                    </>
+                  ) : sortBy === "efficiency" ? (
+                    <>
+                      {formatNumber(Math.round(s.totalTokens / Math.max(s.totalCost, 1)))}
+                      <span className="text-muted text-[10px] font-normal"> tok/$</span>
                     </>
                   ) : (
                     <>${formatNumber(s.totalCost)}</>

--- a/src/lib/data/demo/client.ts
+++ b/src/lib/data/demo/client.ts
@@ -250,7 +250,16 @@ const submissions: Submission[] = [
 
 const openToWork = new Set(["B-EtterDigital", "azamara", "dprvda"]);
 
-function sortSubmissions(items: Submission[], sortBy: "cost" | "tokens" = "cost") {
+function sortSubmissions(
+  items: Submission[],
+  sortBy: "cost" | "tokens" | "efficiency" = "cost"
+) {
+  if (sortBy === "efficiency") {
+    // Mirrors the real backend: spend floor first, then tokens per dollar.
+    return items
+      .filter((item) => item.totalCost >= 100)
+      .sort((a, b) => b.totalTokens / b.totalCost - a.totalTokens / a.totalCost);
+  }
   return [...items].sort((a, b) =>
     sortBy === "tokens" ? b.totalTokens - a.totalTokens : b.totalCost - a.totalCost
   );

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -191,6 +191,16 @@ function convertDbDailyBreakdown(db: DbDailyBreakdown): DailyBreakdown {
  * applied to its own query — a stable order is what makes paging correct, and
  * without one it is arbitrary which rows survive.
  */
+/**
+ * Minimum lifetime spend before a submission is ranked on tokens-per-dollar.
+ *
+ * Measured against the live board: unfiltered, the top of the efficiency
+ * ranking was a $0.01 submission at 7M tokens/$ against a median of 1.2M —
+ * the ratio of a rounding error, not a way of working. At $100 the ranking
+ * spans real usage ($112 to $11K of spend) and reads as a genuine second axis.
+ */
+export const EFFICIENCY_MIN_COST = 100;
+
 const PAGE_SIZE = 1000;
 const MAX_ROWS = 200_000;
 
@@ -671,9 +681,13 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     let query = this.client
       .from("submissions")
       .select("*", { count: "exact" })
-      .order(sortBy === "cost" ? "total_cost" : "total_tokens", {
-        ascending: false,
-      })
+      // Efficiency is ranked on the stored tokens_per_dollar column (011) with
+      // a spend floor. Without the floor the board is topped by rounding noise:
+      // a $0.01 submission scored 7M tokens/$ against a median of 1.2M.
+      .order(
+        sortBy === "cost" ? "total_cost" : sortBy === "efficiency" ? "tokens_per_dollar" : "total_tokens",
+        { ascending: false, nullsFirst: false }
+      )
       .range(offset, offset + pageSize - 1);
 
     if (!includeFlagged) {
@@ -687,6 +701,13 @@ export class SupabaseSubmissionsService implements SubmissionsService {
 
     if (params.verifiedOnly) {
       query = query.eq("verified", true);
+    }
+
+    // The spend floor is part of what the efficiency board *means*: below it
+    // the ratio is rounding noise rather than a signal about how someone
+    // works. Applied as a filter so the count and hasMore agree with the rows.
+    if (sortBy === "efficiency") {
+      query = query.gte("total_cost", EFFICIENCY_MIN_COST);
     }
 
     const { data: submissions, count, error } = await query;

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -96,7 +96,7 @@ export interface ProfileWithSubmissions extends Profile {
 // ============================================================================
 
 export interface LeaderboardParams {
-  sortBy?: "cost" | "tokens";
+  sortBy?: "cost" | "tokens" | "efficiency";
   page?: number;
   pageSize?: number;
   includeFlagged?: boolean;

--- a/supabase/migrations/011_efficiency.sql
+++ b/supabase/migrations/011_efficiency.sql
@@ -1,0 +1,25 @@
+-- Migration 011: tokens-per-dollar, for the efficiency leaderboard (#70).
+--
+-- Sorting has to happen in the database. Doing it in the browser over the ~25
+-- rows already fetched would rank "most efficient developer" among the top 25
+-- by *cost*, which is a different and much less interesting question — and it
+-- would silently disagree with the number of pages the board offers.
+--
+-- A generated column keeps the expression in one place and lets PostgREST
+-- order by it directly, since it can order by a column but not an arbitrary
+-- expression.
+--
+-- NULL rather than a sentinel for zero-cost rows: division by zero has no
+-- honest answer here, and NULLS LAST puts them at the bottom instead of
+-- letting a $0 submission with any tokens sit at #1 forever.
+ALTER TABLE submissions
+  ADD COLUMN IF NOT EXISTS tokens_per_dollar DOUBLE PRECISION
+  GENERATED ALWAYS AS (
+    CASE WHEN total_cost > 0 THEN total_tokens::DOUBLE PRECISION / total_cost ELSE NULL END
+  ) STORED;
+
+-- Partial index matching the query: the board only ever ranks rows above the
+-- spend floor, so indexing the rest is dead weight.
+CREATE INDEX IF NOT EXISTS idx_submissions_efficiency
+  ON submissions(tokens_per_dollar DESC NULLS LAST)
+  WHERE total_cost >= 100;


### PR DESCRIPTION
Lands the idea from #70 by @kevinfosterNG, reworked so the ranking is actually true.

## Why it needed reworking

That PR sorted **client-side over the ~25 rows already fetched**, which answers *"who is most efficient among the top 25 by cost"* — a different and much less interesting question. It also forced `hasMore` to `false` (so the board silently offered fewer pages than it had) and scored zero-cost submissions as `Infinity`, which would pin a $0 row at #1 permanently.

Ranking now happens **in the database** on a stored `tokens_per_dollar` column — `NULL` for zero cost, so division by zero has no answer rather than a wrong one — with a partial index matching the query.

## The spend floor is what makes it a metric

This came from looking at the data, not from theory. Unfiltered, the top of the efficiency board was:

| tok/$ | cost | user |
|---|---|---|
| 22,011,119 | **$28.89** | `psource /Users/pawelkiszczak/…/activate` |
| 8,791,586 | **$96.51** | structurebased |
| 7,070,202 | **$0.01** | aayushlovesfj |

Against a median of **1.2M tok/$**. Those are rounding errors, not ways of working.

Above $100 the ranking spans $112 to $11K of real spend (4.1M → 2.6M tok/$) and reads as a genuine second axis — which matters on a board whose #1 by cost is a $205K outlier.

## Date filters

Efficiency is **disabled** while a date filter is active rather than quietly falling back. The date-range board aggregates daily rows and has no stored ratio to order by, so offering the toggle there would show a cost ranking under an efficiency label. Selecting a date range while on efficiency drops back to cost, so the lit toggle never disagrees with the rows.

## Separate finding

That $28.89 row is a **username that's a shell fragment** — `psource /Users/pawelkiszczak/Projects/…/activate`. Someone's `git config user.name` picked up corrupted text and it's now a public leaderboard entry. Filing separately; not fixed here.

Verified against production through the **anon key the browser actually uses**: 1,030 eligible submissions, correctly ordered, noise excluded. Migration 011 applied. `npm test`, `tsc`, `eslint`, `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)