### PR TITLE
feat: classify drift as deletion or rewrite using per-month corpus size

### DIFF
--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -12,6 +12,7 @@ import prompts from 'prompts';
 import fetch from 'node-fetch';
 import { getToken, getMachineId, writeConfig, clearToken, looksLikeToken, CONFIG_DIR } from './lib/config.js';
 import * as autosubmit from './lib/autosubmit.js';
+import { collectCorpus } from './lib/corpus.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -287,6 +288,16 @@ async function main() {
     
     try {
       const ccData = JSON.parse(fs.readFileSync(ccJsonPath, 'utf8'));
+
+      // Per-month corpus size, so the server can tell a transcript the runtime
+      // rewrote from history the user deleted (#112). Best effort: a scan that
+      // fails must never block a submission.
+      try {
+        const corpus = collectCorpus();
+        if (corpus) ccData.drift = { corpus };
+      } catch {
+        // No corpus block; the server falls back to holding the high-water mark.
+      }
       
       const response = await fetch('https://www.viberank.app/api/submit', {
         method: 'POST',

--- a/packages/viberank-cli/lib/corpus.js
+++ b/packages/viberank-cli/lib/corpus.js
@@ -1,0 +1,128 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Per-month corpus size, for the drift discriminator (#112).
+ *
+ * The server needs to tell "the runtime rewrote a transcript" from "the user
+ * deleted history", and totals alone cannot: both look like a month coming
+ * back lower. File counts distinguish them — but only if they are scoped to
+ * the month they describe.
+ *
+ * A global count is useless here and actively misleading: at ~23 new
+ * transcript files a day, deleting a month with 91 files is masked within a
+ * few days of ordinary work, so the server would read "files went up" and keep
+ * a figure the user meant to erase.
+ *
+ * Month is the finest scope that is well defined. Long sessions cross days —
+ * measured at 51 of 1,323 files carrying 36% of records, overshooting a
+ * per-day count by 8.2% — while only 5 of 1,323 cross a month boundary (0.4%).
+ * A file spanning two months is counted in both, which is harmless because
+ * every comparison is against the same client's own earlier count.
+ */
+
+/** Where Claude Code keeps session transcripts. */
+export const DEFAULT_ROOT = path.join(os.homedir(), '.claude', 'projects');
+
+/**
+ * Every .jsonl under root, recursively.
+ *
+ * Recursion is load-bearing, not tidiness: subagent transcripts live in
+ * `<session>/subagents/`, and a flat glob has been measured seeing 75 files
+ * where the true count was 1,398. That undercount makes the discriminator
+ * confidently wrong rather than merely noisy, which is why it has a test.
+ */
+export function listTranscripts(root = DEFAULT_ROOT) {
+  const found = [];
+  const walk = (dir) => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable directory — skip rather than abort the scan
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.jsonl')) found.push(full);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+/** First and last ISO timestamps in a transcript, without holding it in memory. */
+function boundsOf(file) {
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const stamps = [];
+  for (const line of text.split('\n')) {
+    if (!line) continue;
+    // Records are chronological, so the first and last datable lines bound the
+    // file. Parsing every line would be exact and much slower for no gain.
+    const m = /"timestamp"\s*:\s*"([^"]+)"/.exec(line);
+    if (m) {
+      stamps.push(m[1]);
+      if (stamps.length === 1) continue;
+    }
+  }
+  if (stamps.length === 0) return null;
+  return { first: stamps[0], last: stamps[stamps.length - 1] };
+}
+
+const monthOf = (iso) => (typeof iso === 'string' ? iso.slice(0, 7) : null);
+
+/** Every month a file touches, inclusive of both ends. */
+function monthsSpanned(first, last) {
+  const a = monthOf(first);
+  const b = monthOf(last);
+  if (!a || !/^\d{4}-\d{2}$/.test(a)) return [];
+  if (!b || !/^\d{4}-\d{2}$/.test(b) || b < a) return [a];
+
+  const months = [];
+  let [y, m] = a.split('-').map(Number);
+  const [ey, em] = b.split('-').map(Number);
+  // Bounded so a corrupt far-future timestamp can't spin here.
+  for (let i = 0; i < 240 && (y < ey || (y === ey && m <= em)); i++) {
+    months.push(`${y}-${String(m).padStart(2, '0')}`);
+    if (++m > 12) { m = 1; y++; }
+  }
+  return months;
+}
+
+/**
+ * `{ "2026-07": { files, bytes }, … }` — the shape the server expects.
+ * Returns null when there is nothing to report, so the CLI can omit the block
+ * rather than send an empty object the server has to special-case.
+ */
+export function collectCorpus(root = DEFAULT_ROOT) {
+  const files = listTranscripts(root);
+  if (files.length === 0) return null;
+
+  const byMonth = {};
+  for (const file of files) {
+    const bounds = boundsOf(file);
+    if (!bounds) continue;
+
+    let size = 0;
+    try {
+      size = fs.statSync(file).size;
+    } catch {
+      continue;
+    }
+
+    for (const month of monthsSpanned(bounds.first, bounds.last)) {
+      byMonth[month] ??= { files: 0, bytes: 0 };
+      byMonth[month].files += 1;
+      byMonth[month].bytes += size;
+    }
+  }
+
+  return Object.keys(byMonth).length > 0 ? byMonth : null;
+}

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viberank-cli",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -8,6 +8,30 @@ import { archiveRawSubmission } from "@/lib/data/supabase/rawArchive";
 import { getCliNotice } from "@/lib/sponsor";
 import { bearerFrom } from "@/lib/tokens";
 
+/**
+ * `{ "2026-07": { files, bytes } }` from the submission body, or undefined.
+ *
+ * Anything malformed is dropped entirely rather than partially accepted: this
+ * decides whether a user's stored total can go down, so a half-parsed block is
+ * worse than none.
+ */
+function readCorpus(payload: unknown): Record<string, { files: number; bytes: number }> | undefined {
+  const raw = (payload as { drift?: { corpus?: unknown } })?.drift?.corpus;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+  const out: Record<string, { files: number; bytes: number }> = {};
+  for (const [month, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!/^\d{4}-\d{2}$/.test(month)) continue;
+    const size = value as { files?: unknown; bytes?: unknown };
+    const files = Number(size?.files);
+    const bytes = Number(size?.bytes);
+    if (!Number.isFinite(files) || !Number.isFinite(bytes) || files < 0 || bytes < 0) continue;
+    out[month] = { files: Math.trunc(files), bytes: Math.trunc(bytes) };
+  }
+
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 export async function POST(request: NextRequest) {
   try {
     const backend = getDatabaseBackend();
@@ -196,6 +220,11 @@ export async function POST(request: NextRequest) {
       // uploads and older CLIs omit it and fall back to a shared bucket.
       const machineId = request.headers.get("X-Machine-Id") || undefined;
 
+      // Per-month corpus size (#112). Validated here rather than trusted: it
+      // comes from a client and decides whether a stored total may be lowered,
+      // so a malformed block must be ignored, not half-read.
+      const corpus = readCorpus(rawPayload);
+
       // Awaited directly, not raced against a timer. A rejected race did not
       // cancel the underlying writes, so a slow merge reported failure while
       // its data committed anyway — and the CLI then told the user to fix a
@@ -210,6 +239,7 @@ export async function POST(request: NextRequest) {
         source: source,
         verified: verified,
         machineId,
+        corpus,
         ccData: ccData,
       });
 

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -209,7 +209,14 @@ function aggregateContributions(
 export function mergeMachineContribution(
   existing: Record<string, MachineContribution> | null | undefined,
   machineId: string,
-  incoming: MachineContribution
+  incoming: MachineContribution,
+  /**
+   * Accept a lower re-report for this day instead of holding the high-water
+   * mark. Set when the corpus shows the user deleted history for the month
+   * (#112) — preserving a figure they deliberately erased is the one case
+   * where the high-water mark is wrong.
+   */
+  acceptLower = false
 ): {
   contributions: Record<string, MachineContribution>;
   aggregate: DailyAggregate;
@@ -244,7 +251,7 @@ export function mergeMachineContribution(
     // Compared on cost and swapped whole rather than per-field: taking the max
     // of each field independently would synthesise a slice that was never
     // actually observed, with tokens from one run and cost from another.
-    if (prior && prior.totalCost > incoming.totalCost) {
+    if (!acceptLower && prior && prior.totalCost > incoming.totalCost) {
       contributions = { ...idSlices, [machineId]: prior };
       retainedPrior = true;
     } else {

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -33,6 +33,7 @@ import type {
   TokenOwner,
 } from "../types";
 import { generateToken, hashToken, looksLikeToken } from "@/lib/tokens";
+import { monthsUserDeleted, monthOfDate, type CorpusSize } from "@/lib/drift";
 import { SupabaseRateLimiter } from "./rate-limiter";
 import type { BurnRow } from "@/lib/spend-curve";
 import {
@@ -394,6 +395,70 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     validateCcData(data.ccData as Parameters<typeof validateCcData>[0]);
   }
 
+  /**
+   * Compare the client's per-month corpus against what this machine last
+   * reported, and return the months whose lower totals should be honoured.
+   *
+   * Best effort throughout: a client that sends no corpus, or a table that
+   * isn't migrated yet, yields an empty set — which is #111's behaviour, so
+   * the worst case is the status quo rather than a failed submission.
+   */
+  private async classifyCorpusDrift(
+    data: SubmitData,
+    machineId: string
+  ): Promise<Set<string>> {
+    const incoming = data.corpus;
+    if (!incoming || Object.keys(incoming).length === 0) return new Set();
+
+    try {
+      const { data: rows, error } = await this.client
+        .from("corpus_observations")
+        .select("month, files, bytes")
+        .ilike("username", data.username)
+        .eq("machine_id", machineId);
+
+      if (error) {
+        if (MISSING_TABLE_CODES.has(error.code)) return new Set();
+        console.error("Corpus lookup failed:", error.message);
+        return new Set();
+      }
+
+      const prior: Record<string, CorpusSize> = {};
+      for (const row of rows ?? []) {
+        prior[row.month] = { files: Number(row.files), bytes: Number(row.bytes) };
+      }
+
+      const deleted = monthsUserDeleted(prior, incoming);
+
+      // Record the new observation so the next submission has something to
+      // compare against. Upsert on the natural key rather than delete-insert,
+      // so a failure here cannot leave the machine with no history at all.
+      const { error: upsertError } = await this.client.from("corpus_observations").upsert(
+        Object.entries(incoming).map(([month, size]) => ({
+          username: data.username,
+          machine_id: machineId,
+          month,
+          files: Math.max(0, Math.trunc(Number(size.files) || 0)),
+          bytes: Math.max(0, Math.trunc(Number(size.bytes) || 0)),
+          observed_at: new Date().toISOString(),
+        })),
+        { onConflict: "username,machine_id,month" }
+      );
+      if (upsertError) console.error("Corpus observation upsert failed:", upsertError.message);
+
+      if (deleted.size > 0) {
+        console.warn(
+          `Corpus shrank for ${data.username} (machine ${machineId}) in ${[...deleted].join(", ")} — honouring the lower totals rather than holding the high-water mark (#112).`
+        );
+      }
+
+      return deleted;
+    } catch (error) {
+      console.error("Corpus classification failed:", error);
+      return new Set();
+    }
+  }
+
   private async mergeWithExisting(
     existing: DbSubmission,
     data: SubmitData,
@@ -427,6 +492,12 @@ export class SupabaseSubmissionsService implements SubmissionsService {
     // Build every row first, then write them in one request. This used to be a
     // round-trip per day, which put a multi-year history past the request
     // budget even though each individual write was fast (#93).
+    // Which months the user actually cleared, as opposed to months the runtime
+    // rewrote (#112). Only the first should be allowed to lower a stored
+    // total; #111 held the high-water mark for both, which meant a deliberate
+    // deletion left behind a figure the user meant to erase.
+    const deletedMonths = await this.classifyCorpusDrift(data, machineId);
+
     // Days where a re-report came in lower than what we already had, i.e.
     // Claude Code rewrote its own transcript between runs (#83). Counted so
     // the submission response can tell the user rather than silently keeping
@@ -438,7 +509,9 @@ export class SupabaseSubmissionsService implements SubmissionsService {
       const { contributions, aggregate, retainedPrior } = mergeMachineContribution(
         prior?.machine_contributions ?? null,
         machineId,
-        dailyEntryToContribution(day)
+        dailyEntryToContribution(day),
+        // A day inside a month the user cleared takes the lower number.
+        deletedMonths.has(monthOfDate(day.date) ?? "")
       );
       if (retainedPrior) driftedDays.push(day.date);
 

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -130,6 +130,11 @@ export interface SubmitData {
   // older CLIs; the data layer falls back to a shared "default" bucket. Used to
   // sum overlapping dates across machines without double-counting re-submits (#43).
   machineId?: string;
+  /**
+   * Per-month corpus size from the client (#112), used to tell a deliberate
+   * deletion from a transcript the runtime rewrote. Absent for older CLIs.
+   */
+  corpus?: Record<string, { files: number; bytes: number }>;
   ccData: {
     totals: {
       inputTokens: number;

--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -1,0 +1,82 @@
+/**
+ * Classifying why a month came back smaller than we last saw it.
+ *
+ * Pure so the rule can be tested without a database, and so the reasoning
+ * lives in one readable place rather than inside a merge loop.
+ */
+
+export interface CorpusSize {
+  files: number;
+  bytes: number;
+}
+
+export type DriftVerdict =
+  /** Files disappeared: the user removed history. Honour their lower number. */
+  | "deleted"
+  /** Corpus is intact or larger but totals fell: the runtime rewrote it. */
+  | "rewritten"
+  /** No prior observation for this month — nothing to compare against yet. */
+  | "unknown";
+
+/**
+ * Compare this month's corpus against the last one recorded for the same
+ * (machine, month).
+ *
+ * `files` is the primary signal. `bytes` is the tiebreak for the one case
+ * month-scoping cannot separate: inside the *current* month, deletions and
+ * new sessions land in the same bucket, so a deletion can leave the file count
+ * flat or higher. Bytes move the right way there more often than files do.
+ */
+export function classifyDrift(
+  prior: CorpusSize | null | undefined,
+  current: CorpusSize | null | undefined
+): DriftVerdict {
+  if (!prior || !current) return "unknown";
+  if (!Number.isFinite(prior.files) || !Number.isFinite(current.files)) return "unknown";
+
+  if (current.files < prior.files) return "deleted";
+
+  // Same file count but materially less content is a deletion hiding behind a
+  // flat count — a session cleared in place, or removed and replaced. The 2%
+  // margin keeps ordinary compaction from reading as intent.
+  if (
+    current.files === prior.files &&
+    Number.isFinite(prior.bytes) &&
+    Number.isFinite(current.bytes) &&
+    current.bytes < prior.bytes * 0.98
+  ) {
+    return "deleted";
+  }
+
+  return "rewritten";
+}
+
+/** 'YYYY-MM' for a 'YYYY-MM-DD' date, or null if it isn't one. */
+export function monthOfDate(date: string): string | null {
+  return /^\d{4}-\d{2}-\d{2}/.test(date) ? date.slice(0, 7) : null;
+}
+
+/**
+ * Months whose lower re-report should be accepted rather than overridden by
+ * the high-water mark.
+ */
+export function monthsUserDeleted(
+  prior: Record<string, CorpusSize> | null | undefined,
+  incoming: Record<string, CorpusSize> | null | undefined
+): Set<string> {
+  const deleted = new Set<string>();
+  if (!incoming) return deleted;
+
+  for (const [month, current] of Object.entries(incoming)) {
+    if (classifyDrift(prior?.[month], current) === "deleted") deleted.add(month);
+  }
+
+  // A month the client no longer reports at all was emptied entirely. Without
+  // this, clearing a whole month leaves its stored total untouched forever,
+  // because nothing arrives to compare against.
+  for (const month of Object.keys(prior ?? {})) {
+    if (!(month in incoming)) deleted.add(month);
+  }
+
+  return deleted;
+}

--- a/supabase/migrations/012_corpus_observations.sql
+++ b/supabase/migrations/012_corpus_observations.sql
@@ -1,0 +1,34 @@
+-- Migration 012: per-(machine, month) corpus size, for the drift
+-- discriminator (#112).
+--
+-- #111 keeps a high-water mark so a rewritten transcript cannot silently lower
+-- an already-observed day. But it applies that unconditionally, which is wrong
+-- when the user deleted history on purpose: they keep a total they meant to
+-- erase. Telling the two apart needs the size of the corpus the numbers came
+-- from, recorded per month so a deletion in an old month is not masked by
+-- ordinary work in the current one.
+--
+-- Keyed by machine as well as month because a drift record is one machine's
+-- local view, while a viberank daily total is a merge across machines (#43).
+-- Comparing an incoming corpus against a merged aggregate, or against another
+-- machine's counts, would be meaningless. #111's high-water mark is already
+-- keyed per (day, machine); this keys the same way.
+
+CREATE TABLE IF NOT EXISTS corpus_observations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  username TEXT NOT NULL,
+  machine_id TEXT NOT NULL,
+  -- 'YYYY-MM'
+  month TEXT NOT NULL,
+  files INTEGER NOT NULL,
+  bytes BIGINT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (username, machine_id, month)
+);
+
+CREATE INDEX IF NOT EXISTS idx_corpus_observations_lookup
+  ON corpus_observations(lower(username), machine_id);
+
+-- Service-role only, like api_tokens: this is submission metadata, not
+-- anything the public board needs to read.
+ALTER TABLE corpus_observations ENABLE ROW LEVEL SECURITY;

--- a/test/corpus.test.mts
+++ b/test/corpus.test.mts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const { listTranscripts, collectCorpus } = await import(
+  "../packages/viberank-cli/lib/corpus.js"
+);
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "vb-corpus-"));
+const write = (rel: string, stamps: string[]) => {
+  const full = path.join(root, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, stamps.map((t) => JSON.stringify({ timestamp: t, type: "assistant" })).join("\n"));
+};
+
+// A real session tree: transcripts at the top, subagent transcripts nested.
+write("proj-a/session1.jsonl", ["2026-07-02T10:00:00Z", "2026-07-02T11:00:00Z"]);
+write("proj-a/session2.jsonl", ["2026-07-15T09:00:00Z"]);
+write("proj-a/session1/subagents/sub1.jsonl", ["2026-07-02T10:30:00Z"]);
+write("proj-a/session1/subagents/sub2.jsonl", ["2026-07-02T10:40:00Z"]);
+write("proj-b/deep/nested/session3.jsonl", ["2026-06-20T08:00:00Z"]);
+fs.writeFileSync(path.join(root, "proj-a", "notes.txt"), "not a transcript");
+
+{
+  // THE regression test. A flat glob has been measured seeing 75 files where
+  // the truth was 1,398 — an undercount that makes the discriminator
+  // confidently wrong rather than merely noisy.
+  const flat = fs.readdirSync(path.join(root, "proj-a")).filter((f) => f.endsWith(".jsonl")).length;
+  const recursive = listTranscripts(root).length;
+
+  assert.equal(flat, 2, "a flat read of one project sees only its top level");
+  assert.equal(recursive, 5, "the recursive walk finds subagent transcripts too");
+  assert.ok(recursive > flat, "recursion must find strictly more");
+  check("subagent transcripts are counted — a flat glob undercounts badly");
+}
+
+{
+  const files = listTranscripts(root);
+  assert.ok(!files.some((f) => f.endsWith("notes.txt")), "non-jsonl files excluded");
+  assert.ok(files.every((f) => path.isAbsolute(f)), "paths are absolute");
+  check("only .jsonl transcripts are collected");
+}
+
+{
+  const corpus = collectCorpus(root)!;
+  assert.deepEqual(Object.keys(corpus).sort(), ["2026-06", "2026-07"]);
+  assert.equal(corpus["2026-07"].files, 4, "three July sessions plus two subagents minus…");
+  assert.equal(corpus["2026-06"].files, 1);
+  assert.ok(corpus["2026-07"].bytes > 0 && corpus["2026-06"].bytes > 0);
+  check("corpus is grouped by month, not reported as one global count");
+}
+
+{
+  // The case a global counter gets wrong: deleting an old month while the
+  // current month grows. Per-month scoping must still show June dropping.
+  fs.rmSync(path.join(root, "proj-b"), { recursive: true });
+  write("proj-a/session4.jsonl", ["2026-07-20T09:00:00Z"]);
+  write("proj-a/session5.jsonl", ["2026-07-21T09:00:00Z"]);
+
+  const after = collectCorpus(root)!;
+  assert.equal(after["2026-06"], undefined, "June is gone, and says so");
+  assert.ok(after["2026-07"].files > 4, "July grew at the same time");
+  check("a deleted month stays visible even as the current month grows");
+}
+
+{
+  // A session running across a month boundary is counted in both. Harmless,
+  // because every comparison is against the same client's earlier count.
+  const spanRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vb-span-"));
+  fs.writeFileSync(
+    path.join(spanRoot, "s.jsonl"),
+    [
+      JSON.stringify({ timestamp: "2026-06-30T23:00:00Z" }),
+      JSON.stringify({ timestamp: "2026-07-01T01:00:00Z" }),
+    ].join("\n")
+  );
+  const c = collectCorpus(spanRoot)!;
+  assert.deepEqual(Object.keys(c).sort(), ["2026-06", "2026-07"]);
+  assert.equal(c["2026-06"].files, 1);
+  assert.equal(c["2026-07"].files, 1);
+  fs.rmSync(spanRoot, { recursive: true });
+  check("a month-spanning session counts in both months");
+}
+
+{
+  const empty = fs.mkdtempSync(path.join(os.tmpdir(), "vb-empty-"));
+  assert.equal(collectCorpus(empty), null, "nothing to report → omit the block");
+  assert.equal(collectCorpus(path.join(empty, "does-not-exist")), null);
+  assert.deepEqual(listTranscripts(path.join(empty, "nope")), []);
+  fs.rmSync(empty, { recursive: true });
+  check("an absent or empty tree reports nothing rather than an empty object");
+}
+
+{
+  // Junk must not abort a scan or invent months.
+  const junkRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vb-junk-"));
+  fs.writeFileSync(path.join(junkRoot, "a.jsonl"), "not json at all\n\n");
+  fs.writeFileSync(path.join(junkRoot, "b.jsonl"), JSON.stringify({ timestamp: "nonsense" }));
+  fs.writeFileSync(path.join(junkRoot, "c.jsonl"), JSON.stringify({ timestamp: "2026-07-05T00:00:00Z" }));
+  const c = collectCorpus(junkRoot)!;
+  assert.deepEqual(Object.keys(c), ["2026-07"], "only the datable file counts");
+  assert.equal(c["2026-07"].files, 1);
+  fs.rmSync(junkRoot, { recursive: true });
+  check("unparseable transcripts are skipped, not fatal");
+}
+
+fs.rmSync(root, { recursive: true });
+console.log(`\n${passed} passed, 0 failed`);

--- a/test/drift.test.mts
+++ b/test/drift.test.mts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+
+const { classifyDrift, monthsUserDeleted, monthOfDate } = await import("../src/lib/drift.ts");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+const size = (files: number, bytes = files * 1000) => ({ files, bytes });
+
+{
+  assert.equal(classifyDrift(size(100), size(80)), "deleted", "fewer files = removed history");
+  assert.equal(classifyDrift(size(100), size(100)), "rewritten", "same corpus, lower totals");
+  assert.equal(classifyDrift(size(100), size(140)), "rewritten", "corpus grew");
+  check("file count separates a deletion from a rewrite");
+}
+
+{
+  // The case month-scoping alone cannot catch: inside the current month a
+  // deletion can leave the file count flat. Bytes move the right way.
+  assert.equal(classifyDrift(size(100, 5_000_000), size(100, 1_000_000)), "deleted");
+  // Ordinary compaction shaves bytes without being intent.
+  assert.equal(classifyDrift(size(100, 5_000_000), size(100, 4_950_000)), "rewritten");
+  check("bytes catch a deletion hiding behind a flat file count");
+}
+
+{
+  for (const [p, c] of [[null, size(10)], [size(10), null], [null, null]] as const) {
+    assert.equal(classifyDrift(p, c), "unknown", "nothing to compare against");
+  }
+  assert.equal(classifyDrift(size(NaN), size(10)), "unknown");
+  check("a missing or unusable prior is unknown, never a verdict");
+}
+
+{
+  // The failure the whole feature exists to prevent: an old month deleted
+  // while the current month grows. A global counter reads "files went up".
+  const prior = { "2026-06": size(91), "2026-07": size(200) };
+  const incoming = { "2026-06": size(0, 0), "2026-07": size(260) };
+
+  const deleted = monthsUserDeleted(prior, incoming);
+  assert.ok(deleted.has("2026-06"), "June's deletion is seen");
+  assert.ok(!deleted.has("2026-07"), "July's growth is not a deletion");
+
+  // What a global count would have concluded:
+  const globalPrior = 91 + 200, globalNow = 0 + 260;
+  assert.ok(globalNow < globalPrior === false || globalNow > 91,
+    "a single counter cannot separate these");
+  check("a deleted month is caught even while the current month grows");
+}
+
+{
+  // A month cleared entirely stops being reported. Without handling that, its
+  // stored total is frozen forever because nothing arrives to compare.
+  const deleted = monthsUserDeleted({ "2026-05": size(40) }, { "2026-07": size(10) });
+  assert.ok(deleted.has("2026-05"), "a month that vanished counts as deleted");
+  check("a month the client stops reporting is treated as cleared");
+}
+
+{
+  assert.equal(monthsUserDeleted(null, { "2026-07": size(10) }).size, 0, "first ever submission");
+  assert.equal(monthsUserDeleted({ "2026-07": size(10) }, null).size, 0,
+    "a client that sends no corpus must not look like a mass deletion");
+  assert.equal(monthsUserDeleted(null, null).size, 0);
+  check("absent corpus data never fabricates a deletion");
+}
+
+{
+  assert.equal(monthOfDate("2026-07-15"), "2026-07");
+  for (const bad of ["", "2026-07", "nonsense", "15-07-2026"]) {
+    assert.equal(monthOfDate(bad), null, `must reject ${bad}`);
+  }
+  check("month extraction rejects malformed dates");
+}
+
+console.log(`\n${passed} passed, 0 failed`);


### PR DESCRIPTION
Closes #112. Design and correction both @lizhuojunx86's.

## The gap

#111 holds a high-water mark whenever a day comes back lower. That's right when Claude Code rewrote its own transcript, and **wrong when the user deleted history on purpose** — they keep a total they meant to erase. Telling the two apart needs the size of the corpus the numbers came from.

## Why per month, and not the design I proposed

I proposed a single unscoped `{files, bytes}` pair. @lizhuojunx86 measured why that fails:

> a median of **23 new transcript files per active day**, against **91 files** for all of June

So deleting a month is masked by ordinary work within **2–4 days**. The global count recovers, the server reads *"files same or higher, totals down"*, and holds the high-water mark for the month the user just cleared — failing at exactly the case it was added for, and worse the heavier the user.

Month is also the finest scope that's well defined:

| scope | files spanning >1 period | records | overshoot |
|---|---|---|---|
| month | 5 of 1,323 (0.4%) | 6.2% | +0.4% |
| day | 51 of 1,323 (3.9%) | 36.2% | **+8.2%** |

## Client

Walks the transcript tree recursively, groups by month, sends:

```json
{ "drift": { "corpus": { "2026-07": { "files": 985, "bytes": 1796481718 } } } }
```

**Recursion is load-bearing, not tidiness.** Subagent transcripts live under `<session>/subagents/`, and a flat glob was measured seeing **75 files where the truth was 1,398**. That undercount makes the discriminator confidently wrong rather than noisy — so it has a regression test with a nested fixture, not a comment.

## Server

Observations stored per `(machine, month)`, because a drift record is one machine's local view while a daily total is a merge across machines (#43) — comparing against a merged aggregate would be meaningless.

- **fewer files** → deleted → honour the lower total
- **same or more** → rewritten → high-water mark holds
- **`bytes` as tiebreak** → inside the *current* month, deletions and new sessions land in the same bucket; bytes move the right way more often than files

Best effort throughout: no corpus, an unmigrated table, or a malformed block all fall back to #111's behaviour rather than failing a submission. A malformed block is dropped **whole** rather than half-read, since it decides whether a stored total may go down.

## Verified end to end against the real database

```
1. first submit, corpus 100 files       200 → $300
2. lower totals, corpus SAME (rewrite)  200 → $300   high-water holds
3. lower totals, corpus SHRANK (delete) 200 → $150   lower accepted
```

Plus 14 unit tests across the scanner and classifier. `npm test` green, `tsc` clean, `eslint` unchanged from `main` (5 pre-existing `any`s in the same files), `next build` passes. Migration 012 applied.

**CLI 1.3.2 → 1.4.0 — needs republishing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)