### PR TITLE
fix: reject implausible GitHub usernames at both ends (#119)

### DIFF
--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -24,6 +24,15 @@ const __dirname = path.dirname(__filename);
 // scheduled autosubmit run since the feature shipped was a silent no-op).
 const QUIET = process.argv.includes('--quiet') || !process.stdin.isTTY;
 
+/** GitHub handle: 1-39 alphanumerics with single interior hyphens. The
+ * fallback source for the default is `git config user.name`, which has held
+ * anything from real names to captured shell fragments — one of which ended
+ * up as a public profile and a sitemap entry (#119). Validate rather than
+ * warn: a warning is skippable, a re-prompt is not. */
+function looksLikeGithubHandle(value) {
+  return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(value);
+}
+
 /** Generate a fresh ccusage report to `dest` without relying on PATH or a
  * shell redirect — a launchd/schtasks job runs with a minimal PATH that has
  * no node or npx on it, so resolve npx next to the running node binary the
@@ -283,8 +292,10 @@ async function main() {
     type: 'text',
     name: 'username',
     message: 'GitHub username:',
-    initial: githubUser || '',
-    validate: value => value.length > 0 || 'Username is required'
+    initial: githubUser && looksLikeGithubHandle(githubUser) ? githubUser : '',
+    validate: (value) =>
+      looksLikeGithubHandle(value.trim()) ||
+      'That is not a valid GitHub username (1-39 letters, digits, single hyphens)'
   });
   
   if (!response.username) {
@@ -292,7 +303,7 @@ async function main() {
     process.exit(1);
   }
   
-  githubUser = response.username;
+  githubUser = response.username.trim();
   // Remember it: a scheduled --quiet run has no TTY to ask on.
   try { writeConfig({ username: githubUser }); } catch { /* best effort */ }
 

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -123,6 +123,20 @@ export async function POST(request: NextRequest) {
           { status: 400 }
         );
       }
+
+      // The header is unauthenticated and its upstream default is
+      // `git config user.name`, which has held shell fragments that became
+      // public profile pages and sitemap entries (#119). Only a plausible
+      // GitHub handle may create a profile this way; token and OAuth
+      // identities above come from GitHub itself and need no check.
+      if (!/^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(githubUsername)) {
+        return NextResponse.json(
+          {
+            error: `"${githubUsername.slice(0, 60)}" is not a valid GitHub username (1-39 letters, digits, single hyphens). Pass your GitHub handle in X-GitHub-User, or run npx viberank-cli login to submit with a token.`,
+          },
+          { status: 400 }
+        );
+      }
     }
 
     // Check if ccData is null or undefined


### PR DESCRIPTION
The CLI's git-config fallback let shell fragments, emails, and command
lines become public profile pages and sitemap entries. The CLI now
re-prompts on an invalid handle instead of warning past it, and
/api/submit 400s header-claimed names that can't be GitHub handles
(token/OAuth identities come from GitHub and skip the check). Prod
cleaned: 7 junk profiles removed (backed up), one @-prefixed duplicate
reassigned to its real profile.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
