### PR TITLE
feat: Leagues in the nav

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -41,6 +41,7 @@ export default function NavBar() {
 
   const navItems = [
     { name: "Stats", href: "/stats" },
+    { name: "Leagues", href: "/leagues" },
     { name: "Calculator", href: "/calculator" },
     { name: "Blog", href: "/blog" },
     { name: "Hire", href: "/hire" },


### PR DESCRIPTION
A leaderboard feature on a leaderboard site belongs next to Stats, and
it's the one nav item that recruits new submitters.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
