### PR TITLE
feat: GSC-driven SEO round 2 — monthly reports, check-usage intent, rank tracker, Korean

### DIFF
--- a/src/app/blog/codex-token-usage-leaderboard/page.tsx
+++ b/src/app/blog/codex-token-usage-leaderboard/page.tsx
@@ -3,17 +3,18 @@ import { ArrowLeft, Clock, Calendar, Terminal, Gauge, Trophy, DollarSign } from 
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard) 2026",
+  title: "How to Check Codex Usage: /status, Token Counts & Costs (2026)",
   description:
-    "Check your OpenAI Codex CLI token usage and costs with ccusage, understand what your sessions burn, and see how you rank against 190+ Codex developers on the public Viberank leaderboard.",
+    "Two commands answer it: /status inside Codex CLI shows how much of your 5-hour and weekly limits you've used, and npx ccusage@latest daily turns your local logs into token counts and real costs.",
   alternates: { canonical: "https://www.viberank.app/blog/codex-token-usage-leaderboard" },
   openGraph: {
-    title: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard)",
+    title: "How to Check Codex Usage: /status, Token Counts & Costs (2026)",
     description:
       "Read your Codex CLI logs with ccusage, understand what sessions cost, and rank yourself on the public Codex leaderboard.",
     url: "https://www.viberank.app/blog/codex-token-usage-leaderboard",
     type: "article",
     publishedTime: "2026-07-24T00:00:00.000Z",
+    modifiedTime: "2026-08-18T00:00:00.000Z",
     authors: ["Viberank Team"],
     images: [
       {
@@ -26,7 +27,7 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard)",
+    title: "How to Check Codex Usage: /status, Token Counts & Costs (2026)",
     description: "Read your Codex CLI logs with ccusage and rank yourself on the public Codex leaderboard.",
     images: ["/api/og?title=Codex%20Token%20Usage&description=Track%20it%2C%20cost%20it%2C%20rank%20it"],
   },
@@ -35,7 +36,15 @@ export const metadata: Metadata = {
 const FAQS = [
   {
     q: "How do I check my OpenAI Codex token usage?",
-    a: "Codex CLI writes session logs as JSONL under ~/.codex. Run npx ccusage@latest daily to parse them into per-day token counts and API-equivalent costs, alongside any other coding agents you use.",
+    a: "Two ways: type /status inside a Codex CLI session to see how much of your 5-hour and weekly rate limits you've used, or run npx ccusage@latest daily to parse Codex's local session logs (JSONL under ~/.codex) into per-day token counts and API-equivalent costs.",
+  },
+  {
+    q: "How do I check how many tokens I have left in Codex?",
+    a: "Codex doesn't meter you in tokens — it meters percentage of a 5-hour session window and a weekly cap. /status shows the live percentages for both. Reset timestamps and any banked usage credits are on your ChatGPT account's web usage page, not in the CLI.",
+  },
+  {
+    q: "Where do I check my Codex credits?",
+    a: "On your ChatGPT/OpenAI account's usage page in the browser. The CLI's /status shows rate-limit percentages only; credit balances and window reset times are web-only for now.",
   },
   {
     q: "Does Codex usage tracked this way match my OpenAI bill?",
@@ -56,12 +65,12 @@ export default function CodexTokenUsage() {
     {
       "@context": "https://schema.org",
       "@type": "BlogPosting",
-      headline: "How to Track OpenAI Codex Token Usage (+ the Codex Leaderboard) 2026",
+      headline: "How to Check Codex Usage: /status, Token Counts & Costs (2026)",
       description:
         "Check your OpenAI Codex CLI token usage and costs with ccusage, and see how you rank on the public Codex leaderboard.",
       image: "https://www.viberank.app/api/og?title=Codex%20Token%20Usage",
       datePublished: "2026-07-24T00:00:00.000Z",
-      dateModified: "2026-07-24T00:00:00.000Z",
+      dateModified: "2026-08-18T00:00:00.000Z",
       author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
       publisher: {
         "@type": "Organization",
@@ -96,7 +105,7 @@ export default function CodexTokenUsage() {
 
         <header className="mb-12">
           <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
-            How to Track OpenAI Codex Token Usage — and Join the Codex Leaderboard
+            How to Check Your Codex Usage: Limits, Tokens & Costs
           </h1>
 
           <div className="flex items-center gap-6 text-sm text-muted mb-8">
@@ -112,10 +121,11 @@ export default function CodexTokenUsage() {
 
           <div className="p-6 bg-card border border-border rounded-lg">
             <p className="text-lg text-foreground m-0">
-              OpenAI&apos;s Codex CLI doesn&apos;t ship a usage dashboard, but it logs everything you need locally.
-              This guide shows how to turn those logs into daily token counts and dollar figures with{" "}
-              <span className="font-semibold text-accent">ccusage</span>, what the numbers actually mean, and how to
-              stack yours against the 190+ developers tracking Codex on the{" "}
+              The short answer: type <code>/status</code> inside Codex CLI to see how much of your 5-hour and
+              weekly rate limits you&apos;ve used, and run{" "}
+              <span className="font-semibold text-accent">npx ccusage@latest daily</span> in your terminal to turn
+              Codex&apos;s local logs into daily token counts and dollar figures. This guide covers both — plus what
+              the numbers mean and how to stack yours against the 190+ developers on the{" "}
               <Link href="/tool/codex">public Codex leaderboard</Link>.
             </p>
           </div>
@@ -123,8 +133,22 @@ export default function CodexTokenUsage() {
 
         <section className="mb-12">
           <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Gauge className="w-8 h-8 text-accent" />
+            Checking your limits: <code className="text-accent">/status</code>
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Inside any Codex CLI session, type <code>/status</code>. It shows your current position against both
+            rate-limit windows — the rolling 5-hour session and the weekly cap — as live percentages. (You need to
+            send at least one message in the session first, or there&apos;s no rate-limit state to report.) What it
+            doesn&apos;t show: reset timestamps or banked credits — those live on your ChatGPT account&apos;s web
+            usage page. And it says nothing about tokens or dollars, which is what the next command is for.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
             <Terminal className="w-8 h-8 text-accent" />
-            Reading your Codex usage with ccusage
+            Checking tokens and costs: ccusage
           </h2>
           <p className="text-foreground text-lg leading-relaxed mb-6">
             Codex CLI writes each session as JSONL under <code>~/.codex</code> (or wherever{" "}

--- a/src/app/blog/how-to-check-opencode-usage/page.tsx
+++ b/src/app/blog/how-to-check-opencode-usage/page.tsx
@@ -1,0 +1,226 @@
+import Link from "next/link";
+import { ArrowLeft, Clock, Calendar, Terminal, FolderOpen, DollarSign, Trophy } from "lucide-react";
+import type { Metadata } from "next";
+
+const TITLE = "How to Check OpenCode Usage: Tokens, Costs & Session Stats (2026)";
+const DESC =
+  "OpenCode has no built-in usage meter, but one command fixes that: npx ccusage@latest daily reads OpenCode's local session logs into per-day token counts and real API costs. Here's how, plus dashboards and the public leaderboard.";
+const URL = "https://www.viberank.app/blog/how-to-check-opencode-usage";
+const OG =
+  "/api/og?title=How%20to%20Check%20OpenCode%20Usage&description=Tokens%2C%20costs%20%26%20session%20stats%20from%20your%20local%20logs";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  keywords: [
+    "opencode check usage",
+    "how to check opencode usage",
+    "opencode token usage",
+    "opencode cost tracking",
+    "opencode usage stats",
+    "check opencode token usage",
+    "opencode ccusage",
+    "opencode leaderboard",
+  ],
+  alternates: { canonical: URL },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: URL,
+    type: "article",
+    publishedTime: "2026-08-18T00:00:00.000Z",
+    authors: ["Viberank Team"],
+    images: [{ url: OG, width: 1200, height: 630, alt: TITLE }],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC, images: [OG] },
+};
+
+const FAQS = [
+  {
+    q: "How do I check my OpenCode token usage?",
+    a: "Run npx ccusage@latest daily in your terminal. It reads OpenCode's local session storage (~/.local/share/opencode/storage/message/) and reports per-day token counts and estimated costs, alongside any other coding agents you use. OpenCode core has no built-in usage command.",
+  },
+  {
+    q: "Does OpenCode have a built-in /usage or /status command?",
+    a: "No — unlike Claude Code's /usage or Codex's /status, OpenCode core doesn't ship a usage meter. Community options fill the gap: the ccusage CLI for daily/monthly reports, the opencode-stats terminal dashboard, and the TokenScope plugin for per-session breakdowns.",
+  },
+  {
+    q: "How is OpenCode cost calculated?",
+    a: "From token counts times model list prices (ccusage uses LiteLLM's pricing data). Because OpenCode is bring-your-own-provider, this is close to your real bill if you pay per token with an API key — or an API-equivalent value if you route through a Claude or ChatGPT subscription.",
+  },
+  {
+    q: "Is there an OpenCode leaderboard?",
+    a: "Yes — Viberank tracks OpenCode usage submitted by developers via ccusage, with a dedicated board at viberank.app/tool/opencode. Run npx viberank-cli to add yours; only usage totals are submitted, never code or prompts.",
+  },
+];
+
+export default function Post() {
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: TITLE,
+      description: DESC,
+      image: "https://www.viberank.app" + OG,
+      datePublished: "2026-08-18T00:00:00.000Z",
+      dateModified: "2026-08-18T00:00:00.000Z",
+      author: { "@type": "Organization", name: "Viberank", url: "https://www.viberank.app" },
+      publisher: {
+        "@type": "Organization",
+        name: "Viberank",
+        url: "https://www.viberank.app",
+        logo: { "@type": "ImageObject", url: "https://www.viberank.app/icon.svg" },
+      },
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: FAQS.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: { "@type": "Answer", text: f.a },
+      })),
+    },
+  ];
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <article className="prose prose-invert prose-neutral max-w-3xl mx-auto">
+        <Link
+          href="/blog"
+          className="inline-flex items-center gap-2 text-muted hover:text-accent transition-colors mb-8 no-underline"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Blog
+        </Link>
+
+        <header className="mb-12">
+          <h1 className="text-5xl font-bold text-foreground mb-4 leading-tight">
+            How to Check Your OpenCode Usage
+          </h1>
+
+          <div className="flex items-center gap-6 text-sm text-muted mb-8">
+            <span className="flex items-center gap-2">
+              <Calendar className="w-4 h-4" />
+              August 18, 2026
+            </span>
+            <span className="flex items-center gap-2">
+              <Clock className="w-4 h-4" />5 min read
+            </span>
+          </div>
+
+          <div className="p-6 bg-card border border-border rounded-lg">
+            <p className="text-lg text-foreground m-0">
+              The short answer: OpenCode core has <strong>no built-in usage command</strong> — but it logs every
+              session locally, and <span className="font-semibold text-accent">npx ccusage@latest daily</span> turns
+              those logs into per-day token counts and costs in one command. Here&apos;s that route, the dashboard
+              alternatives, and how to see where your burn ranks.
+            </p>
+          </div>
+        </header>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Terminal className="w-8 h-8 text-accent" />
+            The one-command answer: ccusage
+          </h2>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6 space-y-2">
+            <div>
+              <code className="text-accent font-mono">npx ccusage@latest daily</code>
+              <span className="text-muted text-sm ml-3"># per-day tokens + cost, OpenCode included</span>
+            </div>
+            <div>
+              <code className="text-accent font-mono">npx ccusage@latest monthly</code>
+              <span className="text-muted text-sm ml-3"># monthly rollup</span>
+            </div>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer">
+              ccusage
+            </a>{" "}
+            reads OpenCode&apos;s session storage and computes tokens and costs from model list prices (via
+            LiteLLM&apos;s pricing data), with subagent sessions included. Nothing is uploaded — it&apos;s all
+            computed from your local files. And because the same command covers{" "}
+            <Link href="/tool/claude">Claude Code</Link>, <Link href="/tool/codex">Codex</Link>,{" "}
+            <Link href="/tool/gemini">Gemini CLI</Link> and <Link href="/tool/copilot">Copilot</Link>, you get one
+            combined report across your whole agent stack.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <FolderOpen className="w-8 h-8 text-accent" />
+            Where OpenCode keeps the data
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            OpenCode writes message-level records — model identifiers and per-turn input/output token usage — under{" "}
+            <code>~/.local/share/opencode/storage/message/</code>. That&apos;s what ccusage parses. It also means
+            your usage history lives (and dies) with that directory: wipe the machine, lose the history — one more
+            reason to snapshot it somewhere (below).
+          </p>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Prefer a live view over a report? Two community tools read the same data: the{" "}
+            <a href="https://github.com/Cateds/opencode-stats" target="_blank" rel="noopener noreferrer">
+              opencode-stats
+            </a>{" "}
+            terminal dashboard (totals, models, activity heatmap) and the{" "}
+            <a href="https://github.com/ramtinJ95/opencode-tokenscope" target="_blank" rel="noopener noreferrer">
+              TokenScope plugin
+            </a>
+            , which adds a <code>/tokenscope</code> command inside OpenCode for per-session breakdowns.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <DollarSign className="w-8 h-8 text-accent" />
+            Why cost tracking matters more on OpenCode
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            OpenCode is bring-your-own-provider. If you plug in an API key, the ccusage number is close to your{" "}
+            <em>actual bill</em> — not the theoretical &quot;API-equivalent&quot; figure subscription users see. If
+            you route through a Claude or ChatGPT plan instead, the number tells you what that plan is saving you.
+            Either way, agentic sessions resend context every turn, so token counts look enormous; on{" "}
+            <Link href="/stats">Viberank&apos;s 11T+ tracked tokens</Link>, ~95% are cheap prompt-cache reads, which
+            is why a scary token count usually maps to a much smaller bill.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6 flex items-center gap-3">
+            <Trophy className="w-8 h-8 text-accent" />
+            Rank it: the OpenCode leaderboard
+          </h2>
+          <p className="text-foreground text-lg leading-relaxed mb-4">
+            Once you can measure it, the next question is &quot;is that a lot?&quot; One command puts your totals on
+            the <Link href="/tool/opencode">public OpenCode leaderboard</Link> — code and prompts never leave your
+            machine:
+          </p>
+          <div className="bg-card border border-border rounded-lg p-4 mb-6">
+            <code className="text-accent font-mono">npx viberank-cli</code>
+          </div>
+          <p className="text-foreground text-lg leading-relaxed mb-6">
+            Your profile charts daily spend, tokens, models, and streaks across every tool ccusage tracks — and it
+            doubles as the off-machine snapshot of your usage history. Curious how OpenCode stacks up against the
+            big agents? See <Link href="/compare/claude-vs-opencode">Claude Code vs OpenCode</Link> or{" "}
+            <Link href="/compare/codex-vs-opencode">Codex vs OpenCode</Link> on live data.
+          </p>
+        </section>
+
+        <section className="mb-12">
+          <h2 className="text-3xl font-bold text-foreground mb-6">OpenCode usage FAQ</h2>
+          <div className="space-y-6">
+            {FAQS.map((f) => (
+              <div key={f.q} className="bg-card border border-border rounded-lg p-5">
+                <h3 className="text-lg font-semibold text-foreground mt-0 mb-2">{f.q}</h3>
+                <p className="text-muted m-0">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+      </article>
+    </>
+  );
+}

--- a/src/app/blog/layout.tsx
+++ b/src/app/blog/layout.tsx
@@ -5,9 +5,9 @@ import Footer from "@/components/Footer";
 export const metadata: Metadata = {
   title: {
     template: '%s | Viberank Blog',
-    default: 'Blog | Viberank',
+    default: 'AI Coding Costs, Limits & Usage Data — the Viberank Blog',
   },
-  description: 'Insights on AI-powered development, Claude Code, vibe coding, and the future of programming.',
+  description: 'Data-backed writing on what AI coding actually costs: Claude Code and Codex usage limits, real spend benchmarks from 1,100+ developers, and how to measure your own.',
 };
 
 export default function BlogLayout({

--- a/src/app/claude-rank-tracker/page.tsx
+++ b/src/app/claude-rank-tracker/page.tsx
@@ -1,0 +1,241 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, BadgeCheck, RefreshCcw, Trophy, Shield } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import type { Submission } from "@/lib/data/types";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import TierBadge from "@/components/TierBadge";
+import { formatCurrency, formatNumber } from "@/lib/utils";
+
+const SITE = "https://www.viberank.app";
+const TITLE = "Claude Rank Tracker — Track Your Claude Code Rank, Free & Daily | Viberank";
+const DESC =
+  "Free Claude rank tracker: see where your Claude Code usage ranks among 1,100+ developers, updated daily. One command to join, autosubmit keeps your rank current, README badge included.";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  keywords: [
+    "claude rank tracker",
+    "claude rank",
+    "claude ranking",
+    "claude rank tracking",
+    "free claude rank tracker",
+    "claude code rank",
+    "claude usage ranking",
+    "claude leaderboard",
+    "track claude rank",
+  ],
+  alternates: { canonical: `${SITE}/claude-rank-tracker` },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE}/claude-rank-tracker`,
+    siteName: "Viberank",
+    type: "website",
+    images: [
+      `/api/og?title=${encodeURIComponent("Claude Rank Tracker")}&description=${encodeURIComponent("Track your Claude Code rank daily — free, one command")}`,
+    ],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+const FAQS = [
+  {
+    q: "What is a Claude rank tracker?",
+    a: "A tool that tracks where your Claude usage ranks against other developers. Viberank ranks real Claude Code usage — tokens and API-equivalent spend measured by ccusage from your local logs — across 1,100+ developers, and updates your rank daily if you enable autosubmit. It's free and open source.",
+  },
+  {
+    q: "How do I track my Claude rank?",
+    a: "Run npx viberank-cli once to get on the board. Then mint a token at viberank.app/settings/tokens, run npx viberank-cli login and npx viberank-cli autosubmit — your usage submits daily via your OS scheduler and your rank stays current instead of freezing on the day you first submitted.",
+  },
+  {
+    q: "Is the Claude rank tracker free?",
+    a: "Yes — tracking your rank, your profile page, charts, and the README badge are all free. The code is MIT-licensed and open source on GitHub.",
+  },
+  {
+    q: "Can I put my Claude rank in my GitHub README?",
+    a: "Yes. Viberank serves a live badge at viberank.app/api/badge/{username} showing your rank, cost, or tokens — it updates automatically as your rank changes.",
+  },
+  {
+    q: "Looking to track Google keyword rankings with Claude instead?",
+    a: "That's a different tool category — SEO rank trackers. Viberank tracks your rank on the Claude usage leaderboard, not search-engine positions. If you want to know where your AI coding usage ranks, you're in the right place.",
+  },
+];
+
+export default async function ClaudeRankTrackerPage() {
+  let items: Submission[] = [];
+  let totalUsers = 0;
+  try {
+    const dataLayer = await getServerDataLayer();
+    const [lb, site] = await Promise.all([
+      dataLayer.submissions.getLeaderboard({ sortBy: "cost", page: 0, pageSize: 5, tool: "claude" }),
+      dataLayer.stats.getSiteStats(),
+    ]);
+    items = lb.items;
+    totalUsers = site?.totalUsers ?? 0;
+  } catch {
+    // render static content
+  }
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+  const breadcrumbLd = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Leaderboard", item: SITE },
+      { "@type": "ListItem", position: 2, name: "Claude Rank Tracker", item: `${SITE}/claude-rank-tracker` },
+    ],
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify([breadcrumbLd, faqLd]) }}
+      />
+
+      <NavBar />
+
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
+        <p className="micro-label mb-3">Free tool</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">Claude Rank Tracker</h1>
+        <p className="text-muted mb-8 max-w-2xl">
+          Track where your Claude Code usage ranks{" "}
+          {totalUsers > 0 ? `among ${totalUsers.toLocaleString()} developers` : "worldwide"} — measured from your
+          real{" "}
+          <a
+            href="https://github.com/ryoppippi/ccusage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            ccusage
+          </a>{" "}
+          data, updated daily, free. One command to join:
+        </p>
+
+        <div className="rounded-lg border border-accent/40 bg-surface-1 p-5 mb-10 max-w-2xl">
+          <code className="font-mono text-accent text-base">npx viberank-cli</code>
+          <p className="text-sm text-muted mt-2 mb-0">
+            Reads your local Claude Code logs and submits usage totals only — code and prompts never leave your
+            machine.
+          </p>
+        </div>
+
+        {/* How it works */}
+        <div className="grid gap-4 sm:grid-cols-3 mb-12 max-w-4xl">
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <Trophy className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">See your rank</p>
+            <p className="text-sm text-muted m-0">
+              Global and <Link href="/tool/claude" className="text-accent hover:underline">Claude-only</Link>{" "}
+              rankings by cost and tokens, plus your percentile, tier, and daily charts on your profile.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <RefreshCcw className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">Track it daily</p>
+            <p className="text-sm text-muted m-0">
+              <code className="font-mono text-accent">viberank-cli autosubmit</code> registers with your OS
+              scheduler, so your rank moves with your usage instead of freezing at your first submission.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <Shield className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">Show it off</p>
+            <p className="text-sm text-muted m-0">
+              A live README badge at{" "}
+              <code className="font-mono text-xs">/api/badge/{"{username}"}</code> shows your current rank, and
+              GitHub sign-in adds a verified check.
+            </p>
+          </div>
+        </div>
+
+        {/* Live top-5 */}
+        {items.length > 0 && (
+          <div className="rounded-lg border border-border overflow-hidden mb-12 max-w-2xl">
+            <div className="flex items-center justify-between px-4 py-2.5 bg-surface-1 border-b border-border">
+              <span className="micro-label">Current top 5 — Claude Code</span>
+              <Link href="/tool/claude" className="text-xs text-accent hover:underline">
+                Full leaderboard →
+              </Link>
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {items.map((s, i) => (
+                <Link
+                  key={s.id}
+                  href={`/profile/${encodeURIComponent(s.githubUsername || s.username)}`}
+                  className="flex items-center gap-3 px-4 py-2.5 hover:bg-surface-1 transition-colors group"
+                >
+                  <div className="w-6 text-center text-sm font-mono text-muted">{i + 1}</div>
+                  <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                    <span className="text-sm font-medium truncate group-hover:text-accent transition-colors">
+                      {s.githubUsername || s.username}
+                    </span>
+                    {s.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+                  </div>
+                  <div className="hidden sm:block w-20 flex-shrink-0">
+                    <TierBadge totalCost={s.totalCost} size="xs" bare />
+                  </div>
+                  <div className="w-24 text-right text-sm font-mono font-semibold text-accent">
+                    ${formatCurrency(s.totalCost)}
+                  </div>
+                  <div className="w-20 text-right text-sm font-mono text-muted hidden sm:block">
+                    {formatNumber(s.totalTokens)}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* FAQ */}
+        <section className="mb-12 max-w-3xl">
+          <h2 className="font-mono text-xl font-bold tracking-tight mb-4">Claude rank tracker FAQ</h2>
+          <div className="space-y-3">
+            {FAQS.map((f) => (
+              <div key={f.q} className="rounded-lg border border-border bg-surface-1 p-4">
+                <h3 className="font-medium mb-1.5">{f.q}</h3>
+                <p className="text-sm text-muted">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <p className="text-sm text-muted max-w-3xl">
+          More on what the numbers mean:{" "}
+          <Link href="/blog/how-to-check-claude-code-usage" className="text-accent hover:underline">
+            how to check your Claude Code usage
+          </Link>
+          {", "}
+          <Link href="/blog/how-much-does-claude-code-cost" className="text-accent hover:underline">
+            what Claude Code actually costs
+          </Link>
+          {", and "}
+          <Link href="/calculator" className="text-accent hover:underline">
+            which plan your usage justifies
+          </Link>
+          .
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/ko/page.tsx
+++ b/src/app/ko/page.tsx
@@ -1,0 +1,214 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Trophy, Terminal, Shield, BarChart3 } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+
+const SITE = "https://www.viberank.app";
+const TITLE = "Viberank — Claude Code·Codex AI 코딩 사용량 리더보드 | 바이브랭크";
+const DESC =
+  "Claude Code, OpenAI Codex, Gemini CLI 토큰 사용량을 실제 ccusage 데이터로 추적하고 전 세계 1,100+ 개발자와 비교하세요. npx viberank-cli 명령 하나로 무료 등록.";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  keywords: [
+    "claude code 사용량",
+    "claude code 토큰",
+    "클로드 코드 사용량 확인",
+    "claude 리더보드",
+    "codex 사용량 확인",
+    "ai 코딩 사용량",
+    "ccusage",
+    "바이브코딩",
+    "토큰 사용량 리더보드",
+  ],
+  alternates: {
+    canonical: `${SITE}/ko`,
+    languages: {
+      en: `${SITE}/`,
+      ko: `${SITE}/ko`,
+      "x-default": `${SITE}/`,
+    },
+  },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE}/ko`,
+    siteName: "Viberank",
+    locale: "ko_KR",
+    type: "website",
+    images: [
+      `/api/og?title=${encodeURIComponent("AI 코딩 사용량 리더보드")}&description=${encodeURIComponent("Claude Code · Codex · Gemini CLI — 실제 사용 데이터로 랭킹")}`,
+    ],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+const FAQS = [
+  {
+    q: "Claude Code 사용량은 어떻게 확인하나요?",
+    a: "Claude Code 안에서 /usage 명령을 입력하면 5시간 세션과 주간 한도 소진율을 볼 수 있습니다. 토큰 수와 비용까지 보려면 터미널에서 npx ccusage@latest daily를 실행하세요 — 로컬 로그를 읽어 일별 토큰 사용량과 API 환산 비용을 계산합니다.",
+  },
+  {
+    q: "리더보드에는 어떻게 등록하나요?",
+    a: "터미널에서 npx viberank-cli 한 줄이면 됩니다. 로컬 ccusage 데이터를 읽어 사용량 합계만 제출하며, 코드나 프롬프트는 절대 전송되지 않습니다. GitHub 로그인 시 인증 배지가 붙습니다.",
+  },
+  {
+    q: "무료인가요?",
+    a: "네. 리더보드, 프로필 페이지, 통계, README 배지 모두 무료이며 코드는 MIT 라이선스 오픈소스입니다.",
+  },
+  {
+    q: "어떤 도구를 지원하나요?",
+    a: "ccusage가 추적하는 모든 코딩 에이전트를 지원합니다 — Claude Code, OpenAI Codex, Gemini CLI, GitHub Copilot, OpenCode 등. 도구별 리더보드에서 따로 볼 수도 있습니다.",
+  },
+];
+
+export default async function KoreanLandingPage() {
+  let totalUsers = 0;
+  let totalCost = 0;
+  try {
+    const dataLayer = await getServerDataLayer();
+    const site = await dataLayer.stats.getSiteStats();
+    totalUsers = site?.totalUsers ?? 0;
+    totalCost = site?.totalCost ?? 0;
+  } catch {
+    // render static content
+  }
+
+  const faqLd = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    inLanguage: "ko",
+    mainEntity: FAQS.map((f) => ({
+      "@type": "Question",
+      name: f.q,
+      acceptedAnswer: { "@type": "Answer", text: f.a },
+    })),
+  };
+
+  return (
+    <div className="min-h-screen bg-background" lang="ko">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqLd) }} />
+
+      <NavBar />
+
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          리더보드로 이동
+        </Link>
+
+        <p className="micro-label mb-3">한국어 안내</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-3">
+          AI 코딩 사용량 리더보드, Viberank
+        </h1>
+        <p className="text-muted mb-8 max-w-2xl leading-relaxed">
+          Claude Code, OpenAI Codex, Gemini CLI로 얼마나 코딩하고 있나요? Viberank(바이브랭크)는 실제{" "}
+          <a
+            href="https://github.com/ryoppippi/ccusage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            ccusage
+          </a>{" "}
+          데이터로 집계한 공개 리더보드입니다.{" "}
+          {totalUsers > 0 && (
+            <>
+              현재 <span className="text-foreground font-medium">{totalUsers.toLocaleString()}명의 개발자</span>가 총{" "}
+              <span className="text-foreground font-mono">
+                ${Math.round(totalCost / 1_000_000)}M+
+              </span>{" "}
+              상당(API 환산)의 사용량을 기록하고 있습니다.{" "}
+            </>
+          )}
+          내 순위가 궁금하다면 명령 한 줄이면 충분합니다:
+        </p>
+
+        <div className="rounded-lg border border-accent/40 bg-surface-1 p-5 mb-10 max-w-2xl">
+          <code className="font-mono text-accent text-base">npx viberank-cli</code>
+          <p className="text-sm text-muted mt-2 mb-0">
+            로컬 로그에서 사용량 합계만 제출합니다 — 코드와 프롬프트는 절대 컴퓨터 밖으로 나가지 않습니다.
+          </p>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-12">
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <Trophy className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">글로벌 랭킹</p>
+            <p className="text-sm text-muted m-0">
+              비용·토큰 기준 순위, 상위 3인 포디움, 도구별{" "}
+              <Link href="/tool/claude" className="text-accent hover:underline">
+                Claude Code
+              </Link>
+              {" · "}
+              <Link href="/tool/codex" className="text-accent hover:underline">
+                Codex
+              </Link>{" "}
+              보드.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <BarChart3 className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">프로필 &amp; 통계</p>
+            <p className="text-sm text-muted m-0">
+              일별 사용량 차트, 모델별 분석, 연속 사용 스트릭.{" "}
+              <Link href="/stats" className="text-accent hover:underline">
+                전체 통계
+              </Link>
+              도 공개되어 있습니다.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <Terminal className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">자동 제출</p>
+            <p className="text-sm text-muted m-0">
+              <code className="font-mono text-accent text-xs">viberank-cli autosubmit</code>으로 매일 자동
+              업데이트 — 순위가 항상 최신으로 유지됩니다.
+            </p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-5">
+            <Shield className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium mb-1">무료 &amp; 오픈소스</p>
+            <p className="text-sm text-muted m-0">
+              MIT 라이선스. GitHub 로그인 시 인증 배지, README용 실시간 순위 배지 제공.
+            </p>
+          </div>
+        </div>
+
+        <section className="mb-12 max-w-3xl">
+          <h2 className="font-mono text-xl font-bold tracking-tight mb-4">자주 묻는 질문</h2>
+          <div className="space-y-3">
+            {FAQS.map((f) => (
+              <div key={f.q} className="rounded-lg border border-border bg-surface-1 p-4">
+                <h3 className="font-medium mb-1.5">{f.q}</h3>
+                <p className="text-sm text-muted">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <p className="text-sm text-muted max-w-3xl">
+          더 읽어보기 (영문):{" "}
+          <Link href="/blog/how-much-does-claude-code-cost" className="text-accent hover:underline">
+            Claude Code 실제 비용 데이터
+          </Link>
+          {", "}
+          <Link href="/blog/claude-code-usage-limits" className="text-accent hover:underline">
+            Claude Code 사용 한도 정리
+          </Link>
+          {", "}
+          <Link href="/calculator" className="text-accent hover:underline">
+            요금제 계산기
+          </Link>
+          .
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -63,6 +63,11 @@ export const metadata: Metadata = {
   metadataBase: new URL("https://www.viberank.app"),
   alternates: {
     canonical: "https://www.viberank.app",
+    languages: {
+      en: "https://www.viberank.app/",
+      ko: "https://www.viberank.app/ko",
+      "x-default": "https://www.viberank.app/",
+    },
     types: {
       "application/rss+xml": [{ url: "/feed.xml", title: "Viberank Blog" }],
     },

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -31,13 +31,35 @@ const blogEntries: MetadataRoute.Sitemap = BLOG_POSTS.map((p) => ({
   priority: 0.7,
 }));
 
+// Every month from the first tracked data (Sep 2025) through the current one.
+function monthlyReportEntries(): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+  const now = new Date();
+  const cursor = new Date(Date.UTC(2025, 8, 1));
+  while (cursor <= now) {
+    const month = `${cursor.getUTCFullYear()}-${String(cursor.getUTCMonth() + 1).padStart(2, "0")}`;
+    entries.push({
+      url: `${SITE}/stats/monthly/${month}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    });
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return entries;
+}
+
 const staticEntries: MetadataRoute.Sitemap = [
   { url: SITE, lastModified: new Date(), changeFrequency: "daily", priority: 1 },
   ...toolEntries,
   ...compareEntries,
   { url: `${SITE}/compare`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
+  { url: `${SITE}/claude-rank-tracker`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
+  { url: `${SITE}/ko`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
   { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/stats`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+  { url: `${SITE}/stats/monthly`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
+  ...monthlyReportEntries(),
   { url: `${SITE}/calculator`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
   { url: `${SITE}/blog`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.8 },
   ...blogEntries,

--- a/src/app/stats/monthly/[month]/page.tsx
+++ b/src/app/stats/monthly/[month]/page.tsx
@@ -1,0 +1,261 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { ArrowLeft, DollarSign, Users, Cpu, CalendarDays, Gauge, TrendingUp } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import type { MonthStats } from "@/lib/data/types";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import { formatNumber, formatUsd, toolLabel, prettyModelName } from "@/lib/utils";
+
+interface MonthParams {
+  params: Promise<{ month: string }>;
+}
+
+const SITE = "https://www.viberank.app";
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+// Reports for closed months never change; the current month updates hourly.
+export const revalidate = 3600;
+
+function monthLabel(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  return `${MONTHS[m - 1]} ${y}`;
+}
+
+function shiftMonth(month: string, delta: number): string {
+  const [y, m] = month.split("-").map(Number);
+  const d = new Date(Date.UTC(y, m - 1 + delta, 1));
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+const getMonth = cache(async (month: string): Promise<MonthStats | null> => {
+  try {
+    const dataLayer = await getServerDataLayer();
+    return await dataLayer.stats.getMonthStats(month);
+  } catch {
+    return null;
+  }
+});
+
+export function generateStaticParams() {
+  // Prerender the last three months; older months build on demand and stick
+  // (their data no longer changes).
+  const now = new Date();
+  const current = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  return [current, shiftMonth(current, -1), shiftMonth(current, -2)].map((month) => ({ month }));
+}
+
+export async function generateMetadata({ params }: MonthParams): Promise<Metadata> {
+  const { month: raw } = await params;
+  const month = decodeURIComponent(raw);
+  if (!/^\d{4}-\d{2}$/.test(month)) return {};
+  const stats = await getMonth(month);
+  const label = monthLabel(month);
+  const title = stats && stats.users > 0
+    ? `AI Coding Spend Report ${label}: ${formatUsd(Math.round(stats.cost))} Across ${stats.users} Developers | Viberank`
+    : `AI Coding Spend Report ${label} | Viberank`;
+  const description = stats && stats.users > 0
+    ? `${label} on the Viberank leaderboard: ${formatUsd(Math.round(stats.cost))} in API-equivalent AI coding spend, ${formatNumber(stats.tokens)} tokens, median developer at ${formatUsd(Math.round(stats.medianUserCost))}. Per-tool and per-model breakdowns from real ccusage data.`
+    : `Monthly AI coding usage report for ${label} from the Viberank leaderboard.`;
+  const canonical = `${SITE}/stats/monthly/${month}`;
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: "Viberank",
+      type: "article",
+      images: [
+        `/api/og?title=${encodeURIComponent(`AI coding spend — ${label}`)}&description=${encodeURIComponent(
+          stats && stats.users > 0
+            ? `${formatUsd(Math.round(stats.cost))} tracked across ${stats.users} developers`
+            : "Monthly report from the Viberank leaderboard"
+        )}`,
+      ],
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+function StatTile({ icon, label, value, sub }: { icon: React.ReactNode; label: string; value: string; sub?: string }) {
+  return (
+    <div className="bg-surface-1 border border-border rounded-lg p-4">
+      <p className="flex items-center gap-1.5 micro-label mb-1">
+        {icon}
+        {label}
+      </p>
+      <p className="font-mono text-xl font-bold text-foreground m-0">{value}</p>
+      {sub && <p className="text-xs text-muted mt-1 mb-0">{sub}</p>}
+    </div>
+  );
+}
+
+export default async function MonthReportPage({ params }: MonthParams) {
+  const { month: raw } = await params;
+  const month = decodeURIComponent(raw);
+  if (!/^\d{4}-\d{2}$/.test(month)) notFound();
+
+  const stats = await getMonth(month);
+  if (!stats || stats.users === 0) notFound();
+
+  const label = monthLabel(month);
+  const prev = shiftMonth(month, -1);
+  const next = shiftMonth(month, 1);
+  const now = new Date();
+  const currentMonth = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+  const isCurrent = month === currentMonth;
+  const hasNext = next <= currentMonth;
+  const cacheShare = stats.tokens > 0 ? Math.round((stats.cacheReadTokens / stats.tokens) * 100) : 0;
+
+  const jsonLd = [
+    {
+      "@context": "https://schema.org",
+      "@type": "Dataset",
+      name: `AI coding usage — ${label} (Viberank)`,
+      description: `Aggregated AI coding usage for ${label}: ${formatUsd(Math.round(stats.cost))} API-equivalent spend and ${formatNumber(stats.tokens)} tokens across ${stats.users} developers, measured from local ccusage logs of Claude Code, Codex, Gemini CLI and other agents.`,
+      url: `${SITE}/stats/monthly/${month}`,
+      creator: { "@type": "Organization", name: "Viberank", url: SITE },
+      temporalCoverage: month,
+      license: "https://opensource.org/licenses/MIT",
+    },
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Stats", item: `${SITE}/stats` },
+        { "@type": "ListItem", position: 2, name: "Monthly reports", item: `${SITE}/stats/monthly` },
+        { "@type": "ListItem", position: 3, name: label, item: `${SITE}/stats/monthly/${month}` },
+      ],
+    },
+  ];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+
+      <NavBar />
+
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/stats/monthly" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          All monthly reports
+        </Link>
+
+        <p className="micro-label mb-3">Monthly report{isCurrent ? " · updating live" : ""}</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+          AI coding spend — {label}
+        </h1>
+        <p className="text-muted mb-8 max-w-2xl">
+          What {stats.users.toLocaleString()} developers actually spent on AI coding in {label}, measured from real{" "}
+          <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">
+            ccusage
+          </a>{" "}
+          data across Claude Code, Codex, Gemini CLI and every other tracked agent.
+          {isCurrent && " This month is still in progress — numbers grow as submissions come in."}
+        </p>
+
+        {/* Headline tiles */}
+        <div className="grid gap-3 grid-cols-2 lg:grid-cols-4 mb-10">
+          <StatTile icon={<DollarSign className="w-3.5 h-3.5" />} label="Total spend" value={formatUsd(Math.round(stats.cost))} sub="API-equivalent" />
+          <StatTile icon={<Users className="w-3.5 h-3.5" />} label="Active developers" value={stats.users.toLocaleString()} sub={`${stats.activeDays} days with activity`} />
+          <StatTile icon={<Cpu className="w-3.5 h-3.5" />} label="Tokens" value={formatNumber(stats.tokens)} sub={`${cacheShare}% cache reads`} />
+          <StatTile icon={<Gauge className="w-3.5 h-3.5" />} label="Median developer" value={formatUsd(Math.round(stats.medianUserCost))} sub={`top 10% above ${formatUsd(Math.round(stats.p90UserCost))}`} />
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-2 mb-10">
+          {/* Per-tool */}
+          <div id="per-tool" className="rounded-lg border border-border overflow-hidden">
+            <div className="px-4 py-2.5 bg-surface-1 border-b border-border micro-label">Spend by tool</div>
+            <div className="divide-y divide-border-subtle">
+              {stats.perTool.slice(0, 8).map((t) => (
+                <Link key={t.tool} href={`/tool/${encodeURIComponent(t.tool)}`} className="flex items-center gap-3 px-4 py-2.5 hover:bg-surface-1 transition-colors group">
+                  <span className="flex-1 text-sm font-medium group-hover:text-accent transition-colors">{toolLabel(t.tool)}</span>
+                  <span className="text-xs text-muted">{t.users} devs</span>
+                  <span className="w-28 text-right text-sm font-mono font-semibold text-accent">{formatUsd(Math.round(t.cost))}</span>
+                </Link>
+              ))}
+            </div>
+            <p className="px-4 py-2.5 text-xs text-muted border-t border-border m-0">
+              A day&apos;s spend counts toward every tool active that day, so tool figures can sum past the total.
+            </p>
+          </div>
+
+          {/* Per-model */}
+          <div id="per-model" className="rounded-lg border border-border overflow-hidden">
+            <div className="px-4 py-2.5 bg-surface-1 border-b border-border micro-label">Spend by model</div>
+            <div className="divide-y divide-border-subtle">
+              {stats.perModel.slice(0, 8).map((m) => (
+                <div key={m.model} className="flex items-center gap-3 px-4 py-2.5">
+                  <span className="flex-1 text-sm font-mono truncate">{prettyModelName(m.model)}</span>
+                  <span className="w-28 text-right text-sm font-mono font-semibold text-accent">{formatUsd(Math.round(m.cost))}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* Top spenders */}
+        <div id="top-spenders" className="rounded-lg border border-border overflow-hidden mb-10 max-w-3xl">
+          <div className="px-4 py-2.5 bg-surface-1 border-b border-border micro-label">Top spenders — {label}</div>
+          <div className="divide-y divide-border-subtle">
+            {stats.topSpenders.map((u, i) => (
+              <Link key={u.username} href={`/profile/${encodeURIComponent(u.username)}`} className="flex items-center gap-3 px-4 py-2.5 hover:bg-surface-1 transition-colors group">
+                <span className={`w-6 text-center text-sm font-mono ${i === 0 ? "text-[#f5b008] font-bold" : "text-muted"}`}>{i + 1}</span>
+                <span className="flex-1 min-w-0 text-sm font-medium truncate group-hover:text-accent transition-colors">{u.username}</span>
+                <span className="text-xs text-muted hidden sm:block">{u.activeDays} days active</span>
+                <span className="w-24 text-right text-sm font-mono text-muted hidden sm:block">{formatNumber(u.tokens)}</span>
+                <span className="w-28 text-right text-sm font-mono font-semibold text-accent">{formatUsd(Math.round(u.cost))}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {/* Month nav + CTA */}
+        <div className="flex flex-wrap items-center gap-3 mb-10">
+          <Link href={`/stats/monthly/${prev}`} className="px-3 py-1.5 rounded-md border bg-surface-1 border-border text-sm text-muted hover:text-foreground transition-colors">
+            ← {monthLabel(prev)}
+          </Link>
+          {hasNext && (
+            <Link href={`/stats/monthly/${next}`} className="px-3 py-1.5 rounded-md border bg-surface-1 border-border text-sm text-muted hover:text-foreground transition-colors">
+              {monthLabel(next)} →
+            </Link>
+          )}
+          <Link href="/stats" className="px-3 py-1.5 rounded-md border bg-surface-1 border-border text-sm text-muted hover:text-foreground transition-colors">
+            All-time stats
+          </Link>
+        </div>
+
+        <div className="rounded-lg border border-accent/40 bg-surface-1 p-6 max-w-3xl">
+          <p className="font-medium mb-1 flex items-center gap-2">
+            <TrendingUp className="w-4 h-4 text-accent" />
+            Be in next month&apos;s report
+          </p>
+          <p className="text-sm text-muted mb-3">
+            One command reads your local logs and adds your usage to the board — only totals are submitted, never
+            code or prompts. <code className="font-mono text-accent">viberank-cli autosubmit</code> keeps you counted
+            every month.
+          </p>
+          <code className="font-mono text-accent text-sm">npx viberank-cli</code>
+        </div>
+
+        <p className="text-xs text-muted mt-8 max-w-3xl flex items-start gap-1.5">
+          <CalendarDays className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
+          <span>
+            Numbers cite this page as: Viberank, &quot;AI coding spend — {label}&quot;, {SITE}/stats/monthly/{month}.
+            Costs are API-equivalent values computed by ccusage from model list prices; developers on flat-rate
+            subscriptions pay less. Verified and unverified submissions included; flagged submissions excluded.
+          </span>
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/stats/monthly/page.tsx
+++ b/src/app/stats/monthly/page.tsx
@@ -1,0 +1,108 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import { formatUsd } from "@/lib/utils";
+
+const SITE = "https://www.viberank.app";
+const TITLE = "Monthly AI Coding Spend Reports | Viberank";
+const DESC =
+  "Month-by-month reports on what developers actually spend on AI coding — totals, medians, per-tool and per-model breakdowns from real ccusage data on the Viberank leaderboard.";
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: `${SITE}/stats/monthly` },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE}/stats/monthly`,
+    siteName: "Viberank",
+    type: "website",
+    images: [
+      `/api/og?title=${encodeURIComponent("Monthly spend reports")}&description=${encodeURIComponent("What AI coding actually costs, month by month")}`,
+    ],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+function monthLabel(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  return `${MONTHS[m - 1]} ${y}`;
+}
+
+export default async function MonthlyIndexPage() {
+  let monthly: { month: string; cost: number; users: number }[] = [];
+  try {
+    const dataLayer = await getServerDataLayer();
+    const site = await dataLayer.stats.getSiteStats();
+    monthly = (site?.monthly ?? []).slice().sort((a, b) => (a.month < b.month ? 1 : -1));
+  } catch {
+    // render empty state
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link href="/stats" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          All-time stats
+        </Link>
+
+        <p className="micro-label mb-3">Reports</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">Monthly spend reports</h1>
+        <p className="text-muted mb-10 max-w-2xl">
+          What AI coding actually costs, month by month — totals, medians, and per-tool breakdowns from real{" "}
+          <a
+            href="https://github.com/ryoppippi/ccusage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            ccusage
+          </a>{" "}
+          data. Free to cite with a link.
+        </p>
+
+        {monthly.length > 0 ? (
+          <div className="rounded-lg border border-border overflow-hidden max-w-2xl">
+            <div className="flex items-center gap-3 px-4 py-2.5 micro-label bg-surface-1 border-b border-border">
+              <div className="flex-1">Month</div>
+              <div className="w-24 text-right">Devs</div>
+              <div className="w-32 text-right">Tracked spend</div>
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {monthly.map((m) => (
+                <Link
+                  key={m.month}
+                  href={`/stats/monthly/${m.month}`}
+                  className="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors group"
+                >
+                  <span className="flex-1 text-sm font-medium group-hover:text-accent transition-colors">
+                    {monthLabel(m.month)}
+                  </span>
+                  <span className="w-24 text-right text-sm font-mono text-muted">{m.users.toLocaleString()}</span>
+                  <span className="w-32 text-right text-sm font-mono font-semibold text-accent">
+                    {formatUsd(Math.round(m.cost))}
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <p className="text-muted">Reports are generating — check back shortly.</p>
+        )}
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -166,7 +166,12 @@ export default async function StatsPage() {
             Gemini CLI, Copilot and every agent ccusage tracks.
             {site?.firstDate && site?.lastDate && (
               <> Tracking {site.firstDate} → {site.lastDate}.</>
-            )}
+            )}{" "}
+            Prefer it month by month? See the{" "}
+            <Link href="/stats/monthly" className="text-accent hover:underline">
+              monthly spend reports
+            </Link>
+            .
           </p>
           {!exact && (
             <p className="text-xs text-muted/70 mt-2">

--- a/src/app/tool/[tool]/page.tsx
+++ b/src/app/tool/[tool]/page.tsx
@@ -14,6 +14,14 @@ interface ToolParams {
 
 const SITE = "https://www.viberank.app";
 
+// Per-tool "how to check usage" guides — the query family these boards
+// surface for in search ("<tool> check usage") deserves a one-click answer.
+const TOOL_GUIDES: Record<string, { href: string; label: string }> = {
+  claude: { href: "/blog/how-to-check-claude-code-usage", label: "How to check your Claude Code usage" },
+  codex: { href: "/blog/codex-token-usage-leaderboard", label: "How to check your Codex usage (/status + ccusage)" },
+  opencode: { href: "/blog/how-to-check-opencode-usage", label: "How to check your OpenCode usage" },
+};
+
 // Regenerate per-tool boards hourly.
 export const revalidate = 3600;
 
@@ -125,6 +133,15 @@ export default async function ToolPage({ params }: ToolParams) {
           Developers ranked by their {label} usage ({toolBlurb(tool)}) — by cost and tokens, from real{" "}
           <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">ccusage</a>{" "}
           data. Submit yours with <code className="font-mono text-accent">npx viberank-cli</code>.
+          {TOOL_GUIDES[tool] && (
+            <>
+              {" "}New here?{" "}
+              <Link href={TOOL_GUIDES[tool].href} className="text-accent hover:underline">
+                {TOOL_GUIDES[tool].label}
+              </Link>
+              .
+            </>
+          )}
         </p>
 
         {/* Browse other tools */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,6 +5,8 @@ const RESOURCES = [
   { name: "Cost calculator", href: "/calculator" },
   { name: "Blog", href: "/blog" },
   { name: "Compare AI coding tools", href: "/compare" },
+  { name: "Claude rank tracker", href: "/claude-rank-tracker" },
+  { name: "한국어 안내", href: "/ko" },
   { name: "Hire AI-native engineers", href: "/hire" },
   { name: "Claude Code usage limits", href: "/blog/claude-code-usage-limits" },
   { name: "Check your Claude Code usage", href: "/blog/how-to-check-claude-code-usage" },

--- a/src/lib/blogPosts.ts
+++ b/src/lib/blogPosts.ts
@@ -19,6 +19,15 @@ export interface BlogPost {
 
 export const BLOG_POSTS: BlogPost[] = [
   {
+    slug: "how-to-check-opencode-usage",
+    title: "How to Check OpenCode Usage: Tokens, Costs & Session Stats (2026)",
+    excerpt:
+      "OpenCode has no built-in usage meter — but one ccusage command turns its local session logs into per-day token counts and real API costs. Plus dashboards and the public leaderboard.",
+    datePublished: "2026-08-18",
+    dateModified: "2026-08-18",
+    readTime: "5 min read",
+  },
+  {
     slug: "claude-code-usage-limits",
     title: "Claude Code Usage Limits Explained (2026): 5-Hour Sessions, Weekly Caps & What To Do When You Hit Them",
     excerpt:
@@ -56,11 +65,11 @@ export const BLOG_POSTS: BlogPost[] = [
   },
   {
     slug: "codex-token-usage-leaderboard",
-    title: "How to Track OpenAI Codex Token Usage — and Join the Codex Leaderboard",
+    title: "How to Check Codex Usage: /status, Token Counts & Costs (2026)",
     excerpt:
-      "Turn Codex CLI's local logs into daily token counts and costs with ccusage, understand why the numbers look huge, and rank yourself against 190+ Codex developers.",
+      "Two commands answer it: /status inside Codex CLI for your 5-hour and weekly limits, and ccusage for token-level history and costs — plus the public Codex leaderboard.",
     datePublished: "2026-07-24",
-    dateModified: "2026-07-24",
+    dateModified: "2026-08-18",
     readTime: "6 min read",
   },
   {

--- a/src/lib/data/demo/client.ts
+++ b/src/lib/data/demo/client.ts
@@ -8,6 +8,7 @@ import type {
   FindProfilesResult,
   GlobalStats,
   SiteStats,
+  MonthStats,
   HireListing,
   LeaderboardParams,
   LeaderboardResult,
@@ -458,6 +459,10 @@ export function createDemoDataLayer(): DataLayer {
       // The demo backend has no site-wide rollup table; returning null is the
       // documented "not available" signal and callers already handle it.
       async getSiteStats(): Promise<SiteStats | null> {
+        return null;
+      },
+      // Same "not available" signal as getSiteStats — demo has no daily rollup.
+      async getMonthStats(): Promise<MonthStats | null> {
         return null;
       },
       // The demo backend has no cohort to rank against; an empty list makes

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -21,6 +21,7 @@ import type {
   ProfileWithSubmissions,
   GlobalStats,
   SiteStats,
+  MonthStats,
   ClaimStatus,
   ClaimResult,
   DeleteResult,
@@ -1775,6 +1776,18 @@ export class SupabaseStatsService implements StatsService {
       return null;
     }
     return data as SiteStats;
+  }
+
+  async getMonthStats(month: string): Promise<MonthStats | null> {
+    // Exact per-month aggregates (migration 013). The function validates the
+    // month format server-side; invalid input returns an empty-month object.
+    if (!/^\d{4}-\d{2}$/.test(month)) return null;
+    const { data, error } = await this.client.rpc("get_month_stats", { p_month: month });
+    if (error || !data) {
+      if (error) console.error("get_month_stats failed:", error.message);
+      return null;
+    }
+    return data as MonthStats;
   }
 
   async getSpendRows(): Promise<BurnRow[]> {

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -235,6 +235,26 @@ export interface SiteStats {
   modelSpend: { model: string; cost: number }[];
 }
 
+/**
+ * One month's exact aggregates from get_month_stats() (migration 013), for
+ * the /stats/monthly report pages. Note: perTool costs attribute a day's
+ * whole spend to every agent active that day, so they can sum past `cost`.
+ */
+export interface MonthStats {
+  month: string;
+  cost: number;
+  tokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  users: number;
+  activeDays: number;
+  medianUserCost: number;
+  p90UserCost: number;
+  topSpenders: { username: string; cost: number; tokens: number; activeDays: number }[];
+  perTool: { tool: string; cost: number; users: number }[];
+  perModel: { model: string; cost: number }[];
+}
+
 export interface ClaimStatus {
   actionNeeded: "claim" | "merge" | null;
   actionText: string;
@@ -342,6 +362,8 @@ export interface StatsService {
   getGlobalStats(): Promise<GlobalStats>;
   /** Exact aggregates via get_site_stats() (migration 007); null if the function isn't deployed. */
   getSiteStats(): Promise<SiteStats | null>;
+  /** One month's aggregates via get_month_stats() (migration 013); null if unavailable. */
+  getMonthStats(month: string): Promise<MonthStats | null>;
   /** Raw rows for the /calculator spend curve. */
   getSpendRows(): Promise<import("@/lib/spend-curve").BurnRow[]>;
 }

--- a/supabase/migrations/013_month_stats.sql
+++ b/supabase/migrations/013_month_stats.sql
@@ -1,0 +1,86 @@
+-- Migration 013: per-month aggregates for the /stats/monthly report pages.
+--
+-- get_site_stats() (007/008) answers "all time"; the monthly report pages
+-- need one month sliced every way that makes a report worth citing: totals,
+-- per-tool and per-model splits, top spenders, and a median that the
+-- all-time function can't provide. One function call per page render, and
+-- the pages are ISR-cached, so the scans stay rare.
+
+CREATE OR REPLACE FUNCTION get_month_stats(p_month TEXT)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH month_days AS (
+    SELECT d.date,
+           d.total_cost,
+           d.total_tokens,
+           d.input_tokens,
+           d.output_tokens,
+           d.cache_read_tokens,
+           d.cache_creation_tokens,
+           d.agents,
+           d.model_breakdowns,
+           s.username
+    FROM daily_breakdowns d
+    JOIN submissions s ON s.id = d.submission_id
+    WHERE s.flagged_for_review IS NOT TRUE
+      AND p_month ~ '^\d{4}-\d{2}$'
+      AND to_char(d.date, 'YYYY-MM') = p_month
+  ),
+  per_user AS (
+    SELECT username,
+           SUM(total_cost) AS cost,
+           SUM(total_tokens) AS tokens,
+           COUNT(DISTINCT date) AS active_days
+    FROM month_days
+    GROUP BY username
+  )
+  SELECT jsonb_build_object(
+    'month', p_month,
+    'cost', COALESCE((SELECT SUM(total_cost) FROM month_days), 0),
+    'tokens', COALESCE((SELECT SUM(total_tokens) FROM month_days), 0),
+    'outputTokens', COALESCE((SELECT SUM(output_tokens) FROM month_days), 0),
+    'cacheReadTokens', COALESCE((SELECT SUM(cache_read_tokens) FROM month_days), 0),
+    'users', (SELECT COUNT(*) FROM per_user),
+    'activeDays', (SELECT COUNT(DISTINCT date) FROM month_days),
+    'medianUserCost', COALESCE((
+      SELECT percentile_cont(0.5) WITHIN GROUP (ORDER BY cost) FROM per_user
+    ), 0),
+    'p90UserCost', COALESCE((
+      SELECT percentile_cont(0.9) WITHIN GROUP (ORDER BY cost) FROM per_user
+    ), 0),
+    'topSpenders', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+               'username', username, 'cost', cost, 'tokens', tokens, 'activeDays', active_days))
+      FROM (
+        SELECT * FROM per_user ORDER BY cost DESC LIMIT 10
+      ) t
+    ), '[]'::jsonb),
+    'perTool', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('tool', tool, 'cost', cost, 'users', users) ORDER BY cost DESC)
+      FROM (
+        SELECT a.tool, SUM(m.total_cost) AS cost, COUNT(DISTINCT m.username) AS users
+        FROM month_days m, unnest(m.agents) AS a(tool)
+        GROUP BY a.tool
+      ) x
+    ), '[]'::jsonb),
+    'perModel', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('model', model, 'cost', cost) ORDER BY cost DESC)
+      FROM (
+        SELECT mb->>'modelName' AS model, SUM((mb->>'cost')::numeric) AS cost
+        FROM month_days m,
+        LATERAL jsonb_array_elements(m.model_breakdowns) mb
+        WHERE m.model_breakdowns IS NOT NULL
+          AND mb->>'modelName' IS NOT NULL
+        GROUP BY 1
+        ORDER BY 2 DESC
+        LIMIT 10
+      ) x
+    ), '[]'::jsonb)
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION get_month_stats(TEXT) TO anon, authenticated, service_role;


### PR DESCRIPTION
## Driven by Search Console analysis (2026-08-18)

Internal search-performance analysis showed visibility rising while clicks stayed flat — the gaps were intent-match and CTR, not indexing. Each change maps to a measured gap (numbers kept internal).

### 1. Monthly spend reports (`/stats/monthly/[month]`) — prod DB migration
- Migration `get_month_stats(month)` (applied to prod): per-month totals, median/p90 developer cost, per-tool + per-model spend, top-10 spenders
- Report pages with Dataset schema + citation line, month nav, ISR hourly; index at `/stats/monthly`; months since Sep 2025 in the sitemap
- Per-tool figures carry an explicit double-counting caveat (a day's spend counts toward every agent active that day)

### 2. "Check usage" intent fixes
- A large query family ("how to check codex usage", "opencode check usage", "codex tokens left"…) surfaced with near-zero CTR because page titles didn't match the question
- Codex post retitled to lead with the answer ("How to Check Codex Usage: /status, Token Counts & Costs"), gains a verified `/status` section + tokens-left/credits FAQs
- New post: **How to Check OpenCode Usage**; tool pages link their per-tool guides; blog index title upgraded

### 3. `/claude-rank-tracker` landing page
- The "claude rank / rank tracker" query cluster had no dedicated page; new landing with a live top-5 board and honest FAQ disambiguation

### 4. Korean landing page (`/ko`)
- Korea is a top market for the site; Korean-language landing with FAQPage schema, wired via bidirectional hreflang on the homepage

## Verification
- `pnpm build` passes; monthly reports prerendered from live prod data
- Smoke-tested on `next start`: invalid month 404s, hreflang pairs match, rank-tracker renders live top 5
- `get_month_stats` tested directly against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)