### PR TITLE
feat: IndexNow key file

### DIFF
--- a/public/d57d1cf37451a0b46e0e3e15d9f4d9bc.txt
+++ b/public/d57d1cf37451a0b46e0e3e15d9f4d9bc.txt
@@ -1,0 +1,1 @@
+d57d1cf37451a0b46e0e3e15d9f4d9bc


### PR DESCRIPTION
Hosts the IndexNow verification key so new URLs can be pushed to
Bing, Naver, and other IndexNow engines on publish — Naver matters
for the Korean audience /ko now serves.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
