### PR TITLE
fix: a Codex month is not a deleted Claude month

### DIFF
--- a/packages/viberank-cli/lib/corpus.js
+++ b/packages/viberank-cli/lib/corpus.js
@@ -115,8 +115,23 @@ function boundsOf(file) {
     const tailLen = Math.min(size, EDGE_BYTES);
     const tail = Buffer.allocUnsafe(tailLen);
     fs.readSync(fd, tail, 0, tailLen, size - tailLen);
-    // A stamp split across the boundary simply is not matched here; the head's
-    // value still bounds the file, so the month is right either way.
+    // The two ends are deliberately not treated alike, and the asymmetry is
+    // the first thing a reader notices here, so: the head falls back to a full
+    // scan when it finds no stamp, the tail falls back to `first`.
+    //
+    // The head fallback exists because a missing first stamp drops the file
+    // from the corpus entirely — a real undercount, measured at 17 of 922 files
+    // on one tree and 10 of 1,509 on another. A missing *last* stamp cannot
+    // drop anything; it can only collapse a file's span to the month the head
+    // already put it in. That is a narrowing, not a disappearance.
+    //
+    // It also appears not to happen. Two independent trees were searched for a
+    // file whose final 64 KB contains no timestamp, or whose tail window yields
+    // a different month than a full read: zero cases in either. Records are
+    // appended chronologically and every record carries a stamp, so the last
+    // 64 KB would have to be one unterminated write to qualify.
+    //
+    // If that ever shows up, the fix is the same fallback the head uses.
     const last = lastStamp(tail.toString('utf8')) ?? first;
 
     return { first, last };

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -33,7 +33,7 @@ import type {
   TokenOwner,
 } from "../types";
 import { generateToken, hashToken, looksLikeToken } from "@/lib/tokens";
-import { monthsUserDeleted, monthOfDate, type CorpusSize } from "@/lib/drift";
+import { monthsUserDeleted, monthOfDate, corpusCoversDay, type CorpusSize } from "@/lib/drift";
 import { SupabaseRateLimiter } from "./rate-limiter";
 import type { BurnRow } from "@/lib/spend-curve";
 import {
@@ -510,8 +510,12 @@ export class SupabaseSubmissionsService implements SubmissionsService {
         prior?.machine_contributions ?? null,
         machineId,
         dailyEntryToContribution(day),
-        // A day inside a month the user cleared takes the lower number.
-        deletedMonths.has(monthOfDate(day.date) ?? "")
+        // A day inside a month the user cleared takes the lower number — but
+        // only if the corpus is evidence about that day. The scan covers
+        // ~/.claude/projects alone, so a Codex or Gemini day in the same month
+        // keeps its high-water mark regardless of what happened to Claude's
+        // transcripts.
+        deletedMonths.has(monthOfDate(day.date) ?? "") && corpusCoversDay(day.agents)
       );
       if (retainedPrior) driftedDays.push(day.date);
 

--- a/src/lib/drift.ts
+++ b/src/lib/drift.ts
@@ -51,6 +51,33 @@ export function classifyDrift(
   return "rewritten";
 }
 
+/**
+ * The one tool the corpus is evidence about.
+ *
+ * `collectCorpus` walks ~/.claude/projects and nothing else, so a file count
+ * says something about Claude Code and nothing whatsoever about Codex, Gemini,
+ * Copilot or OpenCode — all of which reach viberank through the same ccusage
+ * payload.
+ */
+export const CORPUS_AGENT = "claude";
+
+/**
+ * Whether a drift verdict may be applied to a day at all.
+ *
+ * A month can legitimately mix tools: Claude Code transcripts pruned while the
+ * same month's Codex usage is untouched. The month-level verdict is derived
+ * from Claude files alone, so it may only lower Claude-attributed days.
+ *
+ * An empty agent list means the payload came from a single-source report that
+ * carries no agent fields — historically `ccusage claude daily --json`. Those
+ * are Claude, so they stay in scope; treating unknown as out-of-scope would
+ * quietly switch the feature off for the exact users it was built for.
+ */
+export function corpusCoversDay(agents: readonly string[] | null | undefined): boolean {
+  if (!agents || agents.length === 0) return true;
+  return agents.some((agent) => agent.toLowerCase() === CORPUS_AGENT);
+}
+
 /** 'YYYY-MM' for a 'YYYY-MM-DD' date, or null if it isn't one. */
 export function monthOfDate(date: string): string | null {
   return /^\d{4}-\d{2}-\d{2}/.test(date) ? date.slice(0, 7) : null;
@@ -71,12 +98,30 @@ export function monthsUserDeleted(
     if (classifyDrift(prior?.[month], current) === "deleted") deleted.add(month);
   }
 
-  // A month the client no longer reports at all was emptied entirely. Without
-  // this, clearing a whole month leaves its stored total untouched forever,
-  // because nothing arrives to compare against.
-  for (const month of Object.keys(prior ?? {})) {
-    if (!(month in incoming)) deleted.add(month);
-  }
+  // A month absent from `incoming` is deliberately NOT treated as deletion.
+  //
+  // It used to be, on the reasoning that a month the client stops reporting was
+  // emptied entirely, and that without the rule a cleared month keeps its total
+  // forever. Both halves of that are true. The rule was still wrong, because
+  // absence has three causes and only one of them is deletion:
+  //
+  //   1. the user cleared the month                        — deletion
+  //   2. the month aged out of ~/.claude/projects          — not deletion
+  //      (Claude Code prunes on `cleanupPeriodDays`, 30 by default, so for
+  //      most users most history is missing as a matter of course)
+  //   3. the user never used Claude Code that month        — not deletion
+  //      (the corpus scans ~/.claude/projects only, while viberank accepts
+  //      Codex, Gemini, Copilot and OpenCode through the same payload)
+  //
+  // Nothing in the payload separates them. On production data at the time this
+  // was removed, every single absent month — 20 of 20, across 5 users — was
+  // cause 3: Codex or Gemini history from users with no Claude Code usage that
+  // month at all. Cause 1 did not appear once.
+  //
+  // The cost of dropping it is that clearing an entire month is no longer
+  // honoured, which is #111's documented behaviour anyway. The cost of keeping
+  // it was disabling the high-water mark across those users' whole non-Claude
+  // history on the strength of a file count that was never evidence about it.
 
   return deleted;
 }

--- a/test/drift.test.mts
+++ b/test/drift.test.mts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
-const { classifyDrift, monthsUserDeleted, monthOfDate } = await import("../src/lib/drift.ts");
+const { classifyDrift, monthsUserDeleted, monthOfDate, corpusCoversDay } =
+  await import("../src/lib/drift.ts");
 
 let passed = 0;
 const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
@@ -48,11 +49,32 @@ const size = (files: number, bytes = files * 1000) => ({ files, bytes });
 }
 
 {
-  // A month cleared entirely stops being reported. Without handling that, its
-  // stored total is frozen forever because nothing arrives to compare.
+  // This used to assert the opposite. A month absent from the payload is not
+  // evidence of deletion: it is equally the signature of Claude Code's own
+  // 30-day pruning, and of a month where the user ran only Codex or Gemini.
+  // On production data every absent month was the latter — 20 of 20.
   const deleted = monthsUserDeleted({ "2026-05": size(40) }, { "2026-07": size(10) });
-  assert.ok(deleted.has("2026-05"), "a month that vanished counts as deleted");
-  check("a month the client stops reporting is treated as cleared");
+  assert.ok(!deleted.has("2026-05"),
+    "an absent month is ambiguous between cleared, aged-off and never-used");
+  assert.equal(deleted.size, 0, "and nothing else should fire either");
+  check("a month the client stops reporting is NOT treated as cleared");
+}
+
+{
+  // The corpus scans ~/.claude/projects only, so its verdict may not lower a
+  // day whose usage came from a tool it never looked at.
+  assert.equal(corpusCoversDay(["claude"]), true);
+  assert.equal(corpusCoversDay(["claude", "codex"]), true, "mixed day still has Claude in it");
+  assert.equal(corpusCoversDay(["Claude"]), true, "agent casing varies by report");
+  assert.equal(corpusCoversDay(["codex"]), false, "a Codex day is out of scope");
+  assert.equal(corpusCoversDay(["codex", "gemini", "opencode"]), false);
+  // Single-source reports carry no agent fields and are Claude by definition;
+  // treating unknown as out-of-scope would disable the feature for the users
+  // it was built for.
+  assert.equal(corpusCoversDay([]), true, "no agents means a legacy Claude report");
+  assert.equal(corpusCoversDay(null), true);
+  assert.equal(corpusCoversDay(undefined), true);
+  check("a drift verdict only reaches days the corpus is evidence about");
 }
 
 {


### PR DESCRIPTION
Reported by @lizhuojunx86 on #121, from the rolling-window angle. Verified against production before changing anything — and the production data reframed it.

## The defect

`collectCorpus` walks `~/.claude/projects` and nothing else. Its verdict was applied to **every day in a month**, regardless of which tool produced the usage. viberank accepts Codex, Gemini, Copilot and OpenCode through the same payload, so for those days a Claude file count was never evidence of anything.

## What production says

Every user who has submitted since 1.4.0, usage months vs corpus months:

| user | usage | corpus | at risk |
|---|---|---|---|
| MLOpsEngineer | 12 | 3 | **9** |
| dennisbrian | 6 | 2 | 4 |
| Chrisa142857 | 6 | 3 | 3 |
| WhorideChicken | 6 | 4 | 2 |
| cjleemesotes | 6 | 5 | 1 |

**19 months.** MLOpsEngineer is 9-of-12 — the same split @lizhuojunx86 measured on their own tree, independently.

Then the part that changed my mind about the cause. Breaking those months down by tool:

```
MLOpsEngineer   2025-09  ABSENT  codex
MLOpsEngineer   2025-10  ABSENT  codex,gemini
Chrisa142857    2026-04  ABSENT  codex,opencode
WhorideChicken  2026-02  ABSENT  gemini
cjleemesotes    2026-02  ABSENT  codex,openclaw
…
at-risk months whose usage was not claude-only: 20 of 20
```

**Not one is an aged-off Claude month.** They are months where the user ran Codex or Gemini and never opened Claude Code, so `~/.claude/projects` was correctly empty. The rolling window would produce the same symptom and is real in principle — it just isn't what's firing today.

Effect: `acceptLower = true` across those users' entire non-Claude history, silently disabling #111's high-water mark for it.

## The fix

**1. Absence no longer means deletion.** Three causes, one payload, no way to separate them:

1. the user cleared the month — deletion
2. Claude Code pruned it (`cleanupPeriodDays`, 30 by default) — not deletion
3. the user didn't run Claude Code that month — not deletion

Production is 20/20 cause 3. Rule removed. Cost: clearing an entire month is no longer honoured — which is #111's documented behaviour anyway.

**2. A verdict only reaches days it has evidence about.** A month in the corpus can still mix tools, so pruning transcripts can no longer lower the same month's Codex totals. Empty agent list stays in scope — those are single-source `ccusage claude daily` reports, and treating unknown as out-of-scope would switch the feature off for exactly the users it was built for.

## On the tail

@lizhuojunx86 asked for the asymmetry to be stated if deliberate. It is, and it's now written where it happens: a missing **first** stamp drops a file from the corpus entirely (17 of 922 on one tree, 10 of 1,509 on theirs) — a real undercount. A missing **last** stamp can only collapse a file's span to the month the head already put it in. Two independent trees contain zero instances of the latter. If one shows up, the fix is the same fallback the head uses.

## Tests

Both properties pinned, including the test that previously asserted the opposite — it now asserts an absent month is *not* deleted, with the reason inline.

All 14 suites pass; type errors unchanged from `main` (10, all pre-existing); build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)