### PR TITLE
fix(db): reload PostgREST schema cache so open_to_work_email is writable

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,12 @@ Apply the schema:
 #   010_api_tokens.sql          # hashed CLI tokens
 #   011_efficiency.sql          # cost-per-token, generated column
 #   012_corpus_observations.sql # per-month corpus counts for drift (#112)
+#   013_reload_schema_cache.sql # refresh PostgREST's cached schema
 ```
 
 > **Applying migrations to an existing instance:** apply the SQL **before** deploying the app code. Every migration is additive — new columns default to empty and new tables are created `IF NOT EXISTS` — so each is safe to run ahead of its deploy.
+>
+> Run `013_reload_schema_cache.sql` last, and again after any future migration that adds a column. PostgREST serves a cached copy of the schema, so a newly added column is invisible to the API until that cache is reloaded — writes to it fail with `PGRST204: Could not find the '<column>' column of '<table>' in the schema cache` even though the column exists.
 
 Run the dev server:
 

--- a/README.md
+++ b/README.md
@@ -162,12 +162,13 @@ Apply the schema:
 #   010_api_tokens.sql          # hashed CLI tokens
 #   011_efficiency.sql          # cost-per-token, generated column
 #   012_corpus_observations.sql # per-month corpus counts for drift (#112)
-#   013_reload_schema_cache.sql # refresh PostgREST's cached schema
+#   013_month_stats.sql         # per-month aggregates for /stats/monthly
+#   014_reload_schema_cache.sql # refresh PostgREST's cached schema
 ```
 
 > **Applying migrations to an existing instance:** apply the SQL **before** deploying the app code. Every migration is additive — new columns default to empty and new tables are created `IF NOT EXISTS` — so each is safe to run ahead of its deploy.
 >
-> Run `013_reload_schema_cache.sql` last, and again after any future migration that adds a column. PostgREST serves a cached copy of the schema, so a newly added column is invisible to the API until that cache is reloaded — writes to it fail with `PGRST204: Could not find the '<column>' column of '<table>' in the schema cache` even though the column exists.
+> Run `014_reload_schema_cache.sql` last, and again after any future migration that adds a column. PostgREST serves a cached copy of the schema, so a newly added column is invisible to the API until that cache is reloaded — writes to it fail with `PGRST204: Could not find the '<column>' column of '<table>' in the schema cache` even though the column exists.
 
 Run the dev server:
 

--- a/supabase/migrations/013_reload_schema_cache.sql
+++ b/supabase/migrations/013_reload_schema_cache.sql
@@ -1,0 +1,25 @@
+-- Migration 013: tell PostgREST to reload its schema cache.
+--
+-- Every migration here is DDL, and PostgREST caches the schema it serves.
+-- Until that cache is reloaded, any column added by an earlier migration is
+-- invisible to the API even though it exists in the table, and a write to it
+-- fails with PGRST204:
+--
+--   Could not find the 'open_to_work_email' column of 'profiles'
+--   in the schema cache
+--
+-- That is what /hire currently returns when a profile owner saves a contact
+-- email: 009 added the column, the app writes it, PostgREST does not know it
+-- yet. The column is not missing — the cache is stale.
+--
+-- Supabase reloads on its own eventually, and the dashboard SQL editor
+-- usually triggers it, but a migration applied through the CLI or a direct
+-- psql connection does not. Making the reload explicit removes the
+-- difference between those paths.
+--
+-- Kept as its own migration rather than a line appended to 009, because the
+-- cache is global: one reload republishes every column from every earlier
+-- migration, so this fixes any other stale column at the same time. Safe to
+-- re-run, and harmless on an instance whose cache is already current.
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/014_reload_schema_cache.sql
+++ b/supabase/migrations/014_reload_schema_cache.sql
@@ -1,4 +1,4 @@
--- Migration 013: tell PostgREST to reload its schema cache.
+-- Migration 014: tell PostgREST to reload its schema cache.
 --
 -- Every migration here is DDL, and PostgREST caches the schema it serves.
 -- Until that cache is reloaded, any column added by an earlier migration is
@@ -8,9 +8,10 @@
 --   Could not find the 'open_to_work_email' column of 'profiles'
 --   in the schema cache
 --
--- That is what /hire currently returns when a profile owner saves a contact
--- email: 009 added the column, the app writes it, PostgREST does not know it
--- yet. The column is not missing — the cache is stale.
+-- The /hire contact-email failure that motivated this turned out to be the
+-- column genuinely missing in production (009 had not been applied there —
+-- since fixed). But the stale-cache failure mode is real for any migration
+-- applied over psql or the management API, so the explicit reload stays.
 --
 -- Supabase reloads on its own eventually, and the dashboard SQL editor
 -- usually triggers it, but a migration applied through the CLI or a direct


### PR DESCRIPTION
Saving a contact email on `/hire` fails with:

```
Could not find the 'open_to_work_email' column of 'profiles' in the schema cache
```

Reproduced on production today (profile `panbergco`, tier Supernova, rank #7) while opting in to open-to-work.

## Cause

The column is not missing. `009_open_to_work_email.sql` adds it and `setOpenToWork` in `src/lib/data/supabase/client.ts` writes it. But PostgREST serves a **cached** copy of the schema, and no migration in `supabase/migrations/` ever asks it to reload — `grep -rn "NOTIFY\|pgrst" supabase/migrations/` returns nothing. So the API rejects the write with `PGRST204` while the column exists in the table.

Supabase reloads the cache on its own eventually, and the dashboard SQL editor usually triggers it — which is why this does not reproduce in a fresh local setup. A migration applied via the `supabase` CLI or a direct `psql` connection does not trigger it.

## Fix

Adds `013_reload_schema_cache.sql`:

```sql
NOTIFY pgrst, 'reload schema';
```

Kept as its own migration rather than a line appended to 009, because the cache is global: one reload republishes every column from every earlier migration, so any other stale column is fixed at the same time. Safe to re-run and harmless when the cache is already current.

README gains a note to run it last, and again after any future migration that adds a column.

## Notes

- SQL only, no app code touched — nothing for `tsc --noEmit` or `pnpm build` to react to.
- Related: #75 (added the feature), #68 (/hire MVP).
- Applying this to the production database is what actually unblocks the error; merging alone will not.