### PR TITLE
feat: dismissible homepage banner announcing Friend Leagues

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -8,6 +8,7 @@ import dynamic from "next/dynamic";
 
 const SubmitModal = dynamic(() => import("@/components/SubmitModal"), { ssr: false });
 import NavBar from "@/components/NavBar";
+import AnnouncementBanner from "@/components/AnnouncementBanner";
 import Footer from "@/components/Footer";
 import { useSession, signIn } from "next-auth/react";
 import { useCheckClaimableSubmissions, useClaimAndMergeSubmissions } from "@/lib/data/hooks/useSubmissions";
@@ -100,6 +101,11 @@ export default function HomeClient({ initialItems, initialStats, initialHasMore 
       {stats && <Ticker stats={stats} />}
 
       <NavBar />
+
+      <AnnouncementBanner id="leagues-2026-08" href="/leagues">
+        <span className="font-medium text-accent">New:</span> Friend Leagues — a private leaderboard for your team
+        or group chat, one invite code to start. <span className="underline underline-offset-2">Start yours →</span>
+      </AnnouncementBanner>
 
       {/* Claim/Merge Banner */}
       <AnimatePresence>

--- a/src/components/AnnouncementBanner.tsx
+++ b/src/components/AnnouncementBanner.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { X, Users } from "lucide-react";
+
+/**
+ * One-line launch announcement, dismissible forever per `id`. Change the id
+ * for a future announcement and everyone sees it exactly once again — no
+ * server state, no nagging.
+ */
+export default function AnnouncementBanner({ id, href, children }: {
+  id: string;
+  href: string;
+  children: React.ReactNode;
+}) {
+  const key = `viberank-announcement-${id}`;
+  // Start hidden so SSR/hydration match; reveal only for un-dismissed browsers.
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (!localStorage.getItem(key)) setVisible(true);
+    } catch {
+      // Storage blocked — better to stay quiet than to nag on every load.
+    }
+  }, [key]);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    setVisible(false);
+    try {
+      localStorage.setItem(key, "1");
+    } catch {
+      // Session-only dismissal is fine.
+    }
+  };
+
+  return (
+    <div className="bg-surface-1 border-b border-accent/30">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 py-2 flex items-center gap-3 text-sm">
+        <Users className="w-4 h-4 text-accent flex-shrink-0" />
+        <Link href={href} onClick={dismiss} className="flex-1 min-w-0 truncate text-foreground hover:text-accent transition-colors">
+          {children}
+        </Link>
+        <button
+          onClick={dismiss}
+          aria-label="Dismiss announcement"
+          className="text-muted hover:text-foreground transition-colors flex-shrink-0"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
One line under the nav, localStorage-dismissed per announcement id so
it shows exactly once per browser and future launches can reuse the
component by changing the id.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
