### PR TITLE
fix(cli): scheduled autosubmit runs never actually submitted (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## CLI v1.5.0 — autosubmit actually submits (August 2026)
+
+### Fixed
+- **Scheduled autosubmit runs never submitted.** Three compounding bugs: `submit --quiet` still ran interactive prompts, which cancel silently (exit 0) with no TTY; `cc.json` was written to the scheduler's working directory (`/` under launchd); and ccusage was invoked via `npx` from PATH, which launchd/schtasks jobs don't have node on. Every scheduled run since the feature shipped was a no-op that looked successful in the logs. `--quiet` (or any non-TTY stdin) now takes a dedicated prompt-free path: token-authenticated, PATH-safe ccusage invocation resolved next to the running node binary, temp file under `~/.viberank/`, network retries with backoff, and one timestamped log line per run — success or failure, with a real exit code.
+- **Missed-run catch-up now works on all three platforms**, not just Linux. launchd's calendar trigger doesn't fire across a power-off, and schtasks DAILY doesn't catch up either; macOS now also runs at login (`RunAtLoad`) and Windows gains an `ONLOGON` companion task. A 20-hour staleness guard in the CLI keeps catch-up triggers from double-submitting.
+- The interactive flow now remembers your confirmed GitHub username (`~/.viberank/config.json`) so scheduled runs can label submissions without prompting; the server still resolves identity from the API token either way.
+
 ## v2.0 — Multi-tool leaderboard (June 2026)
 
 viberank evolved from a Claude Code leaderboard into the leaderboard for **all AI coding usage** — Claude Code, Codex, Gemini CLI, Copilot, OpenCode and every other tool [ccusage](https://github.com/ryoppippi/ccusage) tracks.

--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
@@ -10,12 +10,33 @@ import chalk from 'chalk';
 import ora from 'ora';
 import prompts from 'prompts';
 import fetch from 'node-fetch';
-import { getToken, getMachineId, writeConfig, clearToken, looksLikeToken, CONFIG_DIR } from './lib/config.js';
+import { getToken, getMachineId, readConfig, writeConfig, clearToken, looksLikeToken, CONFIG_DIR } from './lib/config.js';
 import * as autosubmit from './lib/autosubmit.js';
 import { collectCorpus } from './lib/corpus.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Quiet mode: no prompts, no cwd side effects, timestamped log lines. A
+// scheduled run passes --quiet explicitly; a missing TTY means there is no
+// human to answer prompts either way, so treat that as quiet too rather than
+// cancel (the pre-1.5 behavior: prompts got EOF, "cancelled", exit 0 — every
+// scheduled autosubmit run since the feature shipped was a silent no-op).
+const QUIET = process.argv.includes('--quiet') || !process.stdin.isTTY;
+
+/** Generate a fresh ccusage report to `dest` without relying on PATH or a
+ * shell redirect — a launchd/schtasks job runs with a minimal PATH that has
+ * no node or npx on it, so resolve npx next to the running node binary the
+ * same way lib/autosubmit.js does. */
+function generateCcJson(dest) {
+  const npxLocal = path.join(path.dirname(process.execPath), process.platform === 'win32' ? 'npx.cmd' : 'npx');
+  const npx = fs.existsSync(npxLocal) ? npxLocal : 'npx';
+  const out = execFileSync(npx, ['-y', 'ccusage@latest', 'daily', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  fs.writeFileSync(dest, out);
+}
 
 // Read package.json to get version
 const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
@@ -152,7 +173,79 @@ async function autosubmitCommand(arg) {
   console.log(chalk.gray('  Turn it off with: npx viberank-cli autosubmit off\n'));
 }
 
+/**
+ * The scheduled path: no prompts, no cwd writes, one timestamped line per run.
+ * Identity comes from the API token (the server resolves the token's owner and
+ * ignores the header claim), so a token is required here.
+ */
+async function quietSubmit() {
+  const stamp = () => `[${new Date().toISOString()}]`;
+
+  if (!getToken()) {
+    console.error(`${stamp()} no API token — run \`npx viberank-cli login\`, then re-enable autosubmit`);
+    process.exit(1);
+  }
+
+  // RunAtLoad/logon triggers fire on every boot; skip if a run already
+  // succeeded in the last 20 hours so catch-up never double-submits.
+  const last = readConfig().lastAutosubmit;
+  if (last && Date.now() - Date.parse(last) < 20 * 60 * 60 * 1000) {
+    console.log(`${stamp()} already submitted at ${last}, skipping`);
+    return;
+  }
+
+  const ccJsonPath = path.join(CONFIG_DIR, 'cc.json');
+  try {
+    generateCcJson(ccJsonPath);
+  } catch (error) {
+    console.error(`${stamp()} ccusage failed: ${error.message}`);
+    process.exit(1);
+  }
+
+  const ccData = JSON.parse(fs.readFileSync(ccJsonPath, 'utf8'));
+  try {
+    const corpus = collectCorpus();
+    if (corpus) ccData.drift = { corpus };
+  } catch { /* best effort */ }
+
+  const githubUser = readConfig().username || 'autosubmit';
+  let lastError = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const response = await fetch('https://www.viberank.app/api/submit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-GitHub-User': githubUser,
+          'X-CLI-Version': CLI_VERSION,
+          'X-Machine-Id': getMachineId(),
+          Authorization: `Bearer ${getToken()}`,
+        },
+        body: JSON.stringify(ccData),
+      });
+      const result = await response.json().catch(() => ({}));
+      if (response.ok && result.success) {
+        writeConfig({ lastAutosubmit: new Date().toISOString() });
+        console.log(`${stamp()} submitted ${ccData.daily?.length ?? '?'} days — ${result.profileUrl ?? ''}`);
+        try { fs.unlinkSync(ccJsonPath); } catch { /* fine */ }
+        return;
+      }
+      lastError = new Error(result.error || `server returned ${response.status}`);
+      if (response.status !== 503 && response.status < 500) break; // 4xx: retrying won't help
+    } catch (error) {
+      lastError = error; // network error — retry
+    }
+    if (attempt < 3) await new Promise((r) => setTimeout(r, 5000 * attempt));
+  }
+
+  try { fs.unlinkSync(ccJsonPath); } catch { /* fine */ }
+  console.error(`${stamp()} submit failed: ${lastError?.message ?? 'unknown error'}`);
+  process.exit(1);
+}
+
 async function main() {
+  if (QUIET) return quietSubmit();
+
   console.log(chalk.yellow.bold(`\n🚀 Viberank Submission Tool v${CLI_VERSION}\n`));
 
   // Try to get GitHub username from remote URL first, then fall back to git config
@@ -200,6 +293,8 @@ async function main() {
   }
   
   githubUser = response.username;
+  // Remember it: a scheduled --quiet run has no TTY to ask on.
+  try { writeConfig({ username: githubUser }); } catch { /* best effort */ }
 
   // Check if cc.json already exists
   let ccJsonPath = path.join(process.cwd(), 'cc.json');
@@ -218,10 +313,7 @@ async function main() {
       const spinner = ora('Generating usage data with ccusage...').start();
       
       try {
-        execSync('npx ccusage@latest daily --json > cc.json', { 
-          encoding: 'utf8',
-          stdio: 'pipe' 
-        });
+        generateCcJson(ccJsonPath);
         spinner.succeed('Generated cc.json successfully');
       } catch (error) {
         spinner.fail('Failed to generate cc.json');
@@ -238,10 +330,7 @@ async function main() {
     const spinner = ora('Generating usage data with ccusage...').start();
     
     try {
-      execSync('npx ccusage@latest daily --json > cc.json', { 
-        encoding: 'utf8',
-        stdio: 'pipe' 
-      });
+      generateCcJson(ccJsonPath);
       spinner.succeed('Generated cc.json successfully');
     } catch (error) {
       spinner.fail('Failed to generate cc.json');
@@ -437,7 +526,6 @@ async function main() {
 }
 
 const [command, arg] = process.argv.slice(2).filter((a) => !a.startsWith('--'));
-const QUIET = process.argv.includes('--quiet');
 
 const run = async () => {
   switch (command) {

--- a/packages/viberank-cli/lib/autosubmit.js
+++ b/packages/viberank-cli/lib/autosubmit.js
@@ -77,9 +77,11 @@ ${args}
   </array>
   <key>StartCalendarInterval</key>
   <dict><key>Hour</key><integer>${hour}</integer><key>Minute</key><integer>0</integer></dict>
-  <!-- Fire on wake if the machine was asleep at the scheduled time, so a
-       laptop that is shut overnight still submits. -->
-  <key>RunAtLoad</key><false/>
+  <!-- launchd coalesces a missed StartCalendarInterval on wake from sleep,
+       but not across a power-off: a laptop shut down overnight would skip
+       the day entirely. RunAtLoad fires at login instead; the CLI's quiet
+       path skips within 20h of a success, so this never double-submits. -->
+  <key>RunAtLoad</key><true/>
   <key>StandardOutPath</key><string>${LOG_FILE}</string>
   <key>StandardErrorPath</key><string>${LOG_FILE}</string>
 </dict>
@@ -147,6 +149,16 @@ export function enable(hour = 9) {
     '/TR', tr,
     '/SC', 'DAILY', '/ST', `${String(hour).padStart(2, '0')}:00`,
   ], { stdio: 'ignore' });
+  // A DAILY trigger does not catch up if the machine was off at the scheduled
+  // time. A second ONLOGON task covers that; the CLI's 20-hour guard keeps
+  // the pair from double-submitting.
+  try {
+    execFileSync('schtasks', [
+      '/Create', '/F', '/TN', 'viberank-autosubmit-logon',
+      '/TR', tr,
+      '/SC', 'ONLOGON',
+    ], { stdio: 'ignore' });
+  } catch { /* logon trigger can need elevation on some setups; daily still works */ }
   return { scheduler: 'schtasks', path: 'viberank-autosubmit', hour, durable: invocation().durable };
 }
 
@@ -167,7 +179,9 @@ export function disable() {
     return true;
   }
   if (target === 'schtasks') {
-    try { execFileSync('schtasks', ['/Delete', '/F', '/TN', 'viberank-autosubmit'], { stdio: 'ignore' }); } catch { /* not present */ }
+    for (const tn of ['viberank-autosubmit', 'viberank-autosubmit-logon']) {
+      try { execFileSync('schtasks', ['/Delete', '/F', '/TN', tn], { stdio: 'ignore' }); } catch { /* not present */ }
+    }
     return true;
   }
   return false;

--- a/packages/viberank-cli/package-lock.json
+++ b/packages/viberank-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "viberank-cli",
-  "version": "1.2.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "viberank-cli",
-      "version": "1.2.0",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viberank-cli",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",


### PR DESCRIPTION
## The bug

`npx viberank-cli autosubmit` schedules `viberank submit --quiet` via launchd/systemd/schtasks — but `--quiet` only timestamped error logs. The submit path still ran three interactive prompts, which cancel silently (exit **0**) when there's no TTY. Result: **every scheduled run since the feature shipped was a no-op that looked successful in scheduler logs.** Reproduced with `npx viberank-cli@1.4.1 submit --quiet < /dev/null` — prints the username prompt, exits 0, submits nothing.

Two more bugs would have broken it anyway:
- `cc.json` was written to the scheduler's cwd (`/` under launchd)
- ccusage was invoked as `npx ccusage@latest daily --json > cc.json` via shell + PATH — launchd jobs have no node/npx on PATH

## The fix

- `--quiet` (or any non-TTY stdin) takes a dedicated prompt-free path: requires the API token (identity resolves server-side from it), PATH-safe ccusage invocation (npx resolved next to the running node, same trick as autosubmit.js), temp file under `~/.viberank/`, retries with backoff on network/5xx, timestamped log line per run, real exit codes
- Interactive submits now remember the confirmed username for scheduled runs to label
- **Missed-run catch-up on all platforms**: launchd `RunAtLoad` (calendar triggers don't fire across power-off) and a Windows `ONLOGON` companion task; a 20h staleness guard prevents double-submits (server merge is idempotent regardless)

## Verified locally
- No-token quiet run: timestamped error, exit 1
- PATH-safe generation: 99 days parsed from real logs
- Invalid-token run: full pipeline → server 401 surfaced, no 4xx retry, exit 1, temp cleaned
- `node --check` on both files

## Rollout
npx-scheduled jobs run `viberank-cli@latest` and self-heal on next fire once **v1.5.0 is published to npm** (needs `npm login` + `npm publish` from a maintainer — not done here, npm auth unavailable). Global-install users need `npm i -g viberank-cli@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)