### PR TITLE
feat: SEO expansion — /compare pages, usage-limits cluster, RSS, llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,11 @@ Live at **[viberank.app](https://www.viberank.app)**.
 - 🖥️ **Multi-machine** — a laptop and a desktop sum into one profile instead of overwriting each other
 - 📈 **[`/stats`](https://www.viberank.app/stats)** — site-wide spend curve, monthly trend, and where your burn lands against everyone else
 - 🧮 **[`/calculator`](https://www.viberank.app/calculator)** — which subscription tier your actual usage justifies, based on your real `ccusage` numbers rather than a guess
+- ⚔️ **[Head-to-head comparisons](https://www.viberank.app/compare)** — `/compare/claude-vs-codex` and every other tool matchup, with live adoption numbers from the board
 - 🎖️ **README badges** — `https://www.viberank.app/api/badge/{username}` for rank, cost, or tokens
 - 🛡️ **Input validation** — one-sided token math (reasoning-token aware), cost/token ratio guard, date sanity, realistic-range ceilings
 - 🔄 **Merge flow** — re-submitting the same range overwrites prior daily entries; merging combines unverified CLI rows into your verified profile
-- ✍️ **Blog** — data-backed posts on AI coding costs at [viberank.app/blog](https://www.viberank.app/blog)
+- ✍️ **Blog** — data-backed posts on AI coding costs at [viberank.app/blog](https://www.viberank.app/blog) ([RSS](https://www.viberank.app/feed.xml)); [`llms.txt`](https://www.viberank.app/llms.txt) for AI search engines
 
 ## Submitting your usage data
 

--- a/src/app/blog/claude-code-complete-guide/page.tsx
+++ b/src/app/blog/claude-code-complete-guide/page.tsx
@@ -3,30 +3,32 @@ import { ArrowLeft, Clock, Calendar, Terminal, Zap, Settings, Code, FileCode, Bo
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Claude Code Complete Guide 2025: Installation, Commands & Best Practices",
-  description: "Master Claude Code in 2025 with this comprehensive guide. Learn installation, essential commands, MCP servers, hooks, and advanced workflows for AI-powered terminal development.",
+  title: "Claude Code Complete Guide 2026: Installation, Commands & Best Practices",
+  description: "Master Claude Code in 2026 with this comprehensive guide. Learn installation, essential commands, MCP servers, hooks, and advanced workflows for AI-powered terminal development.",
   keywords: ["claude code", "claude code tutorial", "claude code guide", "anthropic cli", "ai coding assistant", "terminal ai", "claude code commands", "mcp servers", "claude code installation"],
+  alternates: { canonical: "https://www.viberank.app/blog/claude-code-complete-guide" },
   openGraph: {
-    title: "Claude Code Complete Guide 2025: Installation, Commands & Best Practices",
+    title: "Claude Code Complete Guide 2026: Installation, Commands & Best Practices",
     description: "Master Claude Code with this comprehensive guide covering installation, commands, MCP servers, and advanced workflows.",
     url: "https://www.viberank.app/blog/claude-code-complete-guide",
     type: "article",
     publishedTime: "2025-10-12T00:00:00.000Z",
+    modifiedTime: "2026-08-18T00:00:00.000Z",
     authors: ["Viberank Team"],
     images: [
       {
-        url: "/api/og?title=Claude%20Code%20Complete%20Guide%202025&description=Installation%2C%20Commands%20%26%20Best%20Practices",
+        url: "/api/og?title=Claude%20Code%20Complete%20Guide%202026&description=Installation%2C%20Commands%20%26%20Best%20Practices",
         width: 1200,
         height: 630,
-        alt: "Claude Code Complete Guide 2025",
+        alt: "Claude Code Complete Guide 2026",
       },
     ],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Claude Code Complete Guide 2025: Installation, Commands & Best Practices",
+    title: "Claude Code Complete Guide 2026: Installation, Commands & Best Practices",
     description: "Master Claude Code with this comprehensive guide covering installation, commands, and advanced workflows.",
-    images: ["/api/og?title=Claude%20Code%20Complete%20Guide%202025&description=Installation%2C%20Commands%20%26%20Best%20Practices"],
+    images: ["/api/og?title=Claude%20Code%20Complete%20Guide%202026&description=Installation%2C%20Commands%20%26%20Best%20Practices"],
   },
 };
 
@@ -34,11 +36,11 @@ export default function ClaudeCodeCompleteGuide() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    "headline": "Claude Code Complete Guide 2025: Installation, Commands & Best Practices",
-    "description": "Master Claude Code in 2025 with this comprehensive guide covering installation, essential commands, MCP servers, and advanced workflows.",
-    "image": "https://www.viberank.app/api/og?title=Claude%20Code%20Complete%20Guide%202025",
+    "headline": "Claude Code Complete Guide 2026: Installation, Commands & Best Practices",
+    "description": "Master Claude Code in 2026 with this comprehensive guide covering installation, essential commands, MCP servers, and advanced workflows.",
+    "image": "https://www.viberank.app/api/og?title=Claude%20Code%20Complete%20Guide%202026",
     "datePublished": "2025-10-12T00:00:00.000Z",
-    "dateModified": "2025-10-12T00:00:00.000Z",
+    "dateModified": "2026-08-18T00:00:00.000Z",
     "author": {
       "@type": "Organization",
       "name": "Viberank",
@@ -73,7 +75,7 @@ export default function ClaudeCodeCompleteGuide() {
 
         <header className="mb-12">
           <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
-            Claude Code Complete Guide 2025: Installation, Commands & Best Practices
+            Claude Code Complete Guide 2026: Installation, Commands & Best Practices
           </h1>
 
           <div className="flex items-center gap-6 text-sm text-muted mb-8">
@@ -91,7 +93,7 @@ export default function ClaudeCodeCompleteGuide() {
             <p className="text-lg text-foreground m-0">
               <span className="font-semibold text-accent">Claude Code</span> is Anthropic's official CLI tool that brings
               AI-powered development directly into your terminal. This comprehensive guide covers everything from installation
-              to advanced workflows, helping you become a power user in 2025.
+              to advanced workflows, helping you become a power user in 2026.
             </p>
           </div>
         </header>
@@ -465,7 +467,10 @@ export default function ClaudeCodeCompleteGuide() {
           <p className="text-foreground text-lg leading-relaxed mb-6">
             Curious how your Claude Code usage compares to other developers? Viberank analyzes your
             <code className="bg-stone-800 px-2 py-1 rounded text-accent mx-1">cc.json</code>
-            file to show detailed analytics about your AI-assisted development workflow.
+            file to show detailed analytics about your AI-assisted development workflow. Once you&apos;re up and
+            running, learn <Link href="/blog/how-to-check-claude-code-usage">how to check your usage</Link>, how{" "}
+            <Link href="/blog/claude-code-usage-limits">the 5-hour and weekly limits work</Link>, and{" "}
+            <Link href="/blog/how-much-does-claude-code-cost">what Claude Code actually costs in practice</Link>.
           </p>
 
           <div className="bg-card border border-border rounded-lg p-8 text-center">

--- a/src/app/blog/claude-code-usage-limits/page.tsx
+++ b/src/app/blog/claude-code-usage-limits/page.tsx
@@ -1,0 +1,274 @@
+import Link from "next/link";
+import { ArrowLeft, Clock, Calendar, Timer, CalendarClock, Gauge, Wrench, CreditCard } from "lucide-react";
+import type { Metadata } from "next";
+
+const TITLE = "Claude Code Usage Limits Explained (2026): 5-Hour Sessions, Weekly Caps & What To Do When You Hit Them";
+const DESC =
+  "How Claude Code's rolling 5-hour session limit and weekly cap actually work in 2026, how to check where you stand with /usage and ccusage, and your options when you hit the wall.";
+const URL = "https://www.viberank.app/blog/claude-code-usage-limits";
+const OG =
+  "/api/og?title=Claude%20Code%20Usage%20Limits%20Explained&description=5-hour%20sessions%2C%20weekly%20caps%2C%20and%20what%20to%20do%20when%20you%20hit%20them";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  keywords: [
+    "claude code usage limits",
+    "claude weekly limit",
+    "claude code limit reset",
+    "claude 5 hour limit",
+    "claude code rate limit",
+    "hit claude code limit",
+    "claude pro limits",
+    "claude max limits",
+    "check claude code usage",
+  ],
+  alternates: { canonical: URL },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: URL,
+    type: "article",
+    publishedTime: "2026-08-18T00:00:00.000Z",
+    authors: ["Viberank Team"],
+    images: [{ url: OG, width: 1200, height: 630, alt: TITLE }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC, images: [OG] },
+};
+
+const FAQS = [
+  {
+    q: "What are Claude Code's usage limits in 2026?",
+    a: "Two layers: a rolling 5-hour session limit and a weekly cap on top, both shared across Claude Code and the Claude apps. Anthropic permanently doubled the 5-hour limits for Pro, Max, Team, and Enterprise plans in May 2026; the weekly caps stayed put. Exact allowances scale with your plan — Pro ($20/mo), Max 5x ($100/mo), or Max 20x ($200/mo).",
+  },
+  {
+    q: "How do I check my Claude Code usage against the limits?",
+    a: "Run /usage inside Claude Code — it shows your current session and weekly consumption and when each resets. The same view lives at claude.ai/settings/usage. For token-level history and API-equivalent cost, run npx ccusage@latest daily, which reads your local session logs.",
+  },
+  {
+    q: "When does the Claude weekly limit reset?",
+    a: "At a fixed time each week assigned to your account — it does not roll with your usage the way the 5-hour session window does. /usage shows your exact reset time.",
+  },
+  {
+    q: "How do I keep working after hitting a Claude Code limit?",
+    a: "Wait for the reset, enable usage credits (pay-as-you-go at standard API rates once your included limit runs out), switch that session to an API key, or upgrade your plan. Before upgrading, check your real usage — the Viberank calculator tells you which tier your actual consumption justifies.",
+  },
+  {
+    q: "Do Claude Code limits apply if I pay with an API key?",
+    a: "Subscription session and weekly caps don't apply to API billing — you pay per token against your organization's API rate limits instead. Heavy users on the Viberank leaderboard routinely consume thousands of dollars of API-equivalent usage per month on a $100–$200 subscription, which is why hitting subscription limits is so common.",
+  },
+];
+
+export default function Post() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: TITLE,
+      description: DESC,
+      image: "https://www.viberank.app" + OG,
+      datePublished: "2026-08-18T00:00:00.000Z",
+      dateModified: "2026-08-18T00:00:00.000Z",
+      author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
+      publisher: {
+        "@type": "Organization",
+        name: "Viberank",
+        url: "https://www.viberank.app",
+        logo: { "@type": "ImageObject", url: "https://www.viberank.app/icon.svg" },
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
+            Claude Code Usage Limits, Explained
+          </h1>
+
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              August 18, 2026
+            </span>
+            <span className="flex items-center gap-2">
+              <Clock className="w-4 h-4" />8 min read
+            </span>
+          </div>
+
+          <div className="p-6 bg-card border border-border rounded-lg">
+            <p className="text-lg text-foreground m-0">
+              You&apos;re mid-refactor and Claude Code stops: limit reached. If that&apos;s why you&apos;re here,
+              the short version: there are <strong>two limits stacked on top of each other</strong> — a rolling
+              5-hour session window and a weekly cap — and <code>/usage</code> shows exactly where you stand on
+              both. Here&apos;s how the system works in 2026, how to see your real consumption, and every option
+              you have when you hit the wall.
+            </p>
+          </div>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Timer className="w-8 h-8 text-accent" />
+            Limit one: the rolling 5-hour session
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Every message you send starts or joins a 5-hour window. Your plan includes a certain amount of usage per
+            window, shared across Claude Code, claude.ai, and the desktop and mobile apps. When the window expires, a
+            fresh one starts with your next message — so &quot;wait for the reset&quot; is never more than a few
+            hours away. In May 2026 Anthropic <strong>permanently doubled</strong> the 5-hour limits on Pro, Max,
+            Team, and seat-based Enterprise plans, which moved the everyday pain from session limits to the weekly
+            cap.
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            How much a session &quot;costs&quot; depends heavily on what you do with it: model choice, codebase
+            size, and how much context each request drags along. The same hour of work can consume wildly different
+            amounts of your allowance — which is why measuring your own usage (below) beats rules of thumb.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <CalendarClock className="w-8 h-8 text-accent" />
+            Limit two: the weekly cap
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            On top of sessions sits a weekly limit covering all your usage across all models. Unlike the session
+            window, the weekly reset is <strong>fixed, not rolling</strong> — it resets at a set time each week
+            assigned to your account, whether you&apos;ve been coding or not. This is the limit heavy users actually
+            plan around: burn hard early in your week and no amount of session discipline gets it back before the
+            reset.
+          </p>
+          <div className="bg-card border-l-4 border-accent p-6 my-8">
+            <p className="text-stone-200 m-0">
+              Anthropic introduced weekly caps in mid-2025 after a wave of always-on agent loops, and has adjusted
+              them since — including a temporary 50% boost in mid-2026. Treat exact allowances as a moving target;
+              treat <code>/usage</code> as the source of truth for your account.
+            </p>
+          </div>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Gauge className="w-8 h-8 text-accent" />
+            Checking where you stand
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">Three tools, three different questions:</p>
+          <ul className="text-foreground text-lg leading-relaxed mb-6 space-y-3">
+            <li>
+              <strong><code>/usage</code> in Claude Code</strong> (or claude.ai/settings/usage) — am I about to hit
+              a limit, and when does it reset? This is the official percent-used view of both the session and the
+              week.
+            </li>
+            <li>
+              <strong><code>npx ccusage@latest daily</code></strong> — what am I actually consuming? It reads your
+              local session logs and computes per-day tokens and API-equivalent USD cost, per model. This is the
+              number that tells you whether your subscription is a bargain.{" "}
+              <Link href="/blog/how-to-check-claude-code-usage">Full guide here</Link>.
+            </li>
+            <li>
+              <strong><code>npx viberank-cli</code></strong> — is my usage normal? It submits your ccusage totals to
+              the <Link href="/">public leaderboard</Link>, where you can compare against 1,100+ developers.{" "}
+              <Link href="/blog/how-much-does-claude-code-cost">Median heavy users</Link> burn far more than most
+              people guess.
+            </li>
+          </ul>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            One number from the board worth knowing: across{" "}
+            <Link href="/stats">11+ trillion tracked tokens</Link>, about 95% are prompt-cache reads that cost
+            roughly a tenth of normal input tokens. A scary token count in ccusage usually maps to a much smaller
+            real cost — and to less limit pressure than you&apos;d fear.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Wrench className="w-8 h-8 text-accent" />
+            Hit the limit? Your options, in order
+          </h2>
+          <ol className="text-foreground text-lg leading-relaxed mb-6 space-y-3 list-decimal pl-6">
+            <li>
+              <strong>Wait it out.</strong> Session windows refresh within hours; <code>/usage</code> shows your
+              weekly reset time.
+            </li>
+            <li>
+              <strong>Burn less per task.</strong> Route routine work to smaller models, keep context lean, start
+              fresh conversations instead of dragging 100k-token histories.{" "}
+              <Link href="/blog/reduce-ai-coding-costs">Nine concrete tactics here</Link> — the same habits that cut
+              API bills stretch subscription limits.
+            </li>
+            <li>
+              <strong>Enable usage credits.</strong> Pro and Max plans can keep working past the included limit at
+              standard API rates, billed pay-as-you-go — no plan change required.
+            </li>
+            <li>
+              <strong>Switch to an API key for the overflow.</strong> API billing has no session or weekly caps,
+              just per-token pricing and org rate limits.
+            </li>
+            <li>
+              <strong>Upgrade — but check the math first.</strong> Max 5x ($100/mo) and Max 20x ($200/mo) multiply
+              your limits, and for heavy users they&apos;re dramatically cheaper than equivalent API usage. Whether{" "}
+              <em>you&apos;re</em> a heavy user is an empirical question:{" "}
+              <Link href="/calculator">drop your ccusage numbers into the calculator</Link> and see which tier your
+              actual usage justifies, or read{" "}
+              <Link href="/blog/is-claude-max-worth-it">our full Pro vs Max breakdown</Link>.
+            </li>
+          </ol>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <CreditCard className="w-8 h-8 text-accent" />
+            The subscription arbitrage, quantified
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Limits exist because flat-rate plans are a genuine arbitrage. On the{" "}
+            <Link href="/tool/claude">Claude Code leaderboard</Link>, developers routinely show thousands of dollars
+            of API-equivalent usage per month on a $100–$200 subscription — the top of the board is past{" "}
+            <em>six figures</em> in tracked equivalent spend. If you keep slamming into weekly caps, you&apos;re
+            almost certainly in the population for whom Max pays for itself many times over.
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx viberank-cli</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            One command puts your real numbers on the board — your code and prompts never leave your machine, only
+            usage totals do.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6">Claude Code limits FAQ</h2>
+          <div className="space-y-6">
+            {FAQS.map((f) => (
+              <div key={f.q} className="bg-card border border-border rounded-lg p-5">
+                <h3 className="text-lg font-semibold text-foreground mt-0 mb-2">{f.q}</h3>
+                <p className="text-muted m-0">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/blog/codex-vs-claude-code-vs-gemini-cli/page.tsx
+++ b/src/app/blog/codex-vs-claude-code-vs-gemini-cli/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
   title: TITLE,
   description: DESC,
   keywords: ["codex vs claude code", "claude code vs gemini cli", "openai codex cli", "gemini cli", "ai coding cost comparison", "ccusage", "ai coding tools 2026", "claude code cost"],
+  alternates: { canonical: "https://www.viberank.app/blog/codex-vs-claude-code-vs-gemini-cli" },
   openGraph: {
     title: TITLE,
     description: DESC,

--- a/src/app/blog/cursor-vs-claude-code-vs-copilot/page.tsx
+++ b/src/app/blog/cursor-vs-claude-code-vs-copilot/page.tsx
@@ -3,19 +3,21 @@ import { ArrowLeft, Clock, Calendar, Zap, Terminal, Code, Brain, GitBranch, Chec
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2025)",
-  description: "In-depth comparison of Cursor, Claude Code, and GitHub Copilot in 2025. Features, pricing, use cases, and which AI coding assistant is right for your workflow.",
-  keywords: ["cursor vs copilot", "claude code vs cursor", "ai coding tools comparison", "best ai coding assistant 2025", "cursor ai", "github copilot", "claude code", "ai pair programming"],
+  title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2026)",
+  description: "In-depth comparison of Cursor, Claude Code, and GitHub Copilot in 2026. Features, pricing, use cases, and which AI coding assistant is right for your workflow.",
+  keywords: ["cursor vs copilot", "claude code vs cursor", "ai coding tools comparison", "best ai coding assistant 2026", "cursor ai", "github copilot", "claude code", "ai pair programming"],
+  alternates: { canonical: "https://www.viberank.app/blog/cursor-vs-claude-code-vs-copilot" },
   openGraph: {
-    title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2025)",
+    title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2026)",
     description: "In-depth comparison of the top AI coding assistants. Features, pricing, and which one fits your workflow.",
     url: "https://www.viberank.app/blog/cursor-vs-claude-code-vs-copilot",
     type: "article",
     publishedTime: "2025-11-28T00:00:00.000Z",
+    modifiedTime: "2026-08-18T00:00:00.000Z",
     authors: ["Viberank Team"],
     images: [
       {
-        url: "/api/og?title=Cursor%20vs%20Claude%20Code%20vs%20Copilot&description=AI%20Coding%20Tools%20Compared%202025",
+        url: "/api/og?title=Cursor%20vs%20Claude%20Code%20vs%20Copilot&description=AI%20Coding%20Tools%20Compared%202026",
         width: 1200,
         height: 630,
         alt: "Cursor vs Claude Code vs GitHub Copilot Comparison",
@@ -24,9 +26,9 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2025)",
+    title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2026)",
     description: "In-depth comparison of Cursor, Claude Code, and GitHub Copilot for developers.",
-    images: ["/api/og?title=Cursor%20vs%20Claude%20Code%20vs%20Copilot&description=AI%20Coding%20Tools%20Compared%202025"],
+    images: ["/api/og?title=Cursor%20vs%20Claude%20Code%20vs%20Copilot&description=AI%20Coding%20Tools%20Compared%202026"],
   },
 };
 
@@ -34,11 +36,11 @@ export default function CursorVsClaudeCodeVsCopilot() {
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    "headline": "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2025)",
-    "description": "In-depth comparison of the top AI coding assistants for developers in 2025.",
+    "headline": "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2026)",
+    "description": "In-depth comparison of the top AI coding assistants for developers in 2026.",
     "image": "https://www.viberank.app/api/og?title=Cursor%20vs%20Claude%20Code%20vs%20Copilot",
     "datePublished": "2025-11-28T00:00:00.000Z",
-    "dateModified": "2025-11-28T00:00:00.000Z",
+    "dateModified": "2026-08-18T00:00:00.000Z",
     "author": {
       "@type": "Organization",
       "name": "Viberank",
@@ -73,7 +75,7 @@ export default function CursorVsClaudeCodeVsCopilot() {
 
         <header className="mb-12">
           <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
-            Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2025)
+            Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2026)
           </h1>
 
           <div className="flex items-center gap-6 text-sm text-muted mb-8">
@@ -89,10 +91,11 @@ export default function CursorVsClaudeCodeVsCopilot() {
 
           <div className="p-6 bg-card border border-border rounded-lg">
             <p className="text-lg text-foreground m-0">
-              The AI coding tool landscape has exploded in 2025. <span className="font-semibold text-accent">Cursor</span>,
+              Three years into the agentic coding era, three tools still anchor most workflows. <span className="font-semibold text-accent">Cursor</span>,
               <span className="font-semibold text-accent"> Claude Code</span>, and
               <span className="font-semibold text-accent"> GitHub Copilot</span> lead the pack, each with distinct
-              approaches to AI-assisted development. This guide breaks down the key differences to help you choose.
+              approaches to AI-assisted development. Updated for 2026 — including where each tool’s agentic
+              mode actually stands. This guide breaks down the key differences to help you choose.
             </p>
           </div>
         </header>
@@ -122,9 +125,9 @@ export default function CursorVsClaudeCodeVsCopilot() {
                 </tr>
                 <tr className="bg-card/50">
                   <td className="border border-border p-4 font-medium">AI Model</td>
-                  <td className="border border-border p-4 text-center">Claude/GPT-4</td>
-                  <td className="border border-border p-4 text-center">Claude 3.5/Opus</td>
-                  <td className="border border-border p-4 text-center">GPT-4/Codex</td>
+                  <td className="border border-border p-4 text-center">Multi-model (Claude, GPT, Gemini)</td>
+                  <td className="border border-border p-4 text-center">Claude (Opus, Sonnet, Haiku)</td>
+                  <td className="border border-border p-4 text-center">Multi-model (GPT, Claude, Gemini)</td>
                 </tr>
                 <tr>
                   <td className="border border-border p-4 font-medium">Multi-file Editing</td>
@@ -136,13 +139,13 @@ export default function CursorVsClaudeCodeVsCopilot() {
                   <td className="border border-border p-4 font-medium">Agentic Mode</td>
                   <td className="border border-border p-4 text-center"><CheckCircle className="w-5 h-5 text-green-400 mx-auto" /></td>
                   <td className="border border-border p-4 text-center"><CheckCircle className="w-5 h-5 text-green-400 mx-auto" /></td>
-                  <td className="border border-border p-4 text-center"><XCircle className="w-5 h-5 text-red-400 mx-auto" /></td>
+                  <td className="border border-border p-4 text-center"><CheckCircle className="w-5 h-5 text-green-400 mx-auto" /></td>
                 </tr>
                 <tr>
                   <td className="border border-border p-4 font-medium">Shell Commands</td>
                   <td className="border border-border p-4 text-center"><CheckCircle className="w-5 h-5 text-green-400 mx-auto" /></td>
                   <td className="border border-border p-4 text-center"><CheckCircle className="w-5 h-5 text-green-400 mx-auto" /></td>
-                  <td className="border border-border p-4 text-center"><XCircle className="w-5 h-5 text-red-400 mx-auto" /></td>
+                  <td className="border border-border p-4 text-center"><Minus className="w-5 h-5 text-yellow-400 mx-auto" /></td>
                 </tr>
                 <tr className="bg-card/50">
                   <td className="border border-border p-4 font-medium">Git Integration</td>
@@ -159,7 +162,7 @@ export default function CursorVsClaudeCodeVsCopilot() {
                 <tr className="bg-card/50">
                   <td className="border border-border p-4 font-medium">Starting Price</td>
                   <td className="border border-border p-4 text-center">$20/mo</td>
-                  <td className="border border-border p-4 text-center">Usage-based</td>
+                  <td className="border border-border p-4 text-center">$20/mo (Pro) or API</td>
                   <td className="border border-border p-4 text-center">$10/mo</td>
                 </tr>
               </tbody>
@@ -294,10 +297,10 @@ export default function CursorVsClaudeCodeVsCopilot() {
             <div className="bg-red-900/20 border border-red-400/30 rounded-lg p-6">
               <h3 className="text-red-400 font-semibold text-lg mb-3">Limitations</h3>
               <ul className="text-foreground space-y-2 m-0">
-                <li>• Terminal-only interface</li>
                 <li>• Steeper learning curve</li>
-                <li>• Usage-based pricing adds up</li>
-                <li>• No visual diff preview</li>
+                <li>• Weekly usage caps on heavy use</li>
+                <li>• Heavy agentic runs burn limits fast</li>
+                <li>• Less visual than an IDE</li>
               </ul>
             </div>
           </div>
@@ -316,9 +319,9 @@ export default function CursorVsClaudeCodeVsCopilot() {
           </h2>
 
           <p className="text-foreground text-lg leading-relaxed mb-6">
-            GitHub Copilot pioneered AI pair programming and remains the most widely adopted tool.
-            It integrates seamlessly with VS Code, JetBrains, and Neovim through extensions,
-            focusing on inline completions and chat assistance.
+            GitHub Copilot pioneered AI pair programming and remains the most widely adopted tool. It has grown
+            well past autocomplete: Copilot now ships an agent mode, a coding agent that works GitHub issues into
+            pull requests, and a <Link href="/tool/copilot">CLI</Link> — while staying the cheapest entry point.
           </p>
 
           <div className="bg-card p-6 rounded-lg border border-border my-8">
@@ -365,10 +368,10 @@ export default function CursorVsClaudeCodeVsCopilot() {
             <div className="bg-red-900/20 border border-red-400/30 rounded-lg p-6">
               <h3 className="text-red-400 font-semibold text-lg mb-3">Limitations</h3>
               <ul className="text-foreground space-y-2 m-0">
-                <li>• No agentic capabilities</li>
-                <li>• Limited multi-file editing</li>
-                <li>• Can't run shell commands</li>
-                <li>• Less autonomous than rivals</li>
+                <li>• Agent mode younger than rivals&apos;</li>
+                <li>• Less terminal-native than CLI agents</li>
+                <li>• Premium-request billing on higher tiers</li>
+                <li>• Best experience assumes GitHub-centric flow</li>
               </ul>
             </div>
           </div>
@@ -401,7 +404,8 @@ export default function CursorVsClaudeCodeVsCopilot() {
               <p className="text-foreground m-0">
                 You're a terminal power user who wants AI as a command-line agent. You need to integrate with
                 external services through MCP servers. You want to automate AI workflows in scripts and CI/CD.
-                You prefer Claude's models over GPT-4.
+                It's also the tool driving the most spend on the{" "}
+                <Link href="/tool/claude">Claude Code leaderboard</Link> — by a wide margin.
               </p>
             </div>
 
@@ -410,6 +414,8 @@ export default function CursorVsClaudeCodeVsCopilot() {
               <p className="text-foreground m-0">
                 You want reliable autocomplete in your existing IDE without workflow changes. You're on a budget
                 and $10/month fits better than $20+. Your enterprise requires compliance features and admin controls.
+                In 2026 its agent mode is genuinely capable — see how its usage stacks up on the{" "}
+                <Link href="/compare/claude-vs-copilot">Claude Code vs Copilot comparison</Link>.
               </p>
             </div>
           </div>
@@ -428,9 +434,10 @@ export default function CursorVsClaudeCodeVsCopilot() {
           <h2 className="text-3xl font-bold text-foreground mb-6">Track Your AI Coding Stats</h2>
 
           <p className="text-foreground text-lg leading-relaxed mb-6">
-            Whichever tool you choose, tracking your usage helps optimize your workflow. If you're using
-            Claude Code, Viberank analyzes your <code className="bg-stone-800 px-2 py-1 rounded text-accent">cc.json</code>
-            file to show detailed analytics about tokens, sessions, and productivity patterns.
+            Whichever tool you choose, tracking your usage helps optimize your workflow. Viberank ranks real usage
+            from Claude Code, Codex, Gemini CLI, Copilot and more — see{" "}
+            <Link href="/blog/how-to-check-claude-code-usage">how to check your own usage</Link>, or{" "}
+            <Link href="/blog/how-much-does-claude-code-cost">what these tools actually cost in practice</Link>.
           </p>
 
           <div className="bg-card border border-border rounded-lg p-8 text-center">
@@ -453,7 +460,7 @@ export default function CursorVsClaudeCodeVsCopilot() {
             is the reliable autocomplete companion. Try them, find what clicks, and don't be afraid to combine them.
           </p>
           <p className="text-stone-500 text-sm">
-            Updated November 2025. Pricing and features may change—check official sites for current information.
+            Updated August 2026. Pricing and features may change—check official sites for current information.
           </p>
         </footer>
       </article>

--- a/src/app/blog/how-much-does-claude-code-cost/page.tsx
+++ b/src/app/blog/how-much-does-claude-code-cost/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
   title: TITLE,
   description: DESC,
   keywords: ["how much does claude code cost", "claude code pricing", "claude code cost per month", "claude code token cost", "ai coding cost", "claude code usage", "ccusage"],
+  alternates: { canonical: "https://www.viberank.app/blog/how-much-does-claude-code-cost" },
   openGraph: {
     title: TITLE,
     description: DESC,

--- a/src/app/blog/how-to-check-claude-code-usage/page.tsx
+++ b/src/app/blog/how-to-check-claude-code-usage/page.tsx
@@ -1,0 +1,250 @@
+import Link from "next/link";
+import { ArrowLeft, Clock, Calendar, Gauge, Terminal, LineChart, RefreshCcw } from "lucide-react";
+import type { Metadata } from "next";
+
+const TITLE = "How to Check Your Claude Code Usage (and Codex, Gemini CLI): /usage, ccusage & Your Real Costs";
+const DESC =
+  "Three ways to see exactly how much Claude Code you've used — the /usage command for limits, ccusage for token-level history and API-equivalent cost, and the leaderboard that tracks it daily.";
+const URL = "https://www.viberank.app/blog/how-to-check-claude-code-usage";
+const OG =
+  "/api/og?title=How%20to%20Check%20Your%20Claude%20Code%20Usage&description=%2Fusage%2C%20ccusage%2C%20and%20your%20real%20API-equivalent%20costs";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  keywords: [
+    "how to check claude code usage",
+    "claude code token usage",
+    "claude code usage command",
+    "ccusage",
+    "ccusage tutorial",
+    "claude code cost tracking",
+    "check codex usage",
+    "check gemini cli usage",
+    "ai coding usage tracker",
+  ],
+  alternates: { canonical: URL },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: URL,
+    type: "article",
+    publishedTime: "2026-08-18T00:00:00.000Z",
+    authors: ["Viberank Team"],
+    images: [{ url: OG, width: 1200, height: 630, alt: TITLE }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC, images: [OG] },
+};
+
+const FAQS = [
+  {
+    q: "What's the fastest way to check Claude Code usage?",
+    a: "Type /usage inside Claude Code. It shows how much of your 5-hour session and weekly limit you've consumed and when each resets. The same data is at claude.ai/settings/usage.",
+  },
+  {
+    q: "How do I see my Claude Code usage in tokens and dollars?",
+    a: "Run npx ccusage@latest daily. It parses Claude Code's local session logs (no account or API key needed) into per-day input/output/cache token counts and API-equivalent USD costs per model. Add --json for machine-readable output.",
+  },
+  {
+    q: "Does ccusage work for OpenAI Codex and Gemini CLI too?",
+    a: "Yes. ccusage reads local logs from Claude Code, Codex CLI, Gemini CLI, Copilot CLI, OpenCode and more, and can report each separately or aggregate them — one report across your whole AI toolchain.",
+  },
+  {
+    q: "How do I track my usage over time automatically?",
+    a: "Run npx viberank-cli once to put your usage on the public leaderboard, then viberank-cli login and viberank-cli autosubmit to keep it current daily via your OS scheduler. Your profile charts daily spend, tokens, models, and streaks.",
+  },
+  {
+    q: "Is my code or conversation shared when I submit usage?",
+    a: "No. ccusage computes totals locally from your logs, and viberank-cli submits only aggregate numbers — tokens, costs, dates, and models. Code and prompts never leave your machine.",
+  },
+];
+
+export default function Post() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: TITLE,
+      description: DESC,
+      image: "https://www.viberank.app" + OG,
+      datePublished: "2026-08-18T00:00:00.000Z",
+      dateModified: "2026-08-18T00:00:00.000Z",
+      author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
+      publisher: {
+        "@type": "Organization",
+        name: "Viberank",
+        url: "https://www.viberank.app",
+        logo: { "@type": "ImageObject", url: "https://www.viberank.app/icon.svg" },
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
+            How to Check Your Claude Code Usage
+          </h1>
+
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              August 18, 2026
+            </span>
+            <span className="flex items-center gap-2">
+              <Clock className="w-4 h-4" />7 min read
+            </span>
+          </div>
+
+          <div className="p-6 bg-card border border-border rounded-lg">
+            <p className="text-lg text-foreground m-0">
+              There are three different questions hiding inside &quot;how much Claude Code have I used?&quot; —{" "}
+              <em>am I near my limit</em>, <em>what is my usage actually worth in dollars</em>, and{" "}
+              <em>is that a lot</em>. Each has its own tool: <code>/usage</code>, <code>ccusage</code>, and the{" "}
+              <Link href="/">leaderboard</Link>. This guide covers all three, plus the same tricks for OpenAI Codex
+              and Gemini CLI.
+            </p>
+          </div>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Gauge className="w-8 h-8 text-accent" />
+            1. <code className="text-accent">/usage</code> — the limits view
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Inside any Claude Code session, type <code>/usage</code>. You get your current consumption against both
+            limit layers — the rolling 5-hour session and the weekly cap — with reset times for each. The same
+            dashboard lives at <strong>claude.ai/settings/usage</strong> if you&apos;d rather check from a browser.
+            This is the view to reach for when you&apos;re rationing your week.
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            What it doesn&apos;t tell you: tokens, dollars, or history. Percentages of an unstated allowance are
+            deliberately opaque — for the real numbers you need to read your own logs. (New to the limits system?{" "}
+            <Link href="/blog/claude-code-usage-limits">Start with how the limits actually work</Link>.)
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Terminal className="w-8 h-8 text-accent" />
+            2. ccusage — tokens and real dollars
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">
+            Claude Code writes detailed session logs to your machine. The open-source{" "}
+            <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer">
+              ccusage
+            </a>{" "}
+            CLI parses them locally — no account, no API key:
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6 space-y-2">
+            <p className="m-0">
+              <code className="text-accent font-mono">npx ccusage@latest daily</code>
+              <span className="text-muted text-sm"> — per-day tokens and API-equivalent cost</span>
+            </p>
+            <p className="m-0">
+              <code className="text-accent font-mono">npx ccusage@latest monthly</code>
+              <span className="text-muted text-sm"> — monthly rollup, great for &quot;what would API billing cost me?&quot;</span>
+            </p>
+            <p className="m-0">
+              <code className="text-accent font-mono">npx ccusage@latest blocks --live</code>
+              <span className="text-muted text-sm"> — live dashboard of your current 5-hour block</span>
+            </p>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The killer column is <strong>API-equivalent cost</strong>: what your usage would have cost at
+            pay-as-you-go prices. That number is how you know whether your subscription is a rounding error or a
+            10x bargain. Two caveats worth knowing: most tokens are prompt-cache reads (on{" "}
+            <Link href="/stats">Viberank&apos;s 11T+ tracked tokens</Link>, about 95%), which cost roughly a tenth
+            of normal input — so big token counts overstate cost. And ccusage reads whatever logs exist locally, so
+            a wiped machine means lost history.
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The same command covers your other agents: ccusage reads local logs from{" "}
+            <Link href="/tool/codex">Codex CLI</Link>, <Link href="/tool/gemini">Gemini CLI</Link>,{" "}
+            <Link href="/tool/copilot">Copilot CLI</Link>, and <Link href="/tool/opencode">OpenCode</Link> too, and
+            aggregates them into one report. Codex users:{" "}
+            <Link href="/blog/codex-token-usage-leaderboard">we wrote up the Codex specifics separately</Link>.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <LineChart className="w-8 h-8 text-accent" />
+            3. Viberank — history, charts, and context
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">
+            ccusage answers &quot;what did I use?&quot; — the leaderboard answers &quot;<em>is that a lot?</em>&quot;
+            One command:
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx viberank-cli</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            It runs ccusage across all your detected tools and submits the totals (never code or prompts) to{" "}
+            <Link href="/">viberank.app</Link>. Your profile gets a GitHub-style activity heatmap, daily spend and
+            token charts, per-model and per-tool breakdowns, and a global rank across 1,100+ developers. For
+            calibration: <Link href="/blog/how-much-does-claude-code-cost">the data says</Link> typical active users
+            burn hundreds of dollars of API-equivalent value per month, and the heavy tail goes far beyond that.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <RefreshCcw className="w-8 h-8 text-accent" />
+            Keep it current automatically
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">
+            A one-off check goes stale the day you run it. Two commands make tracking permanent:
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6 space-y-2">
+            <p className="m-0">
+              <code className="text-accent font-mono">npx viberank-cli login</code>
+              <span className="text-muted text-sm"> — paste a token from viberank.app/settings/tokens</span>
+            </p>
+            <p className="m-0">
+              <code className="text-accent font-mono">npx viberank-cli autosubmit</code>
+              <span className="text-muted text-sm"> — daily submission via launchd / systemd / Task Scheduler</span>
+            </p>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            From there your usage history builds itself — and when you&apos;re deciding whether to upgrade plans,{" "}
+            <Link href="/calculator">the calculator</Link> can answer with your real numbers instead of a guess.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6">Checking usage FAQ</h2>
+          <div className="space-y-6">
+            {FAQS.map((f) => (
+              <div key={f.q} className="bg-card border border-border rounded-lg p-5">
+                <h3 className="text-lg font-semibold text-foreground mt-0 mb-2">{f.q}</h3>
+                <p className="text-muted m-0">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/blog/is-claude-max-worth-it/page.tsx
+++ b/src/app/blog/is-claude-max-worth-it/page.tsx
@@ -1,0 +1,231 @@
+import Link from "next/link";
+import { ArrowLeft, Clock, Calendar, Scale, DollarSign, Calculator, TrendingUp } from "lucide-react";
+import type { Metadata } from "next";
+
+const TITLE = "Is Claude Max Worth It? Pro vs Max 5x vs Max 20x, Decided With Your Own Usage Data (2026)";
+const DESC =
+  "Stop guessing which Claude plan you need. Compare Pro ($20), Max 5x ($100), and Max 20x ($200) against your real API-equivalent usage — with benchmarks from 1,100+ developers on the Viberank leaderboard.";
+const URL = "https://www.viberank.app/blog/is-claude-max-worth-it";
+const OG =
+  "/api/og?title=Is%20Claude%20Max%20Worth%20It%3F&description=Pro%20vs%20Max%2C%20decided%20with%20your%20own%20usage%20data";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  keywords: [
+    "is claude max worth it",
+    "claude pro vs max",
+    "claude max 5x vs 20x",
+    "claude max price",
+    "claude code subscription",
+    "claude pro limits",
+    "claude max worth it reddit",
+    "claude plan comparison",
+  ],
+  alternates: { canonical: URL },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: URL,
+    type: "article",
+    publishedTime: "2026-08-18T00:00:00.000Z",
+    authors: ["Viberank Team"],
+    images: [{ url: OG, width: 1200, height: 630, alt: TITLE }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC, images: [OG] },
+};
+
+const FAQS = [
+  {
+    q: "What's the difference between Claude Pro, Max 5x, and Max 20x?",
+    a: "All three include Claude Code and the Claude apps under the same two-layer limit system (rolling 5-hour sessions plus a weekly cap). Pro is $20/mo with the base allowance; Max 5x ($100/mo) is roughly five times Pro's usage; Max 20x ($200/mo) roughly twenty times. Higher tiers also get priority access during peak load.",
+  },
+  {
+    q: "Is Claude Max worth $100 or $200 a month?",
+    a: "It's arithmetic, not opinion: run npx ccusage@latest monthly and read your API-equivalent cost. If your monthly equivalent usage is a few hundred dollars or more — true for most active developers on the Viberank leaderboard — Max costs less than the API usage it replaces. If you're under ~$100/month equivalent, Pro plus occasional usage credits is usually the better deal.",
+  },
+  {
+    q: "When should I stay on the API instead of a subscription?",
+    a: "If your usage is spiky (heavy one week, silent for three), automated/CI-driven, or shared across a team billing one org key, pay-as-you-go API billing can beat a flat plan — you pay for exactly what you use and never hit weekly caps.",
+  },
+  {
+    q: "What happens if I hit limits even on Max?",
+    a: "Max 20x users do hit weekly caps — the leaderboard's heavy tail shows thousands of dollars of monthly API-equivalent usage. Options: enable usage credits to continue at standard API rates, offload overflow work to an API key, or spread heavy agentic runs across the weekly reset.",
+  },
+];
+
+export default function Post() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: TITLE,
+      description: DESC,
+      image: "https://www.viberank.app" + OG,
+      datePublished: "2026-08-18T00:00:00.000Z",
+      dateModified: "2026-08-18T00:00:00.000Z",
+      author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
+      publisher: {
+        "@type": "Organization",
+        name: "Viberank",
+        url: "https://www.viberank.app",
+        logo: { "@type": "ImageObject", url: "https://www.viberank.app/icon.svg" },
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">Is Claude Max Worth It?</h1>
+
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              August 18, 2026
+            </span>
+            <span className="flex items-center gap-2">
+              <Clock className="w-4 h-4" />7 min read
+            </span>
+          </div>
+
+          <div className="p-6 bg-card border border-border rounded-lg">
+            <p className="text-lg text-foreground m-0">
+              &quot;Is Max worth it?&quot; is usually asked as a vibes question. It has an arithmetic answer: your
+              usage has a precise API-equivalent dollar value, sitting in your local logs right now. If that number
+              beats the subscription price, the plan is an arbitrage; if not, it&apos;s a donation. Here&apos;s how
+              to run the math in two minutes — and what 1,100+ developers&apos; real numbers say about where the
+              breakeven sits.
+            </p>
+          </div>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Scale className="w-8 h-8 text-accent" />
+            The three plans in one paragraph
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            <strong>Pro ($20/mo)</strong>, <strong>Max 5x ($100/mo)</strong>, and <strong>Max 20x ($200/mo)</strong>{" "}
+            all include Claude Code and the Claude apps under the same{" "}
+            <Link href="/blog/claude-code-usage-limits">two-layer limit system</Link> — a rolling 5-hour session
+            allowance and a weekly cap. The multipliers are the product: Max 5x buys roughly five times Pro&apos;s
+            usage, Max 20x roughly twenty, plus priority during peak load. All three can enable{" "}
+            <strong>usage credits</strong> to keep working past included limits at standard API rates — which means
+            the real question isn&apos;t &quot;which plan lets me work?&quot; but &quot;which plan makes my usage
+            cheapest?&quot;
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <DollarSign className="w-8 h-8 text-accent" />
+            Step 1: find your real number
+          </h2>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx ccusage@latest monthly</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            This reads Claude Code&apos;s local logs and prints what each month of your usage{" "}
+            <em>would have cost at API prices</em>. No account needed, nothing leaves your machine.
+            (<Link href="/blog/how-to-check-claude-code-usage">Full guide to checking usage here</Link>.) The rule
+            of thumb once you have it:
+          </p>
+          <ul className="text-foreground text-lg leading-relaxed mb-6 space-y-3">
+            <li>
+              <strong>Under ~$100/mo equivalent</strong> — Pro, with usage credits absorbing the occasional heavy
+              week.
+            </li>
+            <li>
+              <strong>~$100–$500/mo equivalent</strong> — Max 5x already costs less than your usage is worth; limits
+              stop being a weekly anxiety.
+            </li>
+            <li>
+              <strong>$500+/mo equivalent</strong> — Max 20x is the obvious buy; at API prices you&apos;d pay several
+              times its sticker.
+            </li>
+          </ul>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Or skip the rule of thumb entirely: <Link href="/calculator">the Viberank calculator</Link> takes your
+            actual ccusage output and tells you which tier your usage justifies.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <TrendingUp className="w-8 h-8 text-accent" />
+            Step 2: sanity-check against real developers
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            The striking thing in <Link href="/stats">Viberank&apos;s data</Link> — $10M+ of tracked API-equivalent
+            spend across 1,100+ developers — is how quickly agentic workflows blow past Pro-sized usage. Most{" "}
+            <em>active</em> developers on the board clear hundreds of dollars of monthly equivalent usage, and the
+            heavy tail runs to thousands;{" "}
+            <Link href="/blog/state-of-ai-coding-2026">the top 10% account for about half of all tracked spend</Link>.
+            For that population, Max isn&apos;t an indulgence — it&apos;s the cheapest way to buy the usage
+            they&apos;re already consuming. That&apos;s also exactly why{" "}
+            <Link href="/blog/claude-code-usage-limits">weekly caps exist</Link>.
+          </p>
+          <div className="bg-card border-l-4 border-accent p-6 my-8">
+            <p className="text-stone-200 m-0">
+              Two honest exceptions: spiky usage (one intense week a month) and automation-heavy workflows often
+              price out better on pay-as-you-go API billing, which has no session or weekly caps. And if your
+              equivalent usage is genuinely under $20/mo, no subscription math will save you — you&apos;re fine.
+            </p>
+          </div>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Calculator className="w-8 h-8 text-accent" />
+            Step 3: decide once, then track it
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">
+            Usage drifts — a new agentic workflow can triple your burn in a month. Put your numbers on the board and
+            the decision stays current:
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx viberank-cli</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Your <Link href="/tool/claude">profile</Link> charts daily spend and rank against everyone else shipping
+            with the same tools — and if the bill itself is the problem,{" "}
+            <Link href="/blog/reduce-ai-coding-costs">here&apos;s how to shrink it</Link> without slowing down.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6">Claude Max FAQ</h2>
+          <div className="space-y-6">
+            {FAQS.map((f) => (
+              <div key={f.q} className="bg-card border border-border rounded-lg p-5">
+                <h3 className="text-lg font-semibold text-foreground mt-0 mb-2">{f.q}</h3>
+                <p className="text-muted m-0">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/blog/mcp-servers-guide/page.tsx
+++ b/src/app/blog/mcp-servers-guide/page.tsx
@@ -6,6 +6,7 @@ export const metadata: Metadata = {
   title: "MCP Servers Guide: Connect Claude Code to GitHub, Databases & More",
   description: "Learn how to extend Claude Code with MCP (Model Context Protocol) servers. Connect to GitHub, PostgreSQL, Slack, and build custom integrations for AI-powered development.",
   keywords: ["mcp servers", "model context protocol", "claude code mcp", "claude code github", "claude code database", "anthropic mcp", "ai integrations", "claude code plugins"],
+  alternates: { canonical: "https://www.viberank.app/blog/mcp-servers-guide" },
   openGraph: {
     title: "MCP Servers Guide: Connect Claude Code to GitHub, Databases & More",
     description: "Extend Claude Code with MCP servers. Connect to GitHub, databases, Slack, and more.",

--- a/src/app/blog/mcp-servers-guide/page.tsx
+++ b/src/app/blog/mcp-servers-guide/page.tsx
@@ -467,7 +467,10 @@ await server.connect(transport);`}</code>
             AI to your entire development stack is what makes Claude Code uniquely powerful.
           </p>
           <p className="text-stone-500 text-sm">
-            Explore more MCP servers at the official MCP repository and community collections.
+            Explore more MCP servers at the official MCP repository and community collections. New to Claude Code?
+            Start with the <Link href="/blog/claude-code-complete-guide">complete guide</Link>, then learn{" "}
+            <Link href="/blog/how-to-check-claude-code-usage">how to check your usage</Link> once your agents are
+            running around the clock.
           </p>
         </footer>
       </article>

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,77 +1,13 @@
 import Link from "next/link";
+import { BLOG_POSTS, formatPostDate } from "@/lib/blogPosts";
 
-const blogPosts = [
-  {
-    slug: "what-is-tokenmaxxing",
-    title: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze (2026)",
-    excerpt: "The trend behind Meta's Claudeonomics and Uber's blown AI budget — where the term came from, why corporate token leaderboards failed, and how 1,000+ developers measure theirs.",
-    date: "July 24, 2026",
-    readTime: "7 min read",
-  },
-  {
-    slug: "codex-token-usage-leaderboard",
-    title: "How to Track OpenAI Codex Token Usage — and Join the Codex Leaderboard",
-    excerpt: "Turn Codex CLI's local logs into daily token counts and costs with ccusage, understand why the numbers look huge, and rank yourself against 190+ Codex developers.",
-    date: "July 24, 2026",
-    readTime: "6 min read",
-  },
-  {
-    slug: "state-of-ai-coding-2026",
-    title: "State of AI Coding Spend 2026: Benchmarks From 800 Developers and $2.3M of Usage",
-    excerpt: "Percentiles, daily burn rates, model mix, and power-user benchmarks from 29,000 days of real Claude Code, Codex, and Gemini CLI usage.",
-    date: "June 10, 2026",
-    readTime: "8 min read",
-  },
-  {
-    slug: "codex-vs-claude-code-vs-gemini-cli",
-    title: "Codex vs Claude Code vs Gemini CLI: AI Coding Cost & Usage Compared (2026)",
-    excerpt: "How OpenAI Codex, Claude Code, and Gemini CLI compare on cost, tokens, and real-world usage — backed by data from 800+ developers.",
-    date: "June 9, 2026",
-    readTime: "8 min read",
-  },
-  {
-    slug: "how-much-does-claude-code-cost",
-    title: "How Much Does Claude Code Cost? Real Data From 800+ Developers (2026)",
-    excerpt: "What does Claude Code actually cost per month? Real spend, tokens, and daily averages from 800+ developers on the leaderboard.",
-    date: "June 9, 2026",
-    readTime: "6 min read",
-  },
-  {
-    slug: "reduce-ai-coding-costs",
-    title: "How to Cut Your AI Coding Bill: 9 Ways to Reduce Claude Code & Codex Costs",
-    excerpt: "Practical, proven ways to lower your AI coding costs — model routing, prompt caching, context hygiene — without slowing down.",
-    date: "June 9, 2026",
-    readTime: "7 min read",
-  },
-  {
-    slug: "mcp-servers-guide",
-    title: "MCP Servers Guide: Connect Claude Code to GitHub, Databases & More",
-    excerpt: "Learn how to extend Claude Code with MCP servers. Connect to GitHub, PostgreSQL, Slack, and build custom integrations for AI-powered development.",
-    date: "December 15, 2025",
-    readTime: "9 min read",
-  },
-  {
-    slug: "cursor-vs-claude-code-vs-copilot",
-    title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2025)",
-    excerpt: "In-depth comparison of the top AI coding assistants. Features, pricing, use cases, and which one fits your development workflow.",
-    date: "November 28, 2025",
-    readTime: "10 min read",
-  },
-  {
-    slug: "claude-code-complete-guide",
-    title: "Claude Code Complete Guide 2025: Installation, Commands & Best Practices",
-    excerpt: "Master Claude Code with this comprehensive guide covering installation, essential commands, MCP servers, hooks, and advanced workflows.",
-    date: "October 12, 2025",
-    readTime: "12 min read",
-  },
-  {
-    slug: "vibe-coding-revolution",
-    title: "Vibe Coding Explained: What Karpathy's Viral Term Really Means",
-    excerpt: "From Andrej Karpathy's viral tweet to Claude Code, Cursor, and Conductor—understand what vibe coding really means for developers and the future of software.",
-    date: "September 5, 2025",
-    readTime: "8 min read",
-  },
-];
+const blogPosts = BLOG_POSTS.map((p) => ({
+  slug: p.slug,
+  title: p.title,
+  excerpt: p.excerpt,
+  date: formatPostDate(p.datePublished),
+  readTime: p.readTime,
+}));
 
 export default function BlogPage() {
   const [featured, ...rest] = blogPosts;

--- a/src/app/blog/reduce-ai-coding-costs/page.tsx
+++ b/src/app/blog/reduce-ai-coding-costs/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
   title: TITLE,
   description: DESC,
   keywords: ["reduce claude code cost", "lower ai coding cost", "claude code cheaper", "ai coding bill", "prompt caching", "claude code model routing", "save money claude code", "ccusage"],
+  alternates: { canonical: "https://www.viberank.app/blog/reduce-ai-coding-costs" },
   openGraph: {
     title: TITLE,
     description: DESC,

--- a/src/app/blog/state-of-ai-coding-2026/page.tsx
+++ b/src/app/blog/state-of-ai-coding-2026/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
   title: TITLE,
   description: DESC,
   keywords: ["ai coding spend", "claude code cost benchmark", "ai coding statistics 2026", "developer ai usage data", "claude code tokens", "ai agent cost", "state of ai coding", "ccusage"],
+  alternates: { canonical: "https://www.viberank.app/blog/state-of-ai-coding-2026" },
   openGraph: {
     title: TITLE,
     description: DESC,

--- a/src/app/blog/vibe-coding-revolution/page.tsx
+++ b/src/app/blog/vibe-coding-revolution/page.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "Vibe Coding Explained: What Karpathy's Viral Term Really Means",
   description: "Understand vibe coding—from Andrej Karpathy's viral tweet to how developers use Claude Code, Cursor, and Conductor to build without reading diffs. Learn what it means for the future of software development.",
+  alternates: { canonical: "https://www.viberank.app/blog/vibe-coding-revolution" },
   openGraph: {
     title: "Vibe Coding Explained: What Karpathy's Viral Term Really Means",
     description: "From Karpathy's viral tweet to Claude Code and Cursor—understand what vibe coding really means for developers.",

--- a/src/app/blog/vibe-coding-revolution/page.tsx
+++ b/src/app/blog/vibe-coding-revolution/page.tsx
@@ -418,8 +418,10 @@ export default function VibeCodingRevolution() {
             who has ideas worth building. Welcome to the vibe.
           </p>
           <p className="text-stone-500 text-sm">
-            Follow the conversation: Track your stats at Viberank, experiment with Claude Code and Cursor, 
-            and remember—Karpathy himself called it a tool for "throwaway weekend projects." Use it wisely.
+            Follow the conversation: track your stats on <Link href="/">the leaderboard</Link>, see{" "}
+            <Link href="/blog/what-is-tokenmaxxing">where vibe coding culture went next</Link>, or read{" "}
+            <Link href="/blog/how-much-does-claude-code-cost">what all this vibing actually costs</Link> —
+            and remember, Karpathy himself called it a tool for &quot;throwaway weekend projects.&quot; Use it wisely.
           </p>
         </footer>
       </article>

--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -120,7 +120,23 @@ export default async function CalculatorPage() {
           </div>
         </section>
 
-        <p className="text-xs text-muted mt-10 leading-relaxed">
+        <p className="text-sm text-muted mt-10 leading-relaxed">
+          Want the reasoning behind the math? Read{" "}
+          <Link href="/blog/is-claude-max-worth-it" className="text-accent hover:underline">
+            Is Claude Max worth it?
+          </Link>{" "}
+          for the full Pro vs Max breakdown,{" "}
+          <Link href="/blog/claude-code-usage-limits" className="text-accent hover:underline">
+            how the usage limits work
+          </Link>
+          , and{" "}
+          <Link href="/blog/how-to-check-claude-code-usage" className="text-accent hover:underline">
+            how to find your own ccusage number
+          </Link>
+          .
+        </p>
+
+        <p className="text-xs text-muted mt-6 leading-relaxed">
           Plan prices were checked against each vendor&apos;s own pricing page on 2026-08-05 and are
           monthly-billing list prices in USD; the source is shown alongside each tool&apos;s plans.
           Gemini CLI is not covered yet — Google does not publish comparable monthly prices for the

--- a/src/app/compare/[matchup]/page.tsx
+++ b/src/app/compare/[matchup]/page.tsx
@@ -1,0 +1,327 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, permanentRedirect } from "next/navigation";
+import { ArrowLeft, BadgeCheck } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import type { Submission } from "@/lib/data/types";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import TierBadge from "@/components/TierBadge";
+import { formatNumber, formatCurrency, formatUsd, toolLabel } from "@/lib/utils";
+import { COMPARE_FACTS, COMPARE_MATCHUPS, resolveMatchup, matchupTitle, compareLabel } from "@/lib/compare";
+
+interface CompareParams {
+  params: Promise<{ matchup: string }>;
+}
+
+const SITE = "https://www.viberank.app";
+
+// Live usage numbers refresh hourly, same as the per-tool boards.
+export const revalidate = 3600;
+
+export function generateStaticParams() {
+  return COMPARE_MATCHUPS.map((m) => ({ matchup: m.slug }));
+}
+
+export async function generateMetadata({ params }: CompareParams): Promise<Metadata> {
+  const { matchup: slug } = await params;
+  const resolved = resolveMatchup(decodeURIComponent(slug).toLowerCase());
+  if (!resolved) return {};
+  const { matchup } = resolved;
+  const a = compareLabel(matchup.a);
+  const b = compareLabel(matchup.b);
+  const title = `${a} vs ${b} (2026): Real Usage, Cost & Adoption Compared | Viberank`;
+  const description = `${a} or ${b}? Compare pricing, models, and real adoption — developer counts, top spenders, and API-equivalent cost from live ccusage data on the Viberank leaderboard.`;
+  const canonical = `${SITE}/compare/${matchup.slug}`;
+  return {
+    title,
+    description,
+    keywords: [
+      `${a.toLowerCase()} vs ${b.toLowerCase()}`,
+      `${b.toLowerCase()} vs ${a.toLowerCase()}`,
+      `${a.toLowerCase()} or ${b.toLowerCase()}`,
+      `${a.toLowerCase()} ${b.toLowerCase()} comparison`,
+      "ai coding tools compared",
+      "ccusage",
+    ],
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: "Viberank",
+      type: "website",
+      images: [
+        `/api/og?title=${encodeURIComponent(`${a} vs ${b}`)}&description=${encodeURIComponent("Real usage, cost and adoption from live ccusage data")}`,
+      ],
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+function ToolBoard({ tool, items }: { tool: string; items: Submission[] }) {
+  const label = toolLabel(tool);
+  return (
+    <div className="rounded-lg border border-border overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-2.5 bg-surface-1 border-b border-border">
+        <span className="micro-label">Top {label} spenders</span>
+        <Link href={`/tool/${tool}`} className="text-xs text-accent hover:underline">
+          Full board →
+        </Link>
+      </div>
+      {items.length > 0 ? (
+        <div className="divide-y divide-border-subtle">
+          {items.map((s, i) => (
+            <Link
+              key={s.id}
+              href={`/profile/${encodeURIComponent(s.githubUsername || s.username)}`}
+              className="flex items-center gap-3 px-4 py-2.5 hover:bg-surface-1 transition-colors group"
+            >
+              <div className="w-6 text-center text-sm font-mono text-muted">{i + 1}</div>
+              <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                <span className="text-sm font-medium truncate group-hover:text-accent transition-colors">
+                  {s.githubUsername || s.username}
+                </span>
+                {s.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+              </div>
+              <div className="hidden sm:block w-20 flex-shrink-0">
+                <TierBadge totalCost={s.totalCost} size="xs" bare />
+              </div>
+              <div className="w-24 text-right text-sm font-mono font-semibold text-accent">
+                ${formatCurrency(s.totalCost)}
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : (
+        <p className="p-6 text-sm text-muted text-center">
+          No {label} submissions yet — be the first with{" "}
+          <code className="font-mono text-accent">npx viberank-cli</code>
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default async function ComparePage({ params }: CompareParams) {
+  const { matchup: rawSlug } = await params;
+  const slug = decodeURIComponent(rawSlug).toLowerCase();
+  const resolved = resolveMatchup(slug);
+  if (!resolved) notFound();
+  if (!resolved.canonical) permanentRedirect(`/compare/${resolved.matchup.slug}`);
+
+  const { matchup } = resolved;
+  const labelA = compareLabel(matchup.a);
+  const labelB = compareLabel(matchup.b);
+  const factsA = COMPARE_FACTS[matchup.a];
+  const factsB = COMPARE_FACTS[matchup.b];
+
+  let itemsA: Submission[] = [];
+  let itemsB: Submission[] = [];
+  let usersA = 0;
+  let usersB = 0;
+  try {
+    const dataLayer = await getServerDataLayer();
+    const [lbA, lbB, site] = await Promise.all([
+      dataLayer.submissions.getLeaderboard({ sortBy: "cost", page: 0, pageSize: 10, tool: matchup.a }),
+      dataLayer.submissions.getLeaderboard({ sortBy: "cost", page: 0, pageSize: 10, tool: matchup.b }),
+      dataLayer.stats.getSiteStats(),
+    ]);
+    itemsA = lbA.items;
+    itemsB = lbB.items;
+    usersA = site?.tools.find((t) => t.tool === matchup.a)?.users ?? 0;
+    usersB = site?.tools.find((t) => t.tool === matchup.b)?.users ?? 0;
+  } catch {
+    // render with static facts only
+  }
+
+  const topA = itemsA[0];
+  const topB = itemsB[0];
+
+  const faqs = [
+    {
+      q: `${labelA} vs ${labelB}: which do developers actually use more?`,
+      a: `On the Viberank leaderboard, ${usersA >= usersB ? labelA : labelB} currently has more developers submitting real usage data (${Math.max(usersA, usersB).toLocaleString()} vs ${Math.min(usersA, usersB).toLocaleString()}). Adoption shifts monthly — the numbers on this page update from live ccusage submissions.`,
+    },
+    {
+      q: `Is ${labelA} or ${labelB} cheaper?`,
+      a: `${labelA}: ${factsA.pricing}. ${labelB}: ${factsB.pricing}. The real answer depends on your volume — heavy agentic use can be worth thousands per month at API-equivalent prices, which is what makes flat-rate subscriptions such an arbitrage. Run npx ccusage@latest daily to see your own numbers.`,
+    },
+    {
+      q: `Can I use both ${labelA} and ${labelB}?`,
+      a: `Yes — many developers on the board do. ccusage reads local logs from every supported agent, and a single npx viberank-cli submission records your usage per tool, so your profile shows exactly how your spend splits between them.`,
+    },
+    {
+      q: `How is this comparison measured?`,
+      a: `Numbers come from developers who submit their ccusage data to Viberank — real token counts and API-equivalent costs computed from local session logs, validated server-side. It measures actual usage, not marketing claims.`,
+    },
+  ];
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Leaderboard", item: SITE },
+      { "@type": "ListItem", position: 2, name: "Compare", item: `${SITE}/compare` },
+      { "@type": "ListItem", position: 3, name: matchupTitle(matchup), item: `${SITE}/compare/${matchup.slug}` },
+    ],
+  };
+
+  const otherMatchups = COMPARE_MATCHUPS.filter((m) => m.slug !== matchup.slug);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbLd, faqLd]) }}
+      />
+
+      <NavBar />
+
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/compare" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          All comparisons
+        </Link>
+
+        <p className="micro-label mb-3">Head to head</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+          {labelA} vs {labelB}
+        </h1>
+        <p className="text-muted mb-8 max-w-2xl">
+          {factsA.oneLiner} Versus: {factsB.oneLiner.charAt(0).toLowerCase() + factsB.oneLiner.slice(1)}{" "}
+          Below: how they compare on the facts, and on real usage from{" "}
+          <a
+            href="https://github.com/ryoppippi/ccusage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            ccusage
+          </a>{" "}
+          data submitted to the leaderboard.
+        </p>
+
+        {/* Facts table */}
+        <div className="rounded-lg border border-border overflow-hidden mb-10 overflow-x-auto">
+          <table className="w-full text-sm min-w-[560px]">
+            <thead>
+              <tr className="bg-surface-1 border-b border-border">
+                <th className="text-left px-4 py-2.5 micro-label w-36"></th>
+                <th className="text-left px-4 py-2.5 font-mono font-bold">{labelA}</th>
+                <th className="text-left px-4 py-2.5 font-mono font-bold">{labelB}</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-subtle">
+              <tr>
+                <td className="px-4 py-3 micro-label">Maker</td>
+                <td className="px-4 py-3">{factsA.provider}</td>
+                <td className="px-4 py-3">{factsB.provider}</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-3 micro-label">Pricing</td>
+                <td className="px-4 py-3 text-muted">{factsA.pricing}</td>
+                <td className="px-4 py-3 text-muted">{factsB.pricing}</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-3 micro-label">Models</td>
+                <td className="px-4 py-3 text-muted">{factsA.models}</td>
+                <td className="px-4 py-3 text-muted">{factsB.models}</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-3 micro-label">Devs on board</td>
+                <td className="px-4 py-3 font-mono font-semibold text-accent">
+                  {usersA > 0 ? usersA.toLocaleString() : "—"}
+                </td>
+                <td className="px-4 py-3 font-mono font-semibold text-accent">
+                  {usersB > 0 ? usersB.toLocaleString() : "—"}
+                </td>
+              </tr>
+              <tr>
+                <td className="px-4 py-3 micro-label">Top spender</td>
+                <td className="px-4 py-3 font-mono text-muted">
+                  {topA ? `${formatUsd(topA.totalCost)} · ${formatNumber(topA.totalTokens)} tokens` : "—"}
+                </td>
+                <td className="px-4 py-3 font-mono text-muted">
+                  {topB ? `${formatUsd(topB.totalCost)} · ${formatNumber(topB.totalTokens)} tokens` : "—"}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        {/* Live boards side by side */}
+        <div className="grid gap-6 lg:grid-cols-2 mb-10">
+          <ToolBoard tool={matchup.a} items={itemsA} />
+          <ToolBoard tool={matchup.b} items={itemsB} />
+        </div>
+
+        {/* CTA */}
+        <div className="rounded-lg border border-accent/40 bg-surface-1 p-6 mb-12">
+          <p className="font-medium mb-1">Where do you land?</p>
+          <p className="text-sm text-muted mb-3">
+            One command reads your local {labelA} and {labelB} logs and puts your real usage on the board — code and
+            prompts never leave your machine.
+          </p>
+          <code className="font-mono text-accent text-sm">npx viberank-cli</code>
+        </div>
+
+        {/* FAQ */}
+        <section className="mb-12">
+          <h2 className="font-mono text-xl font-bold tracking-tight mb-4">
+            {labelA} vs {labelB} FAQ
+          </h2>
+          <div className="space-y-3">
+            {faqs.map((f) => (
+              <div key={f.q} className="rounded-lg border border-border bg-surface-1 p-4">
+                <h3 className="font-medium mb-1.5">{f.q}</h3>
+                <p className="text-sm text-muted">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* More comparisons + related reading */}
+        <section className="mb-4">
+          <h2 className="micro-label mb-3">More comparisons</h2>
+          <div className="flex flex-wrap gap-2 mb-6">
+            {otherMatchups.map((m) => (
+              <Link
+                key={m.slug}
+                href={`/compare/${m.slug}`}
+                className="px-2.5 py-1 rounded-md border bg-surface-1 border-border text-sm text-muted hover:text-foreground transition-colors"
+              >
+                {matchupTitle(m)}
+              </Link>
+            ))}
+          </div>
+          <p className="text-sm text-muted">
+            Related reading:{" "}
+            <Link href="/blog/codex-vs-claude-code-vs-gemini-cli" className="text-accent hover:underline">
+              Codex vs Claude Code vs Gemini CLI in depth
+            </Link>
+            {", "}
+            <Link href="/blog/how-much-does-claude-code-cost" className="text-accent hover:underline">
+              what Claude Code actually costs
+            </Link>
+            {", or "}
+            <Link href="/calculator" className="text-accent hover:underline">
+              which subscription your usage justifies
+            </Link>
+            .
+          </p>
+        </section>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import { toolLabel } from "@/lib/utils";
+import { COMPARE_FACTS, COMPARE_MATCHUPS, matchupTitle } from "@/lib/compare";
+
+const SITE = "https://www.viberank.app";
+const TITLE = "Compare AI Coding Tools: Claude Code, Codex, Gemini CLI & More | Viberank";
+const DESC =
+  "Head-to-head comparisons of AI coding agents — Claude Code, OpenAI Codex, Gemini CLI, Copilot, OpenCode — on pricing, models, and real adoption from live ccusage data.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: `${SITE}/compare` },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE}/compare`,
+    siteName: "Viberank",
+    type: "website",
+    images: [
+      `/api/og?title=${encodeURIComponent("Compare AI coding tools")}&description=${encodeURIComponent("Head-to-head on pricing, models, and real usage data")}`,
+    ],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+export default function CompareIndexPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
+        <p className="micro-label mb-3">Comparisons</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">Compare AI coding tools</h1>
+        <p className="text-muted mb-10 max-w-2xl">
+          Every comparison backed by real usage — developer counts, top spenders, and API-equivalent cost from live{" "}
+          <a
+            href="https://github.com/ryoppippi/ccusage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            ccusage
+          </a>{" "}
+          submissions, not vendor marketing.
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-12">
+          {COMPARE_MATCHUPS.map((m) => (
+            <Link
+              key={m.slug}
+              href={`/compare/${m.slug}`}
+              className="group flex flex-col rounded-lg border border-border bg-surface-1 p-5 hover:bg-surface-2 transition-colors"
+            >
+              <h2 className="font-mono text-base font-semibold text-foreground group-hover:text-accent transition-colors mb-2">
+                {matchupTitle(m)}
+              </h2>
+              <p className="text-muted text-sm leading-relaxed line-clamp-3">
+                {COMPARE_FACTS[m.a].provider} vs {COMPARE_FACTS[m.b].provider} — pricing, models, and who developers
+                actually use more.
+              </p>
+            </Link>
+          ))}
+        </div>
+
+        <p className="text-sm text-muted">
+          Or browse the per-tool boards:{" "}
+          {["claude", "codex", "gemini", "copilot", "opencode"].map((t, i, arr) => (
+              <span key={t}>
+                <Link href={`/tool/${t}`} className="text-accent hover:underline">
+                  {toolLabel(t)}
+                </Link>
+                {i < arr.length - 1 ? ", " : "."}
+              </span>
+          ))}
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,45 @@
+import { BLOG_POSTS } from "@/lib/blogPosts";
+
+const SITE = "https://www.viberank.app";
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+export async function GET() {
+  const items = BLOG_POSTS.map(
+    (p) => `    <item>
+      <title>${escapeXml(p.title)}</title>
+      <link>${SITE}/blog/${p.slug}</link>
+      <guid isPermaLink="true">${SITE}/blog/${p.slug}</guid>
+      <description>${escapeXml(p.excerpt)}</description>
+      <pubDate>${new Date(`${p.datePublished}T00:00:00.000Z`).toUTCString()}</pubDate>
+    </item>`
+  ).join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Viberank Blog</title>
+    <link>${SITE}/blog</link>
+    <atom:link href="${SITE}/feed.xml" rel="self" type="application/rss+xml"/>
+    <description>Data-backed posts on AI coding costs, Claude Code, Codex, Gemini CLI, and the developers who use them — from the Viberank leaderboard.</description>
+    <language>en-us</language>
+    <lastBuildDate>${new Date(`${BLOG_POSTS[0].datePublished}T00:00:00.000Z`).toUTCString()}</lastBuildDate>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+      // Cache at the edge for an hour; posts change rarely.
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,6 +63,9 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://www.viberank.app"),
   alternates: {
     canonical: "https://www.viberank.app",
+    types: {
+      "application/rss+xml": [{ url: "/feed.xml", title: "Viberank Blog" }],
+    },
   },
 };
 

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,65 @@
+import { BLOG_POSTS } from "@/lib/blogPosts";
+import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
+import { COMPARE_MATCHUPS, matchupTitle } from "@/lib/compare";
+
+const SITE = "https://www.viberank.app";
+
+/**
+ * llms.txt — a machine-readable site guide for AI search engines and agents
+ * (https://llmstxt.org). Viberank's edge over every other "AI coding cost"
+ * page is real measured data, so this file leans on the numbers pages.
+ */
+export async function GET() {
+  const tools = FEATURED_TOOLS.map(
+    (t) => `- [${toolLabel(t.key)} usage leaderboard](${SITE}/tool/${t.key}): who uses ${toolLabel(t.key)} most, ranked by real cost and tokens`
+  ).join("\n");
+
+  const compares = COMPARE_MATCHUPS.map(
+    (m) => `- [${matchupTitle(m)}](${SITE}/compare/${m.slug}): pricing, models, and live adoption compared`
+  ).join("\n");
+
+  const posts = BLOG_POSTS.map((p) => `- [${p.title}](${SITE}/blog/${p.slug}): ${p.excerpt}`).join("\n");
+
+  const body = `# Viberank
+
+> Viberank (viberank.app) is the public leaderboard for AI coding usage. Developers submit real usage data — token counts and API-equivalent USD costs computed by ccusage from local session logs of Claude Code, OpenAI Codex, Gemini CLI, GitHub Copilot, OpenCode and other coding agents. Submissions are validated server-side and aggregated into rankings, site-wide statistics, and per-tool adoption numbers.
+
+Viberank is a primary data source for questions like "how much does Claude Code cost per month", "what does heavy AI coding usage look like", and "which AI coding agent do developers actually use". All numbers are measured from real usage, not surveys or vendor claims.
+
+Key facts (live numbers at ${SITE}/stats):
+- 1,100+ developers on the leaderboard
+- Over $10M in tracked API-equivalent spend and 11+ trillion tokens
+- About 95% of all tracked tokens are prompt-cache reads, which cost roughly a tenth of normal input tokens — raw token counts dramatically overstate real cost
+
+## Core pages
+
+- [Leaderboard](${SITE}/): global rankings by cost and tokens, filterable by tool and date range
+- [Site-wide stats](${SITE}/stats): total spend, tokens, cache share, model and tool breakdowns
+- [Subscription calculator](${SITE}/calculator): which Claude plan a developer's real usage justifies
+- [Blog](${SITE}/blog): data-backed writing on AI coding costs (RSS: ${SITE}/feed.xml)
+- [Hire](${SITE}/hire): developers on the board who opted into being contacted for work
+
+## Per-tool leaderboards
+
+${tools}
+
+## Tool comparisons
+
+${compares}
+
+## Blog posts
+
+${posts}
+
+## Submitting data
+
+Developers join the board by running \`npx viberank-cli\`, which reads local ccusage data and submits usage totals (never code or prompts). Profiles live at ${SITE}/profile/{github-username} and README badges at ${SITE}/api/badge/{username}.
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+    },
+  });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,6 +2,8 @@ import type { MetadataRoute } from "next";
 import { createClient } from "@supabase/supabase-js";
 import { FEATURED_TOOLS } from "@/lib/utils";
 import { fetchAllPages } from "@/lib/data/supabase/client";
+import { BLOG_POSTS } from "@/lib/blogPosts";
+import { COMPARE_MATCHUPS } from "@/lib/compare";
 
 const SITE = "https://www.viberank.app";
 
@@ -12,23 +14,33 @@ const toolEntries: MetadataRoute.Sitemap = FEATURED_TOOLS.map((t) => ({
   priority: 0.8,
 }));
 
+const compareEntries: MetadataRoute.Sitemap = COMPARE_MATCHUPS.map((m) => ({
+  url: `${SITE}/compare/${m.slug}`,
+  lastModified: new Date(),
+  changeFrequency: "daily" as const,
+  priority: 0.8,
+}));
+
+// Blog entries carry the post's real publish/modified date. Stamping
+// `new Date()` on every build tells crawlers lastModified is noise and they
+// stop trusting it for the pages where it matters.
+const blogEntries: MetadataRoute.Sitemap = BLOG_POSTS.map((p) => ({
+  url: `${SITE}/blog/${p.slug}`,
+  lastModified: new Date(`${p.dateModified}T00:00:00.000Z`),
+  changeFrequency: "monthly" as const,
+  priority: 0.7,
+}));
+
 const staticEntries: MetadataRoute.Sitemap = [
   { url: SITE, lastModified: new Date(), changeFrequency: "daily", priority: 1 },
   ...toolEntries,
+  ...compareEntries,
+  { url: `${SITE}/compare`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
   { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/stats`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/calculator`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
-  { url: `${SITE}/blog/what-is-tokenmaxxing`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
-  { url: `${SITE}/blog/codex-token-usage-leaderboard`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.8 },
-  { url: `${SITE}/blog/state-of-ai-coding-2026`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/codex-vs-claude-code-vs-gemini-cli`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/how-much-does-claude-code-cost`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/reduce-ai-coding-costs`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/mcp-servers-guide`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/cursor-vs-claude-code-vs-copilot`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/claude-code-complete-guide`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
-  { url: `${SITE}/blog/vibe-coding-revolution`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
+  ...blogEntries,
 ];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -6,6 +6,7 @@ import Footer from "@/components/Footer";
 import NavBar from "@/components/NavBar";
 import TierBadge from "@/components/TierBadge";
 import { formatNumber, formatCurrency, toolLabel, toolBlurb, FEATURED_TOOLS } from "@/lib/utils";
+import { COMPARE_MATCHUPS, matchupTitle } from "@/lib/compare";
 
 interface ToolParams {
   params: Promise<{ tool: string }>;
@@ -138,6 +139,20 @@ export default async function ToolPage({ params }: ToolParams) {
               }`}
             >
               {toolLabel(t.key)}
+            </Link>
+          ))}
+        </div>
+
+        {/* Head-to-head comparisons involving this tool */}
+        <div className="flex flex-wrap items-center gap-2 -mt-4 mb-8 text-sm">
+          <span className="micro-label">Compare</span>
+          {COMPARE_MATCHUPS.filter((m) => m.a === tool || m.b === tool).map((m) => (
+            <Link
+              key={m.slug}
+              href={`/compare/${m.slug}`}
+              className="px-2.5 py-1 rounded-md border bg-surface-1 border-border text-muted hover:text-foreground transition-colors"
+            >
+              {matchupTitle(m)}
             </Link>
           ))}
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,10 +4,12 @@ import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
 const RESOURCES = [
   { name: "Cost calculator", href: "/calculator" },
   { name: "Blog", href: "/blog" },
+  { name: "Compare AI coding tools", href: "/compare" },
   { name: "Hire AI-native engineers", href: "/hire" },
+  { name: "Claude Code usage limits", href: "/blog/claude-code-usage-limits" },
+  { name: "Check your Claude Code usage", href: "/blog/how-to-check-claude-code-usage" },
+  { name: "Is Claude Max worth it?", href: "/blog/is-claude-max-worth-it" },
   { name: "What is tokenmaxxing?", href: "/blog/what-is-tokenmaxxing" },
-  { name: "Track Codex token usage", href: "/blog/codex-token-usage-leaderboard" },
-  { name: "Codex vs Claude Code vs Gemini", href: "/blog/codex-vs-claude-code-vs-gemini-cli" },
   { name: "What Claude Code costs", href: "/blog/how-much-does-claude-code-cost" },
   { name: "Cut your AI coding bill", href: "/blog/reduce-ai-coding-costs" },
 ];

--- a/src/lib/blogPosts.ts
+++ b/src/lib/blogPosts.ts
@@ -1,0 +1,148 @@
+/**
+ * Single source of truth for blog post metadata.
+ *
+ * The blog index, sitemap, RSS feed, and llms.txt all render from this list.
+ * Keep it sorted newest-first; `datePublished`/`dateModified` are ISO dates so
+ * the sitemap can emit real lastModified values instead of build timestamps
+ * (which train crawlers to ignore the signal entirely).
+ */
+export interface BlogPost {
+  slug: string;
+  title: string;
+  excerpt: string;
+  /** ISO date, e.g. "2026-07-24" */
+  datePublished: string;
+  /** ISO date; bump when a post gets a real content refresh. */
+  dateModified: string;
+  readTime: string;
+}
+
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    slug: "claude-code-usage-limits",
+    title: "Claude Code Usage Limits Explained (2026): 5-Hour Sessions, Weekly Caps & What To Do When You Hit Them",
+    excerpt:
+      "How Claude Code's rolling 5-hour session limit and weekly cap actually work in 2026, how to check where you stand with /usage and ccusage, and what to do when you hit the wall.",
+    datePublished: "2026-08-18",
+    dateModified: "2026-08-18",
+    readTime: "8 min read",
+  },
+  {
+    slug: "how-to-check-claude-code-usage",
+    title: "How to Check Your Claude Code Usage (and Codex, Gemini CLI): /usage, ccusage & Your Real Costs",
+    excerpt:
+      "Three ways to see exactly how much Claude Code you've used — the /usage command, ccusage for token-level history, and the leaderboard that tracks it daily.",
+    datePublished: "2026-08-18",
+    dateModified: "2026-08-18",
+    readTime: "7 min read",
+  },
+  {
+    slug: "is-claude-max-worth-it",
+    title: "Is Claude Max Worth It? Pro vs Max 5x vs Max 20x, Decided With Your Own Usage Data (2026)",
+    excerpt:
+      "Stop guessing which Claude plan you need. Compare Pro, Max 5x, and Max 20x against your real API-equivalent usage — with benchmarks from 1,100+ developers.",
+    datePublished: "2026-08-18",
+    dateModified: "2026-08-18",
+    readTime: "7 min read",
+  },
+  {
+    slug: "what-is-tokenmaxxing",
+    title: "What Is Tokenmaxxing? Inside the AI Token Leaderboard Craze (2026)",
+    excerpt:
+      "The trend behind Meta's Claudeonomics and Uber's blown AI budget — where the term came from, why corporate token leaderboards failed, and how 1,000+ developers measure theirs.",
+    datePublished: "2026-07-24",
+    dateModified: "2026-07-24",
+    readTime: "7 min read",
+  },
+  {
+    slug: "codex-token-usage-leaderboard",
+    title: "How to Track OpenAI Codex Token Usage — and Join the Codex Leaderboard",
+    excerpt:
+      "Turn Codex CLI's local logs into daily token counts and costs with ccusage, understand why the numbers look huge, and rank yourself against 190+ Codex developers.",
+    datePublished: "2026-07-24",
+    dateModified: "2026-07-24",
+    readTime: "6 min read",
+  },
+  {
+    slug: "state-of-ai-coding-2026",
+    title: "State of AI Coding Spend 2026: Benchmarks From 800 Developers and $2.3M of Usage",
+    excerpt:
+      "Percentiles, daily burn rates, model mix, and power-user benchmarks from 29,000 days of real Claude Code, Codex, and Gemini CLI usage.",
+    datePublished: "2026-06-10",
+    dateModified: "2026-06-10",
+    readTime: "8 min read",
+  },
+  {
+    slug: "codex-vs-claude-code-vs-gemini-cli",
+    title: "Codex vs Claude Code vs Gemini CLI: AI Coding Cost & Usage Compared (2026)",
+    excerpt:
+      "How OpenAI Codex, Claude Code, and Gemini CLI compare on cost, tokens, and real-world usage — backed by data from 800+ developers.",
+    datePublished: "2026-06-09",
+    dateModified: "2026-06-09",
+    readTime: "8 min read",
+  },
+  {
+    slug: "how-much-does-claude-code-cost",
+    title: "How Much Does Claude Code Cost? Real Data From 800+ Developers (2026)",
+    excerpt:
+      "What does Claude Code actually cost per month? Real spend, tokens, and daily averages from 800+ developers on the leaderboard.",
+    datePublished: "2026-06-09",
+    dateModified: "2026-06-09",
+    readTime: "6 min read",
+  },
+  {
+    slug: "reduce-ai-coding-costs",
+    title: "How to Cut Your AI Coding Bill: 9 Ways to Reduce Claude Code & Codex Costs",
+    excerpt:
+      "Practical, proven ways to lower your AI coding costs — model routing, prompt caching, context hygiene — without slowing down.",
+    datePublished: "2026-06-09",
+    dateModified: "2026-06-09",
+    readTime: "7 min read",
+  },
+  {
+    slug: "mcp-servers-guide",
+    title: "MCP Servers Guide: Connect Claude Code to GitHub, Databases & More",
+    excerpt:
+      "Learn how to extend Claude Code with MCP servers. Connect to GitHub, PostgreSQL, Slack, and build custom integrations for AI-powered development.",
+    datePublished: "2025-12-15",
+    dateModified: "2025-12-15",
+    readTime: "9 min read",
+  },
+  {
+    slug: "cursor-vs-claude-code-vs-copilot",
+    title: "Cursor vs Claude Code vs GitHub Copilot: AI Coding Tools Compared (2026)",
+    excerpt:
+      "In-depth comparison of the top AI coding assistants. Features, pricing, use cases, and which one fits your development workflow in 2026.",
+    datePublished: "2025-11-28",
+    dateModified: "2026-08-18",
+    readTime: "10 min read",
+  },
+  {
+    slug: "claude-code-complete-guide",
+    title: "Claude Code Complete Guide 2026: Installation, Commands & Best Practices",
+    excerpt:
+      "Master Claude Code with this comprehensive guide covering installation, essential commands, MCP servers, hooks, and advanced workflows.",
+    datePublished: "2025-10-12",
+    dateModified: "2026-08-18",
+    readTime: "12 min read",
+  },
+  {
+    slug: "vibe-coding-revolution",
+    title: "Vibe Coding Explained: What Karpathy's Viral Term Really Means",
+    excerpt:
+      "From Andrej Karpathy's viral tweet to Claude Code, Cursor, and Conductor—understand what vibe coding really means for developers and the future of software.",
+    datePublished: "2025-09-05",
+    dateModified: "2025-09-05",
+    readTime: "8 min read",
+  },
+];
+
+/** "2026-07-24" → "July 24, 2026" — rendered in a fixed locale so SSR is deterministic. */
+export function formatPostDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const months = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+  ];
+  return `${months[m - 1]} ${d}, ${y}`;
+}

--- a/src/lib/compare.ts
+++ b/src/lib/compare.ts
@@ -1,0 +1,99 @@
+import { FEATURED_TOOLS, toolLabel } from "@/lib/utils";
+
+/**
+ * Static editorial facts for the programmatic /compare/[matchup] pages.
+ * Live usage numbers (developer counts, top spenders) come from the data
+ * layer at render time; these are the slow-moving facts a comparison needs.
+ */
+export interface CompareToolFacts {
+  key: string;
+  /** Full search-intent name ("Claude Code", "Gemini CLI") vs the short chip label. */
+  label: string;
+  provider: string;
+  pricing: string;
+  models: string;
+  oneLiner: string;
+}
+
+export const COMPARE_FACTS: Record<string, CompareToolFacts> = {
+  claude: {
+    key: "claude",
+    label: "Claude Code",
+    provider: "Anthropic",
+    pricing: "Included with Claude Pro ($20/mo) and Max ($100–$200/mo), or pay-as-you-go via the Claude API",
+    models: "Claude models (Opus, Sonnet, Haiku)",
+    oneLiner:
+      "Anthropic's terminal-first coding agent — the tool that defined the agentic CLI category and still drives the most spend on the board.",
+  },
+  codex: {
+    key: "codex",
+    label: "OpenAI Codex",
+    provider: "OpenAI",
+    pricing: "Included with ChatGPT paid plans, or pay-as-you-go via the OpenAI API",
+    models: "OpenAI GPT-5 era Codex models",
+    oneLiner:
+      "OpenAI's coding agent with CLI, IDE, and cloud modes — the fastest-growing challenger on the leaderboard.",
+  },
+  gemini: {
+    key: "gemini",
+    label: "Gemini CLI",
+    provider: "Google",
+    pricing: "Generous free tier with a personal Google account; paid via Gemini API / Google AI plans",
+    models: "Gemini models",
+    oneLiner:
+      "Google's open-source terminal agent — the easiest free entry point into agentic coding.",
+  },
+  copilot: {
+    key: "copilot",
+    label: "GitHub Copilot",
+    provider: "GitHub (Microsoft)",
+    pricing: "GitHub Copilot subscription tiers, from free with limits to Pro+",
+    models: "Multi-model (OpenAI, Anthropic, Google)",
+    oneLiner:
+      "GitHub's assistant grown into a CLI agent — the default choice for teams already living inside GitHub.",
+  },
+  opencode: {
+    key: "opencode",
+    label: "OpenCode",
+    provider: "Open source (SST)",
+    pricing: "Free and open source — bring your own model subscription or API key",
+    models: "Any provider (Anthropic, OpenAI, Google, local models)",
+    oneLiner:
+      "The open-source terminal agent for people who want Claude Code ergonomics without the lock-in.",
+  },
+};
+
+export interface CompareMatchup {
+  slug: string;
+  a: string;
+  b: string;
+}
+
+// Ordered pairs in FEATURED_TOOLS order: claude-vs-codex, claude-vs-gemini, …
+// Only this ordering is generated; the reversed slug 301s to the canonical one.
+export const COMPARE_MATCHUPS: CompareMatchup[] = FEATURED_TOOLS.flatMap((a, i) =>
+  FEATURED_TOOLS.slice(i + 1).map((b) => ({
+    slug: `${a.key}-vs-${b.key}`,
+    a: a.key,
+    b: b.key,
+  }))
+);
+
+/** Resolve a slug (either order) to its canonical matchup, or null. */
+export function resolveMatchup(slug: string): { matchup: CompareMatchup; canonical: boolean } | null {
+  const direct = COMPARE_MATCHUPS.find((m) => m.slug === slug);
+  if (direct) return { matchup: direct, canonical: true };
+  const parts = slug.split("-vs-");
+  if (parts.length !== 2) return null;
+  const reversed = COMPARE_MATCHUPS.find((m) => m.a === parts[1] && m.b === parts[0]);
+  return reversed ? { matchup: reversed, canonical: false } : null;
+}
+
+/** Full search-intent label for a tool key ("Claude Code"), falling back to the chip label. */
+export function compareLabel(key: string): string {
+  return COMPARE_FACTS[key]?.label ?? toolLabel(key);
+}
+
+export function matchupTitle(m: CompareMatchup): string {
+  return `${compareLabel(m.a)} vs ${compareLabel(m.b)}`;
+}


### PR DESCRIPTION
## What this does

Four-part push to capture more coding-related search traffic, building on the June/July SEO foundation.

### 1. Technical infrastructure
- **Shared blog-post module** (`src/lib/blogPosts.ts`) — blog index, sitemap, RSS, and llms.txt all render from one list
- **Real sitemap dates** — blog entries now carry actual publish/modified dates instead of a fresh `new Date()` every build (which trains crawlers to ignore lastModified)
- **RSS feed** at `/feed.xml`, discoverable via `<link rel=alternate>`
- **`/llms.txt`** — a citable site map for AI search engines (ChatGPT/Perplexity/Claude answers), leaning on viberank's unique dataset ($10M+ tracked spend, 95% cache-read stat)

### 2. Programmatic /compare pages (10 new indexable pages)
`/compare/claude-vs-codex` etc. for every FEATURED_TOOLS pair — targets evergreen "X vs Y" queries with something no competitor has: live adoption data (dev counts from `get_site_stats`, top-10 spender boards) refreshed hourly via ISR. Static editorial facts + FAQPage/BreadcrumbList schema. Reversed slugs 308 to the canonical order. Cross-linked from tool pages, footer, and `/compare` index.

### 3. Usage-limits content cluster (3 new posts)
The highest-volume pain queries in the niche, previously uncovered:
- `/blog/claude-code-usage-limits` — 5-hour sessions, weekly caps, what to do when you hit them
- `/blog/how-to-check-claude-code-usage` — /usage vs ccusage vs the leaderboard
- `/blog/is-claude-max-worth-it` — Pro vs Max decided with real ccusage data

All facts verified against Aug 2026 sources (May 2026 session-limit doubling, usage credits, fixed weekly resets). Each funnels into `/calculator` and `npx viberank-cli`.

### 4. Freshness + internal linking
- Cursor-vs-Claude-vs-Copilot post updated to 2026 (Copilot agent mode, current models/pricing) with `dateModified` bump
- Complete guide retitled 2025 → 2026
- Both got canonical URLs (previously missing)
- Footer, calculator, and link-thin older posts now link into the new cluster

## Verification
- `pnpm build` passes; all 50 static pages generate (10 compare pages, 13 blog posts)
- Smoke-tested on `next start`: feed.xml validates, llms.txt renders, compare titles use full search labels ("Claude Code vs OpenAI Codex"), reversed slug 308s, sitemap has 1,124 URLs including all new pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)