### PR TITLE
feat: Monthly Wrapped + Friend Leagues + self-serve submission deletion

### DIFF
--- a/src/app/api/leagues/[slug]/invite/route.ts
+++ b/src/app/api/leagues/[slug]/invite/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+
+// The invite code, revealed only to current members — it's the sole gate on
+// joining, so it never renders into the public page HTML.
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.username) {
+    return NextResponse.json({ error: "Sign in with GitHub first." }, { status: 401 });
+  }
+
+  const { slug } = await params;
+  const dataLayer = await getServerDataLayer();
+  const code = await dataLayer.leagues.getInviteCode(slug, session.user.username);
+  if (!code) {
+    return NextResponse.json({ error: "Members only." }, { status: 403 });
+  }
+  return NextResponse.json({ code });
+}

--- a/src/app/api/leagues/join/route.ts
+++ b/src/app/api/leagues/join/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+
+// Join a league by invite code. Idempotent for existing members.
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.username) {
+    return NextResponse.json({ error: "Sign in with GitHub first." }, { status: 401 });
+  }
+
+  let code: string;
+  try {
+    const body = await request.json();
+    if (typeof body.code !== "string" || !body.code.trim()) throw new Error("bad payload");
+    code = body.code.trim();
+  } catch {
+    return NextResponse.json({ error: "Expected JSON body: { code: string }" }, { status: 400 });
+  }
+
+  try {
+    const dataLayer = await getServerDataLayer();
+    const league = await dataLayer.leagues.joinByCode(code, session.user.username);
+    return NextResponse.json({ success: true, league });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not join league.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/src/app/api/leagues/route.ts
+++ b/src/app/api/leagues/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+
+// Create a league. Identity comes from the GitHub OAuth session; the creator
+// becomes the first member and the only holder of the invite code until they
+// share it.
+export async function POST(request: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.username) {
+    return NextResponse.json({ error: "Sign in with GitHub first." }, { status: 401 });
+  }
+
+  let name: string;
+  try {
+    const body = await request.json();
+    if (typeof body.name !== "string") throw new Error("bad payload");
+    name = body.name;
+  } catch {
+    return NextResponse.json({ error: "Expected JSON body: { name: string }" }, { status: 400 });
+  }
+
+  try {
+    const dataLayer = await getServerDataLayer();
+    const { league, inviteCode } = await dataLayer.leagues.create(name, session.user.username);
+    return NextResponse.json({ success: true, league, inviteCode });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Could not create league.";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}
+
+// The signed-in user's leagues, for the /leagues landing page.
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.username) {
+    return NextResponse.json({ leagues: [] });
+  }
+  const dataLayer = await getServerDataLayer();
+  const leagues = await dataLayer.leagues.listForUser(session.user.username);
+  return NextResponse.json({ leagues });
+}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -333,6 +333,76 @@ async function profileCard(searchParams: URLSearchParams, headers: HeadersInit) 
   );
 }
 
+
+// Monthly Wrapped share card: four big tiles under a month headline. Same
+// palette as the profile card so shared links read as one family.
+function wrappedCard(searchParams: URLSearchParams, headers: HeadersInit) {
+  const username = searchParams.get('username') || 'developer';
+  const label = searchParams.get('label') || 'This month';
+  const cost = Number(searchParams.get('cost') || 0);
+  const tokens = searchParams.get('tokens') || '0';
+  const rank = searchParams.get('rank') || '—';
+  const actives = searchParams.get('actives') || '—';
+  const days = searchParams.get('days') || '0';
+  const streak = searchParams.get('streak') || '0';
+
+  const tile = (labelText: string, value: string, sub?: string) => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#1a1a1a',
+        border: '1px solid #2a2a2a',
+        borderRadius: 16,
+        padding: '24px 28px',
+        width: 238,
+      }}
+    >
+      <div style={{ color: '#8a8a8a', fontSize: 20, textTransform: 'uppercase', letterSpacing: 2 }}>{labelText}</div>
+      <div style={{ color: '#f5f5f5', fontSize: 44, fontWeight: 700, marginTop: 8 }}>{value}</div>
+      {sub ? <div style={{ color: '#8a8a8a', fontSize: 18, marginTop: 4 }}>{sub}</div> : null}
+    </div>
+  );
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          backgroundColor: '#121212',
+          padding: '40px 64px',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+          <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div style={{ color: '#f97316', fontSize: 26, textTransform: 'uppercase', letterSpacing: 4 }}>
+              Monthly Wrapped
+            </div>
+            <div style={{ color: '#f5f5f5', fontSize: 56, fontWeight: 700, marginTop: 6 }}>
+              {`${username} — ${label}`}
+            </div>
+          </div>
+          <div style={{ color: '#f97316', fontSize: 34, fontWeight: 700 }}>viberank</div>
+        </div>
+        <div style={{ display: 'flex', gap: 24, marginTop: 36 }}>
+          {tile('Spend', `$${cost.toLocaleString('en-US')}`, 'API-equivalent')}
+          {tile('Tokens', tokens)}
+          {tile('Rank', `#${rank}`, `of ${actives} active devs`)}
+          {tile('Streak', `${streak} days`, `${days} active days`)}
+        </div>
+        <div style={{ color: '#8a8a8a', fontSize: 22, marginTop: 32 }}>
+          Real ccusage data · get yours: npx viberank-cli
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630, headers }
+  );
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -348,6 +418,10 @@ export async function GET(request: Request) {
 
     if (searchParams.get('type') === 'profile') {
       return profileCard(searchParams, cacheHeaders);
+    }
+
+    if (searchParams.get('type') === 'wrapped') {
+      return wrappedCard(searchParams, cacheHeaders);
     }
 
     const title = searchParams.get('title') || 'Viberank';

--- a/src/app/api/submissions/[id]/route.ts
+++ b/src/app/api/submissions/[id]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+
+// Delete one of your own submissions (#127). The data layer's filter is the
+// ownership guard: the row must carry the session username directly or via
+// claimed_by, so there is no path to deleting someone else's data.
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.username) {
+    return NextResponse.json({ error: "Sign in with GitHub first." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  if (!/^[0-9a-f-]{36}$/i.test(id)) {
+    return NextResponse.json({ error: "Invalid submission id." }, { status: 400 });
+  }
+
+  const dataLayer = await getServerDataLayer();
+  const deleted = await dataLayer.submissions.deleteOwn(session.user.username, id);
+  if (!deleted) {
+    return NextResponse.json(
+      { error: "No such submission on your profile." },
+      { status: 404 }
+    );
+  }
+  return NextResponse.json({ success: true });
+}

--- a/src/app/league/[slug]/InvitePanel.tsx
+++ b/src/app/league/[slug]/InvitePanel.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Copy, Check, KeyRound } from "lucide-react";
+
+// Fetches the invite code client-side so it never lands in the (cached,
+// public) page HTML — the API only reveals it to members.
+export default function InvitePanel({ slug }: { slug: string }) {
+  const [code, setCode] = useState<string | null>(null);
+  const [copied, setCopied] = useState<"code" | "link" | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/leagues/${encodeURIComponent(slug)}/invite`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => setCode(d?.code ?? null))
+      .catch(() => setCode(null));
+  }, [slug]);
+
+  if (!code) return null;
+
+  const link = `https://www.viberank.app/league/join/${code}`;
+  const copy = (what: "code" | "link") => {
+    navigator.clipboard.writeText(what === "code" ? code : link);
+    setCopied(what);
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  return (
+    <div className="rounded-lg border border-accent/40 bg-surface-1 p-5">
+      <p className="font-medium mb-1 flex items-center gap-2">
+        <KeyRound className="w-4 h-4 text-accent" />
+        Invite people
+      </p>
+      <p className="text-sm text-muted mb-3">Only members can see this. Share either one:</p>
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          onClick={() => copy("code")}
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-border bg-surface-2 font-mono text-sm text-accent hover:bg-surface-1 transition-colors"
+        >
+          {copied === "code" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+          {code}
+        </button>
+        <button
+          onClick={() => copy("link")}
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-border bg-surface-2 text-sm text-foreground hover:bg-surface-1 transition-colors"
+        >
+          {copied === "link" ? <Check className="w-3.5 h-3.5 text-green-500" /> : <Copy className="w-3.5 h-3.5" />}
+          Copy join link
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/league/[slug]/page.tsx
+++ b/src/app/league/[slug]/page.tsx
@@ -1,0 +1,140 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { ArrowLeft, BadgeCheck } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import TierBadge from "@/components/TierBadge";
+import { formatNumber, formatCurrency } from "@/lib/utils";
+import InvitePanel from "./InvitePanel";
+
+interface LeagueParams {
+  params: Promise<{ slug: string }>;
+}
+
+const SITE = "https://www.viberank.app";
+
+// League boards move with their members' daily submissions.
+export const revalidate = 300;
+
+const getLeague = cache(async (slug: string) => {
+  try {
+    const dataLayer = await getServerDataLayer();
+    return await dataLayer.leagues.getBySlug(slug);
+  } catch {
+    return null;
+  }
+});
+
+export async function generateMetadata({ params }: LeagueParams): Promise<Metadata> {
+  const { slug: raw } = await params;
+  const slug = decodeURIComponent(raw);
+  const data = await getLeague(slug);
+  if (!data) return {};
+  const title = `${data.league.name} — League Leaderboard | Viberank`;
+  const description = `${data.league.name}: ${data.members.length} developers ranked by real AI coding usage on Viberank.`;
+  return {
+    title,
+    description,
+    alternates: { canonical: `${SITE}/league/${slug}` },
+    // Private-ish spaces shouldn't compete in search; the global board does that.
+    robots: { index: false, follow: true },
+    openGraph: {
+      title,
+      description,
+      url: `${SITE}/league/${slug}`,
+      siteName: "Viberank",
+      type: "website",
+      images: [
+        `/api/og?title=${encodeURIComponent(data.league.name)}&description=${encodeURIComponent(`${data.members.length} developers · league leaderboard`)}`,
+      ],
+    },
+    twitter: { card: "summary_large_image", title, description },
+  };
+}
+
+export default async function LeaguePage({ params }: LeagueParams) {
+  const { slug: raw } = await params;
+  const slug = decodeURIComponent(raw);
+  const data = await getLeague(slug);
+  if (!data) notFound();
+
+  const { league, members } = data;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        <Link href="/leagues" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leagues
+        </Link>
+
+        <p className="micro-label mb-3">League</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">{league.name}</h1>
+        <p className="text-muted mb-8">
+          {members.length} member{members.length === 1 ? "" : "s"}, ranked by all-time board totals. Started by{" "}
+          <Link href={`/profile/${encodeURIComponent(league.createdBy)}`} className="text-accent hover:underline">
+            {league.createdBy}
+          </Link>
+          .
+        </p>
+
+        {members.length > 0 ? (
+          <div className="rounded-lg border border-border overflow-hidden mb-8">
+            <div className="flex items-center gap-3 px-4 py-2.5 micro-label bg-surface-1 border-b border-border">
+              <div className="w-8 text-center">#</div>
+              <div className="flex-1">Member</div>
+              <div className="hidden sm:block w-24">Tier</div>
+              <div className="w-28 text-right">Cost</div>
+              <div className="w-24 text-right hidden sm:block">Tokens</div>
+            </div>
+            <div className="divide-y divide-border-subtle">
+              {members.map((m, i) => (
+                <Link
+                  key={m.username}
+                  href={`/profile/${encodeURIComponent(m.username)}`}
+                  className="flex items-center gap-3 px-4 py-3 hover:bg-surface-1 transition-colors group"
+                >
+                  <div className={`w-8 text-center text-sm font-mono ${i === 0 ? "text-[#f5b008] font-bold" : i === 1 ? "text-[#b8bcc4] font-bold" : i === 2 ? "text-[#c2703f] font-bold" : "text-muted"}`}>
+                    {i + 1}
+                  </div>
+                  <div className="flex-1 min-w-0 flex items-center gap-1.5">
+                    <span className="text-sm font-medium truncate group-hover:text-accent transition-colors">
+                      {m.username}
+                    </span>
+                    {m.verified && <BadgeCheck className="w-4 h-4 text-blue-500 flex-shrink-0" />}
+                  </div>
+                  <div className="hidden sm:block w-24 flex-shrink-0">
+                    {m.totalCost > 0 && <TierBadge totalCost={m.totalCost} size="xs" bare />}
+                  </div>
+                  <div className="w-28 text-right text-sm font-mono font-semibold text-accent">
+                    {m.totalCost > 0 ? `$${formatCurrency(m.totalCost)}` : "—"}
+                  </div>
+                  <div className="w-24 text-right text-sm font-mono text-muted hidden sm:block">
+                    {m.totalTokens > 0 ? formatNumber(m.totalTokens) : "no data yet"}
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border p-10 text-center mb-8">
+            <p className="font-medium mb-1">Nobody here yet</p>
+            <p className="text-sm text-muted">Share the invite code to fill the board.</p>
+          </div>
+        )}
+
+        <InvitePanel slug={slug} />
+
+        <p className="text-xs text-muted mt-8">
+          Members without a submission show as &quot;no data yet&quot; — one{" "}
+          <code className="font-mono text-accent">npx viberank-cli</code> fixes that.
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/league/join/[code]/SignInToJoin.tsx
+++ b/src/app/league/join/[code]/SignInToJoin.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { LogIn } from "lucide-react";
+import { usePathname } from "next/navigation";
+
+export default function SignInToJoin() {
+  const pathname = usePathname();
+  return (
+    <button
+      onClick={() => signIn("github", { callbackUrl: pathname ?? "/leagues" })}
+      className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity"
+    >
+      <LogIn className="w-4 h-4" />
+      Sign in with GitHub to join
+    </button>
+  );
+}

--- a/src/app/league/join/[code]/page.tsx
+++ b/src/app/league/join/[code]/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import SignInToJoin from "./SignInToJoin";
+
+interface JoinParams {
+  params: Promise<{ code: string }>;
+}
+
+export const metadata: Metadata = {
+  title: "Join a league | Viberank",
+  description: "Join a private AI coding leaderboard with an invite code.",
+  robots: { index: false, follow: false },
+};
+
+// Invite links resolve per-visitor; never cache a join.
+export const dynamic = "force-dynamic";
+
+export default async function JoinPage({ params }: JoinParams) {
+  const { code: raw } = await params;
+  const code = decodeURIComponent(raw);
+  const session = await getServerSession(authOptions);
+
+  if (session?.user?.username) {
+    let slug: string | null = null;
+    let error: string | null = null;
+    try {
+      const dataLayer = await getServerDataLayer();
+      const league = await dataLayer.leagues.joinByCode(code, session.user.username);
+      slug = league.slug;
+    } catch (e) {
+      error = e instanceof Error ? e.message : "Could not join.";
+    }
+    if (slug) redirect(`/league/${slug}`);
+
+    return (
+      <div className="min-h-screen bg-background">
+        <NavBar />
+        <div className="max-w-xl mx-auto px-6 py-16 text-center">
+          <p className="font-medium mb-2">That didn&apos;t work</p>
+          <p className="text-sm text-muted mb-6">{error}</p>
+          <Link href="/leagues" className="text-accent hover:underline text-sm">
+            Back to leagues
+          </Link>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+      <div className="max-w-xl mx-auto px-6 py-16">
+        <p className="micro-label mb-3">League invite</p>
+        <h1 className="font-mono text-2xl font-bold tracking-tight mb-2">You&apos;re invited</h1>
+        <p className="text-muted mb-6">
+          Sign in with GitHub to accept — leagues hang off your GitHub identity, same as the verified badge.
+        </p>
+        <SignInToJoin />
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/leagues/LeaguesClient.tsx
+++ b/src/app/leagues/LeaguesClient.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
+import { Plus, LogIn, ArrowRight } from "lucide-react";
+import Link from "next/link";
+
+interface LeaguesClientProps {
+  signedIn: boolean;
+  myLeagues: { slug: string; name: string }[];
+}
+
+export default function LeaguesClient({ signedIn, myLeagues }: LeaguesClientProps) {
+  const router = useRouter();
+  const [name, setName] = useState("");
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState<"create" | "join" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [created, setCreated] = useState<{ slug: string; inviteCode: string } | null>(null);
+
+  const create = async () => {
+    setBusy("create");
+    setError(null);
+    try {
+      const res = await fetch("/api/leagues", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Could not create league.");
+      setCreated({ slug: data.league.slug, inviteCode: data.inviteCode });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create league.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const join = async () => {
+    setBusy("join");
+    setError(null);
+    try {
+      const res = await fetch("/api/leagues/join", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Could not join league.");
+      router.push(`/league/${data.league.slug}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not join league.");
+      setBusy(null);
+    }
+  };
+
+  if (!signedIn) {
+    return (
+      <div className="rounded-lg border border-accent/40 bg-surface-1 p-6">
+        <p className="font-medium mb-1">Sign in to start or join a league</p>
+        <p className="text-sm text-muted mb-4">
+          Leagues hang off your GitHub identity, same as the verified badge.
+        </p>
+        <button
+          onClick={() => signIn("github")}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity"
+        >
+          <LogIn className="w-4 h-4" />
+          Sign in with GitHub
+        </button>
+      </div>
+    );
+  }
+
+  if (created) {
+    return (
+      <div className="rounded-lg border border-accent/40 bg-surface-1 p-6">
+        <p className="font-medium mb-2">League created 🎉</p>
+        <p className="text-sm text-muted mb-1">Share this invite code — it&apos;s the only way in:</p>
+        <p className="font-mono text-xl text-accent mb-1">{created.inviteCode}</p>
+        <p className="text-sm text-muted mb-4">
+          Or share the join link:{" "}
+          <span className="font-mono text-foreground text-xs">
+            viberank.app/league/join/{created.inviteCode}
+          </span>
+        </p>
+        <Link
+          href={`/league/${created.slug}`}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity"
+        >
+          Open your league
+          <ArrowRight className="w-4 h-4" />
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {myLeagues.length > 0 && (
+        <div className="rounded-lg border border-border bg-surface-1 p-5">
+          <p className="micro-label mb-3">Your leagues</p>
+          <div className="flex flex-wrap gap-2">
+            {myLeagues.map((l) => (
+              <Link
+                key={l.slug}
+                href={`/league/${l.slug}`}
+                className="px-3 py-1.5 rounded-md border bg-surface-2 border-border text-sm text-foreground hover:text-accent transition-colors"
+              >
+                {l.name}
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="rounded-lg border border-border bg-surface-1 p-5">
+          <p className="font-medium mb-3 flex items-center gap-2">
+            <Plus className="w-4 h-4 text-accent" />
+            Start a league
+          </p>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="League name (2-60 chars)"
+            maxLength={60}
+            className="w-full px-3 py-2 rounded-md bg-background border border-border text-sm text-foreground placeholder:text-muted mb-3 focus:outline-none focus:border-accent"
+          />
+          <button
+            onClick={create}
+            disabled={busy !== null || name.trim().length < 2}
+            className="w-full px-4 py-2 rounded-md bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+          >
+            {busy === "create" ? "Creating…" : "Create league"}
+          </button>
+        </div>
+
+        <div className="rounded-lg border border-border bg-surface-1 p-5">
+          <p className="font-medium mb-3 flex items-center gap-2">
+            <LogIn className="w-4 h-4 text-accent" />
+            Join with a code
+          </p>
+          <input
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            placeholder="Invite code"
+            className="w-full px-3 py-2 rounded-md bg-background border border-border text-sm font-mono text-foreground placeholder:text-muted mb-3 focus:outline-none focus:border-accent"
+          />
+          <button
+            onClick={join}
+            disabled={busy !== null || !code.trim()}
+            className="w-full px-4 py-2 rounded-md border border-border bg-surface-2 text-sm text-foreground font-medium hover:bg-surface-1 transition-colors disabled:opacity-50"
+          >
+            {busy === "join" ? "Joining…" : "Join league"}
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/leagues/page.tsx
+++ b/src/app/leagues/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, Users, Trophy, Shield } from "lucide-react";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+import type { League } from "@/lib/data/types";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import LeaguesClient from "./LeaguesClient";
+
+const SITE = "https://www.viberank.app";
+const TITLE = "Friend Leagues — Private AI Coding Leaderboards | Viberank";
+const DESC =
+  "Start a private leaderboard with your friends or team. Invite-code leagues rank real AI coding usage from ccusage — Claude Code, Codex, Gemini CLI and more.";
+
+export const metadata: Metadata = {
+  title: TITLE,
+  description: DESC,
+  alternates: { canonical: `${SITE}/leagues` },
+  openGraph: {
+    title: TITLE,
+    description: DESC,
+    url: `${SITE}/leagues`,
+    siteName: "Viberank",
+    type: "website",
+    images: [
+      `/api/og?title=${encodeURIComponent("Friend Leagues")}&description=${encodeURIComponent("Private AI coding leaderboards with invite codes")}`,
+    ],
+  },
+  twitter: { card: "summary_large_image", title: TITLE, description: DESC },
+};
+
+export default async function LeaguesPage() {
+  const session = await getServerSession(authOptions);
+  let myLeagues: League[] = [];
+  if (session?.user?.username) {
+    try {
+      const dataLayer = await getServerDataLayer();
+      myLeagues = await dataLayer.leagues.listForUser(session.user.username);
+    } catch {
+      // render without
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        <Link href="/" className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6">
+          <ArrowLeft className="w-3.5 h-3.5" />
+          Leaderboard
+        </Link>
+
+        <p className="micro-label mb-3">Leagues</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+          Your own leaderboard, your own people
+        </h1>
+        <p className="text-muted mb-8 max-w-2xl">
+          The global board has 1,100+ developers. A league has the ones you actually know — teammates, friends, your
+          Discord. Same real <a href="https://github.com/ryoppippi/ccusage" target="_blank" rel="noopener noreferrer" className="text-accent hover:underline">ccusage</a>{" "}
+          data, private invite code, bragging rights that matter.
+        </p>
+
+        <div className="grid gap-4 sm:grid-cols-3 mb-10">
+          <div className="rounded-lg border border-border bg-surface-1 p-4">
+            <Users className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium text-sm mb-1">Invite-only</p>
+            <p className="text-xs text-muted m-0">A private code gates the door. Up to 100 members per league.</p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-4">
+            <Trophy className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium text-sm mb-1">Same real data</p>
+            <p className="text-xs text-muted m-0">Members rank by their board totals — no separate submission needed.</p>
+          </div>
+          <div className="rounded-lg border border-border bg-surface-1 p-4">
+            <Shield className="w-5 h-5 text-accent mb-2" />
+            <p className="font-medium text-sm mb-1">Public page, private door</p>
+            <p className="text-xs text-muted m-0">League boards are viewable; joining requires the code.</p>
+          </div>
+        </div>
+
+        <LeaguesClient
+          signedIn={Boolean(session?.user?.username)}
+          myLeagues={myLeagues.map((l) => ({ slug: l.slug, name: l.name }))}
+        />
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/profile/[username]/page.tsx
+++ b/src/app/profile/[username]/page.tsx
@@ -570,7 +570,32 @@ export default async function ProfilePage({ params }: ProfileParams) {
           </div>
         )}
       </div>
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 pb-10">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 pb-10 space-y-6">
+        {/* Personal monthly recap — the share loop's entry point. */}
+        <div className="rounded-lg border border-accent/40 bg-surface-1 p-5">
+          <p className="font-medium mb-1">Monthly Wrapped</p>
+          <p className="text-sm text-muted mb-3">
+            A shareable recap of a month on the board — spend, tokens, streak, and rank among that month&apos;s
+            active developers.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {[0, 1].map((back) => {
+              const d = new Date();
+              d.setUTCMonth(d.getUTCMonth() - back);
+              const m = `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+              const label = back === 0 ? "This month" : "Last month";
+              return (
+                <Link
+                  key={m}
+                  href={`/wrapped/${m}/${encodeURIComponent(profileData.username)}`}
+                  className="px-3 py-1.5 rounded-md border bg-surface-2 border-border text-sm text-foreground hover:text-accent transition-colors"
+                >
+                  {label} →
+                </Link>
+              );
+            })}
+          </div>
+        </div>
         <BadgeSnippet username={profileData.username} />
       </div>
       <Footer />

--- a/src/app/settings/submissions/SubmissionsClient.tsx
+++ b/src/app/settings/submissions/SubmissionsClient.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState } from "react";
+import { BadgeCheck, Trash2 } from "lucide-react";
+import { formatCurrency, formatNumber } from "@/lib/utils";
+
+interface Row {
+  id: string;
+  totalCost: number;
+  totalTokens: number;
+  dateRange: { start: string; end: string };
+  verified: boolean;
+}
+
+export default function SubmissionsClient({ initialRows }: { initialRows: Row[] }) {
+  const [rows, setRows] = useState(initialRows);
+  const [confirming, setConfirming] = useState<string | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const remove = async (id: string) => {
+    setBusy(id);
+    setError(null);
+    try {
+      const res = await fetch(`/api/submissions/${id}`, { method: "DELETE" });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Delete failed.");
+      setRows((r) => r.filter((row) => row.id !== id));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed.");
+    } finally {
+      setBusy(null);
+      setConfirming(null);
+    }
+  };
+
+  if (rows.length === 0) {
+    return <p className="text-sm text-muted">No submissions on your profile.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.map((row) => (
+        <div key={row.id} className="rounded-lg border border-border bg-surface-1 p-4 flex items-center gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium flex items-center gap-1.5 mb-0.5">
+              {row.dateRange.start} → {row.dateRange.end}
+              {row.verified && <BadgeCheck className="w-4 h-4 text-blue-500" />}
+            </p>
+            <p className="text-xs text-muted m-0 font-mono">
+              ${formatCurrency(row.totalCost)} · {formatNumber(row.totalTokens)} tokens
+            </p>
+          </div>
+          {confirming === row.id ? (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => remove(row.id)}
+                disabled={busy === row.id}
+                className="px-3 py-1.5 rounded-md bg-red-600 text-white text-xs font-medium hover:opacity-90 transition-opacity disabled:opacity-50"
+              >
+                {busy === row.id ? "Deleting…" : "Confirm delete"}
+              </button>
+              <button
+                onClick={() => setConfirming(null)}
+                className="px-3 py-1.5 rounded-md border border-border text-xs text-muted hover:text-foreground transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={() => setConfirming(row.id)}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-xs text-muted hover:text-red-400 hover:border-red-400/40 transition-colors"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              Delete
+            </button>
+          )}
+        </div>
+      ))}
+      {error && <p className="text-sm text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/settings/submissions/page.tsx
+++ b/src/app/settings/submissions/page.tsx
@@ -1,0 +1,85 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { getServerDataLayer } from "@/lib/data";
+import NavBar from "@/components/NavBar";
+import Footer from "@/components/Footer";
+import SubmissionsClient from "./SubmissionsClient";
+
+export const metadata: Metadata = {
+  title: "Your submissions | Viberank",
+  description: "Review and delete your own leaderboard submissions.",
+  robots: { index: false, follow: false },
+};
+
+// Always reflect the current session and current rows.
+export const dynamic = "force-dynamic";
+
+export default async function SubmissionsSettingsPage() {
+  const session = await getServerSession(authOptions);
+
+  let rows: {
+    id: string;
+    totalCost: number;
+    totalTokens: number;
+    dateRange: { start: string; end: string };
+    verified: boolean;
+  }[] = [];
+
+  if (session?.user?.username) {
+    try {
+      const dataLayer = await getServerDataLayer();
+      const profile = await dataLayer.profiles.getProfile(session.user.username, 50);
+      rows = (profile?.submissions ?? []).map((s) => ({
+        id: s.id,
+        totalCost: s.totalCost,
+        totalTokens: s.totalTokens,
+        dateRange: s.dateRange,
+        verified: s.verified,
+      }));
+    } catch {
+      // render empty state
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <NavBar />
+      <main className="flex-1 max-w-2xl w-full mx-auto px-4 sm:px-6 py-10">
+        <Link
+          href={session?.user?.username ? `/profile/${encodeURIComponent(session.user.username)}` : "/"}
+          className="inline-flex items-center gap-1.5 micro-label text-muted hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          {session?.user?.username ? "Your profile" : "Leaderboard"}
+        </Link>
+
+        <p className="micro-label mb-3">Settings</p>
+        <h1 className="font-mono text-2xl font-bold tracking-tight mb-2">Your submissions</h1>
+        <p className="text-muted text-sm mb-8 max-w-xl">
+          Deleting a submission removes its days from your profile and the boards. Useful when a machine migration
+          or backfill double-counted a range (
+          <a
+            href="https://github.com/sculptdotfun/viberank/issues/127"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            #127
+          </a>
+          ) — delete the bad row, then re-submit clean with{" "}
+          <code className="font-mono text-accent">npx viberank-cli</code>.
+        </p>
+
+        {session?.user?.username ? (
+          <SubmissionsClient initialRows={rows} />
+        ) : (
+          <p className="text-sm text-muted">Sign in with GitHub to manage your submissions.</p>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -56,6 +56,7 @@ const staticEntries: MetadataRoute.Sitemap = [
   { url: `${SITE}/compare`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
   { url: `${SITE}/claude-rank-tracker`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.9 },
   { url: `${SITE}/ko`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
+  { url: `${SITE}/leagues`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },
   { url: `${SITE}/hire`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/stats`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
   { url: `${SITE}/stats/monthly`, lastModified: new Date(), changeFrequency: "weekly", priority: 0.7 },

--- a/src/app/stats/monthly/[month]/page.tsx
+++ b/src/app/stats/monthly/[month]/page.tsx
@@ -244,6 +244,11 @@ export default async function MonthReportPage({ params }: MonthParams) {
             every month.
           </p>
           <code className="font-mono text-accent text-sm">npx viberank-cli</code>
+          <p className="text-sm text-muted mt-3 mb-0">
+            Already on the board? Your personal recap lives at{" "}
+            <span className="font-mono text-foreground">/wrapped/{month}/&#123;your-username&#125;</span> — or find
+            it on your profile.
+          </p>
         </div>
 
         <p className="text-xs text-muted mt-8 max-w-3xl flex items-start gap-1.5">

--- a/src/app/wrapped/[month]/[username]/WrappedShare.tsx
+++ b/src/app/wrapped/[month]/[username]/WrappedShare.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check, Share2 } from "lucide-react";
+import type { UserMonthStats } from "@/lib/data/types";
+import { formatNumber, formatUsd } from "@/lib/utils";
+
+interface WrappedShareProps {
+  username: string;
+  month: string;
+  label: string;
+  stats: UserMonthStats;
+  percentile: number;
+}
+
+export default function WrappedShare({ username, month, label, stats, percentile }: WrappedShareProps) {
+  const [copied, setCopied] = useState(false);
+
+  const url = `https://www.viberank.app/wrapped/${month}/${encodeURIComponent(username)}`;
+  const text = `My ${label} in AI coding 🧾\n\n💸 ${formatUsd(Math.round(stats.cost))} (API-equivalent)\n🔢 ${formatNumber(stats.tokens)} tokens\n📅 ${stats.activeDays} active days · ${stats.longestStreak}-day streak\n🏆 top ${percentile}% of ${stats.totalActives} devs\n\nGet yours: npx viberank-cli`;
+
+  const copyLink = () => {
+    navigator.clipboard.writeText(url);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const shareToX = () => {
+    window.open(
+      `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
+      "_blank"
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <button
+        onClick={shareToX}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-accent text-white text-sm font-medium hover:opacity-90 transition-opacity"
+      >
+        <Share2 className="w-4 h-4" />
+        Share on X
+      </button>
+      <button
+        onClick={copyLink}
+        className="inline-flex items-center gap-2 px-4 py-2 rounded-md border border-border bg-surface-1 text-sm text-foreground hover:bg-surface-2 transition-colors"
+      >
+        {copied ? <Check className="w-4 h-4 text-green-500" /> : <Copy className="w-4 h-4" />}
+        {copied ? "Copied" : "Copy link"}
+      </button>
+    </div>
+  );
+}

--- a/src/app/wrapped/[month]/[username]/page.tsx
+++ b/src/app/wrapped/[month]/[username]/page.tsx
@@ -1,0 +1,196 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { cache } from "react";
+import { ArrowLeft, Flame, CalendarDays, Trophy, Cpu, DollarSign, Zap } from "lucide-react";
+import { getServerDataLayer } from "@/lib/data";
+import type { UserMonthStats } from "@/lib/data/types";
+import Footer from "@/components/Footer";
+import NavBar from "@/components/NavBar";
+import { formatNumber, formatUsd, prettyModelName, toolLabel } from "@/lib/utils";
+import WrappedShare from "./WrappedShare";
+
+interface WrappedParams {
+  params: Promise<{ month: string; username: string }>;
+}
+
+const SITE = "https://www.viberank.app";
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+// Past months are frozen; the current month grows until it closes.
+export const revalidate = 3600;
+
+function monthLabel(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  return `${MONTHS[m - 1]} ${y}`;
+}
+
+const getWrapped = cache(async (month: string, username: string): Promise<UserMonthStats | null> => {
+  try {
+    const dataLayer = await getServerDataLayer();
+    return await dataLayer.stats.getUserMonthStats(month, username);
+  } catch {
+    return null;
+  }
+});
+
+export async function generateMetadata({ params }: WrappedParams): Promise<Metadata> {
+  const { month: rawMonth, username: rawUser } = await params;
+  const month = decodeURIComponent(rawMonth);
+  const username = decodeURIComponent(rawUser);
+  if (!/^\d{4}-\d{2}$/.test(month)) return {};
+
+  const stats = await getWrapped(month, username);
+  const label = monthLabel(month);
+  const title = `${username}'s ${label} Wrapped | Viberank`;
+  const description = stats
+    ? `${username} in ${label}: ${formatUsd(Math.round(stats.cost))} of AI coding (API-equivalent), ${formatNumber(stats.tokens)} tokens, ${stats.activeDays} active days, rank #${stats.rank} of ${stats.totalActives}.`
+    : `Monthly AI coding recap for ${username} on Viberank.`;
+  const og = stats
+    ? `/api/og?type=wrapped&username=${encodeURIComponent(username)}&label=${encodeURIComponent(label)}&cost=${Math.round(stats.cost)}&tokens=${encodeURIComponent(formatNumber(stats.tokens))}&rank=${stats.rank}&actives=${stats.totalActives}&days=${stats.activeDays}&streak=${stats.longestStreak}`
+    : `/api/og?title=${encodeURIComponent("Monthly Wrapped")}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: `${SITE}/wrapped/${month}/${encodeURIComponent(username)}` },
+    // Personal recaps are for sharing, not for search results.
+    robots: { index: false, follow: true },
+    openGraph: {
+      title,
+      description,
+      url: `${SITE}/wrapped/${month}/${encodeURIComponent(username)}`,
+      siteName: "Viberank",
+      type: "article",
+      images: [{ url: og, width: 1200, height: 630, alt: title }],
+    },
+    twitter: { card: "summary_large_image", title, description, images: [og] },
+  };
+}
+
+function StatTile({ icon, label, value, sub }: { icon: React.ReactNode; label: string; value: string; sub?: string }) {
+  return (
+    <div className="bg-surface-1 border border-border rounded-lg p-5">
+      <p className="flex items-center gap-1.5 micro-label mb-1.5">
+        {icon}
+        {label}
+      </p>
+      <p className="font-mono text-2xl font-bold text-foreground m-0">{value}</p>
+      {sub && <p className="text-xs text-muted mt-1 mb-0">{sub}</p>}
+    </div>
+  );
+}
+
+export default async function WrappedPage({ params }: WrappedParams) {
+  const { month: rawMonth, username: rawUser } = await params;
+  const month = decodeURIComponent(rawMonth);
+  const username = decodeURIComponent(rawUser);
+  if (!/^\d{4}-\d{2}$/.test(month)) notFound();
+
+  const stats = await getWrapped(month, username);
+  if (!stats) notFound();
+
+  const label = monthLabel(month);
+  const percentile = Math.max(1, Math.round((stats.rank / stats.totalActives) * 100));
+  const topModel = stats.topModels[0];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <NavBar />
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        <Link
+          href={`/profile/${encodeURIComponent(username)}`}
+          className="inline-flex items-center gap-1.5 micro-label hover:text-foreground transition-colors mb-6"
+        >
+          <ArrowLeft className="w-3.5 h-3.5" />
+          {username}&apos;s profile
+        </Link>
+
+        <p className="micro-label mb-3">Monthly Wrapped</p>
+        <h1 className="font-mono text-2xl sm:text-3xl font-bold tracking-tight mb-2">
+          {username}&apos;s {label}
+        </h1>
+        <p className="text-muted mb-8">
+          Rank <span className="text-accent font-mono font-semibold">#{stats.rank}</span> of{" "}
+          {stats.totalActives.toLocaleString()} developers active in {label} — top {percentile}%. From real{" "}
+          <a
+            href="https://github.com/ryoppippi/ccusage"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent hover:underline"
+          >
+            ccusage
+          </a>{" "}
+          data.
+        </p>
+
+        <div className="grid gap-3 grid-cols-2 mb-8">
+          <StatTile
+            icon={<DollarSign className="w-3.5 h-3.5" />}
+            label="Spend"
+            value={formatUsd(Math.round(stats.cost))}
+            sub="API-equivalent"
+          />
+          <StatTile
+            icon={<Cpu className="w-3.5 h-3.5" />}
+            label="Tokens"
+            value={formatNumber(stats.tokens)}
+          />
+          <StatTile
+            icon={<CalendarDays className="w-3.5 h-3.5" />}
+            label="Active days"
+            value={String(stats.activeDays)}
+            sub={`best day ${formatUsd(Math.round(stats.bestDayCost))}`}
+          />
+          <StatTile
+            icon={<Flame className="w-3.5 h-3.5" />}
+            label="Longest streak"
+            value={`${stats.longestStreak} days`}
+          />
+        </div>
+
+        {(topModel || stats.tools.length > 0) && (
+          <div className="rounded-lg border border-border bg-surface-1 p-5 mb-8">
+            {topModel && (
+              <p className="text-sm mb-2">
+                <span className="micro-label mr-2">Top model</span>
+                <span className="font-mono text-foreground">{prettyModelName(topModel.model)}</span>
+                <span className="text-muted"> — {formatUsd(Math.round(topModel.cost))}</span>
+              </p>
+            )}
+            {stats.tools.length > 0 && (
+              <p className="text-sm m-0">
+                <span className="micro-label mr-2">Tools</span>
+                <span className="text-foreground">{stats.tools.map(toolLabel).join(" · ")}</span>
+              </p>
+            )}
+          </div>
+        )}
+
+        <WrappedShare username={username} month={month} label={label} stats={stats} percentile={percentile} />
+
+        <div className="rounded-lg border border-accent/40 bg-surface-1 p-5 mt-10">
+          <p className="font-medium mb-1 flex items-center gap-2">
+            <Trophy className="w-4 h-4 text-accent" />
+            Want yours?
+          </p>
+          <p className="text-sm text-muted mb-3">
+            One command puts your usage on the board — only totals leave your machine, and{" "}
+            <code className="font-mono text-accent">viberank-cli autosubmit</code> keeps every month&apos;s Wrapped
+            complete.
+          </p>
+          <code className="font-mono text-accent text-sm">npx viberank-cli</code>
+        </div>
+
+        <p className="text-sm text-muted mt-8">
+          <Zap className="w-3.5 h-3.5 inline mr-1" />
+          How everyone did: <Link href={`/stats/monthly/${month}`} className="text-accent hover:underline">the {label} report</Link>.
+        </p>
+      </div>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,6 +5,7 @@ const RESOURCES = [
   { name: "Cost calculator", href: "/calculator" },
   { name: "Blog", href: "/blog" },
   { name: "Compare AI coding tools", href: "/compare" },
+  { name: "Friend leagues", href: "/leagues" },
   { name: "Claude rank tracker", href: "/claude-rank-tracker" },
   { name: "한국어 안내", href: "/ko" },
   { name: "Hire AI-native engineers", href: "/hire" },

--- a/src/lib/data/demo/client.ts
+++ b/src/lib/data/demo/client.ts
@@ -9,6 +9,7 @@ import type {
   GlobalStats,
   SiteStats,
   MonthStats,
+  UserMonthStats,
   HireListing,
   LeaderboardParams,
   LeaderboardResult,
@@ -343,6 +344,10 @@ export function createDemoDataLayer(): DataLayer {
       },
     },
     submissions: {
+      async deleteOwn(): Promise<boolean> {
+        // Demo data is read-only.
+        return false;
+      },
       async submit(_data: SubmitData): Promise<string> {
         throw new Error("Demo data is read-only");
       },
@@ -455,6 +460,23 @@ export function createDemoDataLayer(): DataLayer {
         };
       },
     },
+    leagues: {
+      async create(): Promise<never> {
+        throw new Error("Leagues need the live backend.");
+      },
+      async joinByCode(): Promise<never> {
+        throw new Error("Leagues need the live backend.");
+      },
+      async getBySlug() {
+        return null;
+      },
+      async getInviteCode() {
+        return null;
+      },
+      async listForUser() {
+        return [];
+      },
+    },
     stats: {
       // The demo backend has no site-wide rollup table; returning null is the
       // documented "not available" signal and callers already handle it.
@@ -463,6 +485,9 @@ export function createDemoDataLayer(): DataLayer {
       },
       // Same "not available" signal as getSiteStats — demo has no daily rollup.
       async getMonthStats(): Promise<MonthStats | null> {
+        return null;
+      },
+      async getUserMonthStats(): Promise<UserMonthStats | null> {
         return null;
       },
       // The demo backend has no cohort to rank against; an empty list makes

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -22,6 +22,10 @@ import type {
   GlobalStats,
   SiteStats,
   MonthStats,
+  UserMonthStats,
+  League,
+  LeagueBoardRow,
+  LeaguesService,
   ClaimStatus,
   ClaimResult,
   DeleteResult,
@@ -747,6 +751,35 @@ export class SupabaseSubmissionsService implements SubmissionsService {
         throw new Error(`Failed to create profile: ${profileInsertError.message}`);
       }
     }
+  }
+
+  async deleteOwn(username: string, submissionId: string): Promise<boolean> {
+    // Ownership check and delete in one statement: the filter is the guard.
+    // Covers rows submitted as this user and unverified rows they claimed.
+    const { data, error } = await this.client
+      .from("submissions")
+      .delete()
+      .eq("id", submissionId)
+      .or(`username.eq.${username},claimed_by.eq.${username}`)
+      .select("id, username");
+    if (error) throw new Error(`deleteOwn failed: ${error.message}`);
+    if (!data || data.length === 0) return false;
+
+    // Keep the profile's cached rollups honest.
+    const owner = data[0].username;
+    const { data: remaining } = await this.client
+      .from("submissions")
+      .select("id, total_cost")
+      .eq("username", owner)
+      .order("total_cost", { ascending: false });
+    await this.client
+      .from("profiles")
+      .update({
+        total_submissions: remaining?.length ?? 0,
+        best_submission_id: remaining?.[0]?.id ?? null,
+      })
+      .eq("username", owner);
+    return true;
   }
 
   async getLeaderboard(params: LeaderboardParams): Promise<LeaderboardResult> {
@@ -1790,6 +1823,20 @@ export class SupabaseStatsService implements StatsService {
     return data as MonthStats;
   }
 
+  async getUserMonthStats(month: string, username: string): Promise<UserMonthStats | null> {
+    if (!/^\d{4}-\d{2}$/.test(month)) return null;
+    const { data, error } = await this.client.rpc("get_user_month_stats", {
+      p_month: month,
+      p_username: username,
+    });
+    if (error || !data) {
+      if (error) console.error("get_user_month_stats failed:", error.message);
+      return null;
+    }
+    const stats = data as UserMonthStats;
+    return stats.activeDays > 0 ? stats : null;
+  }
+
   async getSpendRows(): Promise<BurnRow[]> {
     // Only the four columns the spend curve needs, paged. The whole table is
     // ~1k rows and /calculator is ISR-cached hourly, so this is cheaper than
@@ -1941,17 +1988,181 @@ export class SupabaseTokensService implements TokensService {
   }
 }
 
+
+class SupabaseLeaguesService implements LeaguesService {
+  constructor(private client: SupabaseClient) {}
+
+  async create(name: string, creator: string): Promise<{ league: League; inviteCode: string }> {
+    const trimmed = name.trim();
+    if (trimmed.length < 2 || trimmed.length > 60) {
+      throw new Error("League names are 2-60 characters.");
+    }
+
+    const { count } = await this.client
+      .from("leagues")
+      .select("id", { count: "exact", head: true })
+      .eq("created_by", creator);
+    if ((count ?? 0) >= 5) throw new Error("You already run 5 leagues — that's the cap.");
+
+    // Slug from the name; a short random suffix resolves collisions without a
+    // read-check race.
+    const base = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40) || "league";
+    const slug = `${base}-${randomToken(4)}`;
+    const inviteCode = randomToken(10);
+
+    const { data: league, error } = await this.client
+      .from("leagues")
+      .insert({ slug, name: trimmed, created_by: creator })
+      .select()
+      .single();
+    if (error || !league) throw new Error(`Could not create league: ${error?.message}`);
+
+    const { error: inviteError } = await this.client
+      .from("league_invites")
+      .insert({ league_id: league.id, code: inviteCode });
+    if (inviteError) {
+      await this.client.from("leagues").delete().eq("id", league.id);
+      throw new Error(`Could not create league invite: ${inviteError.message}`);
+    }
+    await this.client.from("league_members").insert({ league_id: league.id, username: creator });
+
+    return { league: mapLeague(league), inviteCode };
+  }
+
+  async joinByCode(code: string, username: string): Promise<League> {
+    const { data: invite } = await this.client
+      .from("league_invites")
+      .select("league_id")
+      .eq("code", code.trim())
+      .maybeSingle();
+    if (!invite) throw new Error("That invite code doesn't match any league.");
+
+    const { count } = await this.client
+      .from("league_members")
+      .select("username", { count: "exact", head: true })
+      .eq("league_id", invite.league_id);
+    if ((count ?? 0) >= 100) throw new Error("This league is full (100 members).");
+
+    // Idempotent: joining twice is a no-op, not an error.
+    await this.client
+      .from("league_members")
+      .upsert({ league_id: invite.league_id, username }, { onConflict: "league_id,username" });
+
+    const { data: league } = await this.client
+      .from("leagues")
+      .select()
+      .eq("id", invite.league_id)
+      .single();
+    if (!league) throw new Error("League vanished mid-join.");
+    return mapLeague(league);
+  }
+
+  async getBySlug(slug: string): Promise<{ league: League; members: LeagueBoardRow[] } | null> {
+    const { data: league } = await this.client.from("leagues").select().eq("slug", slug).maybeSingle();
+    if (!league) return null;
+
+    const { data: memberRows } = await this.client
+      .from("league_members")
+      .select("username, joined_at")
+      .eq("league_id", league.id);
+    const usernames = (memberRows ?? []).map((m) => m.username);
+
+    // Best submission per member; the whole set is small (≤100 members), so
+    // dedupe client-side rather than grow the query surface.
+    let best = new Map<string, { totalCost: number; totalTokens: number; verified: boolean }>();
+    if (usernames.length > 0) {
+      const { data: subs } = await this.client
+        .from("submissions")
+        .select("username, total_cost, total_tokens, verified")
+        .in("username", usernames)
+        .or("flagged_for_review.is.null,flagged_for_review.eq.false");
+      for (const sub of subs ?? []) {
+        const prior = best.get(sub.username);
+        if (!prior || sub.total_cost > prior.totalCost) {
+          best.set(sub.username, {
+            totalCost: sub.total_cost,
+            totalTokens: sub.total_tokens,
+            verified: sub.verified,
+          });
+        }
+      }
+    }
+
+    const members: LeagueBoardRow[] = (memberRows ?? [])
+      .map((m) => ({
+        username: m.username,
+        joinedAt: m.joined_at,
+        totalCost: best.get(m.username)?.totalCost ?? 0,
+        totalTokens: best.get(m.username)?.totalTokens ?? 0,
+        verified: best.get(m.username)?.verified ?? false,
+      }))
+      .sort((a, b) => b.totalCost - a.totalCost);
+
+    return { league: mapLeague(league), members };
+  }
+
+  async getInviteCode(slug: string, requester: string): Promise<string | null> {
+    const { data: league } = await this.client.from("leagues").select("id").eq("slug", slug).maybeSingle();
+    if (!league) return null;
+    const { data: membership } = await this.client
+      .from("league_members")
+      .select("username")
+      .eq("league_id", league.id)
+      .eq("username", requester)
+      .maybeSingle();
+    if (!membership) return null;
+    const { data: invite } = await this.client
+      .from("league_invites")
+      .select("code")
+      .eq("league_id", league.id)
+      .maybeSingle();
+    return invite?.code ?? null;
+  }
+
+  async listForUser(username: string): Promise<League[]> {
+    const { data } = await this.client
+      .from("league_members")
+      .select("leagues(*)")
+      .eq("username", username);
+    return (data ?? [])
+      .map((row) => (row as unknown as { leagues: LeagueRow | null }).leagues)
+      .filter((l): l is LeagueRow => Boolean(l))
+      .map(mapLeague);
+  }
+}
+
+interface LeagueRow {
+  id: string;
+  slug: string;
+  name: string;
+  created_by: string;
+  created_at: string;
+}
+
+function mapLeague(row: LeagueRow): League {
+  return { id: row.id, slug: row.slug, name: row.name, createdBy: row.created_by, createdAt: row.created_at };
+}
+
+/** URL-safe random token; crypto-strength because invite codes gate joins. */
+function randomToken(bytes: number): string {
+  const buf = new Uint8Array(bytes);
+  crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(36).padStart(2, "0")).join("").slice(0, bytes + 6);
+}
+
 class SupabaseDataLayer implements DataLayer {
   tokens: TokensService;
   submissions: SubmissionsService;
   profiles: ProfilesService;
   stats: StatsService;
+  leagues: LeaguesService;
 
   constructor(client: SupabaseClient) {
     this.tokens = new SupabaseTokensService(client);
     this.submissions = new SupabaseSubmissionsService(client);
     this.profiles = new SupabaseProfilesService(client);
     this.stats = new SupabaseStatsService(client);
+    this.leagues = new SupabaseLeaguesService(client);
   }
 }
 

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -255,6 +255,39 @@ export interface MonthStats {
   perModel: { model: string; cost: number }[];
 }
 
+/** One user's month from get_user_month_stats() (migration 015) — Wrapped data. */
+export interface UserMonthStats {
+  month: string;
+  username: string;
+  cost: number;
+  tokens: number;
+  activeDays: number;
+  bestDayCost: number;
+  longestStreak: number;
+  /** 1-based rank among that month's active users, by cost. */
+  rank: number;
+  totalActives: number;
+  topModels: { model: string; cost: number }[];
+  tools: string[];
+}
+
+export interface League {
+  id: string;
+  slug: string;
+  name: string;
+  createdBy: string;
+  createdAt: string;
+}
+
+/** One row on a league board: a member plus their best submission's totals. */
+export interface LeagueBoardRow {
+  username: string;
+  joinedAt: string;
+  totalCost: number;
+  totalTokens: number;
+  verified: boolean;
+}
+
 export interface ClaimStatus {
   actionNeeded: "claim" | "merge" | null;
   actionText: string;
@@ -317,6 +350,11 @@ export interface FindProfilesResult {
 // ============================================================================
 
 export interface SubmissionsService {
+  /**
+   * Delete one of the caller's own submissions (#127): the row must belong to
+   * `username` directly or be claimed by them. Returns false when no such row.
+   */
+  deleteOwn(username: string, submissionId: string): Promise<boolean>;
   submit(data: SubmitData): Promise<string>;
   getLeaderboard(params: LeaderboardParams): Promise<LeaderboardResult>;
   getLeaderboardByDateRange(
@@ -364,8 +402,23 @@ export interface StatsService {
   getSiteStats(): Promise<SiteStats | null>;
   /** One month's aggregates via get_month_stats() (migration 013); null if unavailable. */
   getMonthStats(month: string): Promise<MonthStats | null>;
+  /** One user's month via get_user_month_stats() (migration 015); null if unavailable or empty. */
+  getUserMonthStats(month: string, username: string): Promise<UserMonthStats | null>;
   /** Raw rows for the /calculator spend curve. */
   getSpendRows(): Promise<import("@/lib/spend-curve").BurnRow[]>;
+}
+
+export interface LeaguesService {
+  /** Create a league owned by `creator` (also its first member). Throws on cap/name problems. */
+  create(name: string, creator: string): Promise<{ league: League; inviteCode: string }>;
+  /** Join via invite code; idempotent for existing members. Throws on unknown code or full league. */
+  joinByCode(code: string, username: string): Promise<League>;
+  /** League + member board rows (best submission per member), or null. */
+  getBySlug(slug: string): Promise<{ league: League; members: LeagueBoardRow[] } | null>;
+  /** The invite code — only revealed to current members. */
+  getInviteCode(slug: string, requester: string): Promise<string | null>;
+  /** Leagues `username` belongs to. */
+  listForUser(username: string): Promise<League[]>;
 }
 
 export interface DataLayer {
@@ -373,6 +426,7 @@ export interface DataLayer {
   submissions: SubmissionsService;
   profiles: ProfilesService;
   stats: StatsService;
+  leagues: LeaguesService;
 }
 
 // ============================================================================

--- a/supabase/migrations/015_wrapped_and_leagues.sql
+++ b/supabase/migrations/015_wrapped_and_leagues.sql
@@ -1,0 +1,125 @@
+-- Migration 015: per-user monthly stats (Wrapped) + friend leagues.
+--
+-- get_user_month_stats powers /wrapped/[month]/[username]: one user's month
+-- sliced the way a shareable recap needs, including rank/percentile among
+-- that month's active users — which is exactly the aggregation the client
+-- can't do without downloading everyone's month.
+--
+-- Leagues are invite-code groups with their own board. Names and members are
+-- public like everything else on the site; invite codes live in a separate
+-- table with no public read policy, because RLS is row-level and a code on a
+-- publicly readable leagues row would be a code anyone can read.
+
+CREATE OR REPLACE FUNCTION get_user_month_stats(p_month TEXT, p_username TEXT)
+RETURNS JSONB
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH month_days AS (
+    SELECT d.date, d.total_cost, d.total_tokens, d.agents, d.model_breakdowns, s.username
+    FROM daily_breakdowns d
+    JOIN submissions s ON s.id = d.submission_id
+    WHERE s.flagged_for_review IS NOT TRUE
+      AND p_month ~ '^\d{4}-\d{2}$'
+      AND to_char(d.date, 'YYYY-MM') = p_month
+  ),
+  per_user AS (
+    SELECT username, SUM(total_cost) AS cost
+    FROM month_days
+    GROUP BY username
+  ),
+  mine AS (
+    SELECT date, SUM(total_cost) AS cost, SUM(total_tokens) AS tokens
+    FROM month_days
+    WHERE username = p_username
+    GROUP BY date
+  ),
+  -- Longest consecutive-day run inside the month (gaps-and-islands).
+  streaks AS (
+    SELECT COUNT(*) AS len
+    FROM (
+      SELECT date, date - (ROW_NUMBER() OVER (ORDER BY date))::int AS grp
+      FROM mine
+    ) g
+    GROUP BY grp
+  )
+  SELECT jsonb_build_object(
+    'month', p_month,
+    'username', p_username,
+    'cost', COALESCE((SELECT SUM(cost) FROM mine), 0),
+    'tokens', COALESCE((SELECT SUM(tokens) FROM mine), 0),
+    'activeDays', (SELECT COUNT(*) FROM mine),
+    'bestDayCost', COALESCE((SELECT MAX(cost) FROM mine), 0),
+    'longestStreak', COALESCE((SELECT MAX(len) FROM streaks), 0),
+    'rank', (
+      SELECT COUNT(*) + 1 FROM per_user
+      WHERE cost > COALESCE((SELECT cost FROM per_user WHERE username = p_username), 0)
+    ),
+    'totalActives', (SELECT COUNT(*) FROM per_user),
+    'topModels', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('model', model, 'cost', cost) ORDER BY cost DESC)
+      FROM (
+        SELECT mb->>'modelName' AS model, SUM((mb->>'cost')::numeric) AS cost
+        FROM month_days m, LATERAL jsonb_array_elements(m.model_breakdowns) mb
+        WHERE m.username = p_username
+          AND m.model_breakdowns IS NOT NULL AND mb->>'modelName' IS NOT NULL
+        GROUP BY 1 ORDER BY 2 DESC LIMIT 3
+      ) x
+    ), '[]'::jsonb),
+    'tools', COALESCE((
+      SELECT jsonb_agg(DISTINCT a.tool)
+      FROM month_days m, unnest(m.agents) AS a(tool)
+      WHERE m.username = p_username
+    ), '[]'::jsonb)
+  );
+$$;
+
+GRANT EXECUTE ON FUNCTION get_user_month_stats(TEXT, TEXT) TO anon, authenticated, service_role;
+
+-- ============================================================================
+-- LEAGUES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS leagues (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT NOT NULL UNIQUE,
+  name TEXT NOT NULL CHECK (length(name) BETWEEN 2 AND 60),
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Codes are secrets; separate table so the public leagues read policy can
+-- never expose them.
+CREATE TABLE IF NOT EXISTS league_invites (
+  league_id UUID PRIMARY KEY REFERENCES leagues(id) ON DELETE CASCADE,
+  code TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS league_members (
+  league_id UUID NOT NULL REFERENCES leagues(id) ON DELETE CASCADE,
+  username TEXT NOT NULL,
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (league_id, username)
+);
+
+CREATE INDEX IF NOT EXISTS idx_league_members_username ON league_members(username);
+
+ALTER TABLE leagues ENABLE ROW LEVEL SECURITY;
+ALTER TABLE league_invites ENABLE ROW LEVEL SECURITY;
+ALTER TABLE league_members ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'leagues' AND policyname = 'Public read leagues') THEN
+    CREATE POLICY "Public read leagues" ON leagues FOR SELECT USING (true);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE tablename = 'league_members' AND policyname = 'Public read league_members') THEN
+    CREATE POLICY "Public read league_members" ON league_members FOR SELECT USING (true);
+  END IF;
+  -- league_invites: no public policy on purpose — service role only.
+END $$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
The two growth features from the approved plan, plus the #127 feature ask that shares their session plumbing. **DB migration 015 is already applied to prod** (additive; safe ahead of deploy, per the repo's migration convention).

## 1. Monthly Wrapped — the share loop
- `/wrapped/[month]/[username]`: personal month recap — spend, tokens, rank + percentile among that month's *active* users, active days, longest streak, best day, top model, tools
- Dedicated OG card (`/api/og?type=wrapped`) — four-tile satori layout, verified pixel-perfect locally
- X share intent + copy link; "want yours?" CTA converts viewers into submitters
- Linked from every profile (This month / Last month chips) and from the monthly reports; noindexed (for sharing, not search); months with no data 404

## 2. Friend Leagues — the recruitment loop
- `/leagues`: create (cap: 5/user) or join by code; `/league/[slug]`: public board ranked by members' board totals with podium colors, tiers, "no data yet" rows for members who haven't submitted
- `/league/join/[code]` invite links with a sign-in-to-join flow
- Invite codes live in a separate `league_invites` table with **no public read policy**, and the board page fetches them client-side via a members-only API — codes never enter the cached public HTML
- Joins are idempotent; 100-member cap; junk codes rejected cleanly

## 3. Self-serve deletion (#127)
- `DELETE /api/submissions/[id]` — ownership enforced in the delete filter itself (username or claimed_by must match the session)
- `/settings/submissions`: list + confirm-to-delete UI, refreshes the profile's cached rollups

## Tested (against prod data, local `next start`)
- Wrapped page renders real stats (July: rank #147/284, 19-day streak); invalid month and empty month both 404; OG card image verified visually
- **Full league lifecycle exercised end-to-end**: create → creator auto-member with real totals → invite visible to member / null to stranger → second user joins by code → board ranks correctly → re-join idempotent → junk code rejected → listForUser → cascade cleanup verified
- Auth guards: league create/join and submission delete all 401 without a session
- `pnpm build` clean; no type errors in changed files

## Deploy notes
- No env changes. Migration already live. After deploy: `/wrapped/2026-07/<user>` works immediately for any July-active user.
- Suggested launch move: create the first league and drop the invite code in the community — and note the reporter of #127 can now self-serve via /settings/submissions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)