### PR TITLE
fix: hand out canonical www URLs, not apex ones that redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Submit usage data. Authenticated submissions (with a NextAuth session cookie) ar
   "success": true,
   "submissionId": "...",
   "message": "Successfully submitted data for username",
-  "profileUrl": "https://viberank.app/profile/username"
+  "profileUrl": "https://www.viberank.app/profile/username"
 }
 ```
 

--- a/packages/viberank-cli/README.md
+++ b/packages/viberank-cli/README.md
@@ -1,6 +1,6 @@
 # viberank-cli
 
-Submit your AI coding usage stats — **Claude Code, Codex, Gemini CLI, Copilot, OpenCode and more** — to the [viberank](https://viberank.app) leaderboard.
+Submit your AI coding usage stats — **Claude Code, Codex, Gemini CLI, Copilot, OpenCode and more** — to the [viberank](https://www.viberank.app) leaderboard.
 
 ## Usage
 
@@ -99,7 +99,7 @@ curl -X POST https://www.viberank.app/api/submit \
 
 Submissions made with a token (`viberank login`) are **verified** and get a blue check immediately.
 
-Without one, the CLI falls back to an `X-GitHub-User` header — anyone can set that, so those rows appear with a `cli` badge (unverified). Sign in to [viberank.app](https://viberank.app) with the same GitHub account and the site will offer to verify or merge them into your profile.
+Without one, the CLI falls back to an `X-GitHub-User` header — anyone can set that, so those rows appear with a `cli` badge (unverified). Sign in to [viberank.app](https://www.viberank.app) with the same GitHub account and the site will offer to verify or merge them into your profile.
 
 ## Troubleshooting
 
@@ -122,4 +122,4 @@ Full ruleset: [VALIDATION.md](https://github.com/sculptdotfun/viberank/blob/main
 
 ## About
 
-viberank is a community leaderboard for AI coding usage — real costs and tokens measured by [ccusage](https://github.com/ryoppippi/ccusage), not self-reported numbers. See how you stack up at [viberank.app](https://viberank.app), or browse the per-tool boards: [Claude](https://www.viberank.app/tool/claude) · [Codex](https://www.viberank.app/tool/codex) · [Gemini](https://www.viberank.app/tool/gemini).
+viberank is a community leaderboard for AI coding usage — real costs and tokens measured by [ccusage](https://github.com/ryoppippi/ccusage), not self-reported numbers. See how you stack up at [viberank.app](https://www.viberank.app), or browse the per-tool boards: [Claude](https://www.viberank.app/tool/claude) · [Codex](https://www.viberank.app/tool/codex) · [Gemini](https://www.viberank.app/tool/gemini).

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -41,5 +41,5 @@
     "type": "git",
     "url": "https://github.com/sculptdotfun/viberank"
   },
-  "homepage": "https://viberank.app"
+  "homepage": "https://www.viberank.app"
 }

--- a/packages/viberank-mcp-server/README.md
+++ b/packages/viberank-mcp-server/README.md
@@ -1,6 +1,6 @@
 # Viberank MCP Server
 
-Submit your AI coding usage stats (Claude Code, Codex, Gemini CLI and more) to [viberank](https://viberank.app) directly from your MCP-compatible AI assistant!
+Submit your AI coding usage stats (Claude Code, Codex, Gemini CLI and more) to [viberank](https://www.viberank.app) directly from your MCP-compatible AI assistant!
 
 ## Features
 
@@ -206,7 +206,7 @@ MIT - See LICENSE file for details
 
 ## Links
 
-- [Viberank Website](https://viberank.app)
+- [Viberank Website](https://www.viberank.app)
 - [GitHub Repository](https://github.com/sculptdotfun/viberank)
 - [Report Issues](https://github.com/sculptdotfun/viberank/issues)
 - [MCP Protocol Docs](https://modelcontextprotocol.io)

--- a/packages/viberank-mcp-server/package.json
+++ b/packages/viberank-mcp-server/package.json
@@ -46,5 +46,5 @@
     "type": "git",
     "url": "https://github.com/sculptdotfun/viberank"
   },
-  "homepage": "https://viberank.app"
+  "homepage": "https://www.viberank.app"
 }

--- a/packages/viberank-mcp-server/src/index.ts
+++ b/packages/viberank-mcp-server/src/index.ts
@@ -346,7 +346,7 @@ class ViberankMCPServer {
             type: 'text',
             text: JSON.stringify({
               success: true,
-              message: 'Leaderboard data is available at https://viberank.app',
+              message: 'Leaderboard data is available at https://www.viberank.app',
               note: 'Direct API access to leaderboard coming soon!',
               limit,
             }, null, 2),
@@ -370,7 +370,7 @@ class ViberankMCPServer {
 
   private async getProfile(username: string) {
     try {
-      const profileUrl = `https://viberank.app/profile/${encodeURIComponent(username)}`;
+      const profileUrl = `https://www.viberank.app/profile/${encodeURIComponent(username)}`;
       
       return {
         content: [

--- a/src/app/api/badge/[username]/route.ts
+++ b/src/app/api/badge/[username]/route.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/badge";
 
 /**
- * README badge: ![viberank](https://viberank.app/api/badge/<username>)
+ * README badge: ![viberank](https://www.viberank.app/api/badge/<username>)
  *
  * Always answers 200 with an SVG, including for unknown users. A README that
  * renders a broken-image icon because someone typo'd their handle is worse

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -8,6 +8,7 @@ import { archiveRawSubmission } from "@/lib/data/supabase/rawArchive";
 import { getCliNotice } from "@/lib/sponsor";
 import { bearerFrom } from "@/lib/tokens";
 import { getTier } from "@/lib/tiers";
+import { badgeMarkdown, profileUrl } from "@/lib/site";
 
 /**
  * `{ "2026-07": { files, bytes } }` from the submission body, or undefined.
@@ -338,7 +339,7 @@ export async function POST(request: NextRequest) {
         // Ceil so nobody is ever told they are "top 0%".
         topPercent: totalDevelopers > 0 ? Math.max(1, Math.ceil((rank / totalDevelopers) * 100)) : 0,
         tier: getTier(cost).name,
-        badgeMarkdown: `[![viberank](https://viberank.app/api/badge/${encodeURIComponent(githubUsername)})](https://viberank.app/profile/${encodeURIComponent(githubUsername)})`,
+        badgeMarkdown: badgeMarkdown(githubUsername),
       };
     } catch {
       // A nicety. Never fail an accepted submission over it.
@@ -348,7 +349,7 @@ export async function POST(request: NextRequest) {
       success: true,
       submissionId,
       message: `Successfully submitted data for ${githubUsername}`,
-      profileUrl: `https://viberank.app/profile/${githubUsername}`,
+      profileUrl: profileUrl(githubUsername),
       standing,
       // Optional sponsor line the CLI prints after a successful submission.
       notice: getCliNotice(),

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -5,6 +5,7 @@ import { Copy, X, Trophy, Check } from "lucide-react";
 import { useState } from "react";
 import { formatNumber, formatCurrency, toolLabel } from "@/lib/utils";
 import { getTier } from "@/lib/tiers";
+import { profileUrl } from "@/lib/site";
 import TierBadge from "./TierBadge";
 
 interface ShareCardProps {
@@ -20,7 +21,7 @@ interface ShareCardProps {
 export default function ShareCard({ rank, username, totalCost, totalTokens, dateRange, tools, onClose }: ShareCardProps) {
   const [copied, setCopied] = useState(false);
 
-  const shareUrl = `https://viberank.app/profile/${encodeURIComponent(username)}`;
+  const shareUrl = profileUrl(username);
   const tier = getTier(totalCost);
   const toolsLine = tools && tools.length > 0 ? `\n🧰 ${tools.map(toolLabel).join(" · ")}` : "";
   const shareText = `I'm ranked #${rank} on viberank 🏆\n\n${tier.glyph} ${tier.name.toUpperCase()} tier\n💰 $${formatCurrency(totalCost)} spent\n📊 ${formatNumber(totalTokens)} tokens${toolsLine}\n\nJoin the AI coding leaderboard:`;

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,0 +1,34 @@
+/**
+ * The one place that knows what host viberank lives on.
+ *
+ * The site is www-canonical — `metadataBase`, every canonical tag, the sitemap
+ * and robots.txt all say `www.viberank.app`, and the apex 307s across to it at
+ * the edge. Links we emit for *ourselves* were fine either way, so the apex
+ * form spread by copy-paste through READMEs, share links and the badge.
+ *
+ * It stopped being cosmetic once those URLs became things other people paste
+ * into their own systems. `curl https://viberank.app/api/stats` answers with
+ * the string "Redirecting..." rather than JSON, because curl does not follow
+ * redirects unless asked — so a citation of the apex endpoint hands the reader
+ * something that fails to parse. Badges and share links survive the hop, but
+ * pay for it on every cold fetch.
+ *
+ * Anything we hand to a third party goes through here.
+ */
+
+export const SITE_URL = "https://www.viberank.app";
+
+/** Public profile page for a GitHub handle. */
+export function profileUrl(username: string): string {
+  return `${SITE_URL}/profile/${encodeURIComponent(username)}`;
+}
+
+/** SVG badge endpoint for a GitHub handle. */
+export function badgeUrl(username: string): string {
+  return `${SITE_URL}/api/badge/${encodeURIComponent(username)}`;
+}
+
+/** Paste-ready README badge — image linked to the profile it describes. */
+export function badgeMarkdown(username: string): string {
+  return `[![viberank](${badgeUrl(username)})](${profileUrl(username)})`;
+}

--- a/test/site-url.test.mts
+++ b/test/site-url.test.mts
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const { SITE_URL, profileUrl, badgeUrl, badgeMarkdown } =
+  await import("../src/lib/site.ts");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+
+{
+  assert.equal(SITE_URL, "https://www.viberank.app");
+  assert.ok(!SITE_URL.endsWith("/"), "callers concatenate a leading-slash path");
+  check("SITE_URL is the canonical host, no trailing slash");
+}
+
+{
+  assert.equal(profileUrl("nikshepsvn"), "https://www.viberank.app/profile/nikshepsvn");
+  assert.equal(badgeUrl("nikshepsvn"), "https://www.viberank.app/api/badge/nikshepsvn");
+  check("profile and badge URLs are built from the canonical host");
+}
+
+{
+  // A handle reaches these from a submission body, so it is untrusted input
+  // that ends up inside markdown someone pastes into a README.
+  const md = badgeMarkdown("a b/c?d#e");
+  assert.ok(!/[ ?#]/.test(md.split("](")[0]), "the image URL is escaped");
+  assert.equal(badgeUrl("a b"), "https://www.viberank.app/api/badge/a%20b");
+  check("handles are percent-encoded before they land in markdown");
+}
+
+{
+  const md = badgeMarkdown("nikshepsvn");
+  assert.equal(md,
+    "[![viberank](https://www.viberank.app/api/badge/nikshepsvn)]" +
+    "(https://www.viberank.app/profile/nikshepsvn)");
+  check("badge markdown links the image to the profile it describes");
+}
+
+{
+  // The regression guard. The apex 307s to www, so an apex URL we hand to a
+  // third party costs a redirect — and for /api/stats, a client that does not
+  // follow redirects gets the body "Redirecting..." where JSON was promised.
+  // site.ts is exempt: its comment quotes the broken call deliberately.
+  const EXEMPT = new Set(["src/lib/site.ts"]);
+  const SKIP = new Set(["node_modules", ".next", ".git", "dist", "build", ".vercel"]);
+  const offenders: string[] = [];
+
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      if (SKIP.has(entry)) continue;
+      const path = join(dir, entry);
+      if (statSync(path).isDirectory()) { walk(path); continue; }
+      if (!/\.(ts|tsx|mts|js|jsx|json|md|txt|xml)$/.test(entry)) continue;
+      if (EXEMPT.has(path)) continue;
+      readFileSync(path, "utf8").split("\n").forEach((line, i) => {
+        if (/https:\/\/viberank\.app/.test(line)) offenders.push(`${path}:${i + 1}`);
+      });
+    }
+  };
+  for (const root of ["src", "packages", "public"]) walk(root);
+  for (const f of ["README.md"]) {
+    if (/https:\/\/viberank\.app/.test(readFileSync(f, "utf8"))) offenders.push(f);
+  }
+
+  assert.deepEqual(offenders, [],
+    `apex URLs must use SITE_URL from src/lib/site.ts:\n  ${offenders.join("\n  ")}`);
+  check("no apex viberank.app URL is emitted anywhere in the tree");
+}
+
+console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
`viberank.app` 307s to `www.viberank.app`. The site itself is cleanly www-canonical — `metadataBase`, every canonical tag, all 1,198 sitemap URLs and robots.txt agree — but the **apex** form is what we hand to third parties.

Reproduced:

```
$ curl https://viberank.app/api/stats
Redirecting...
```

curl doesn't follow redirects unless asked, so anyone who cites the apex endpoint gives their reader a body that fails to parse — on the one endpoint the primary-source positioning depends on. The badge and profile links survive the hop (GitHub's camo proxy follows redirects) but pay for it on every cold fetch.

Not a regression from #140: `git blame` puts these at 2025-08-04 (README), 2026-06-09 (ShareCard) and 2026-08-05 (badge route). Only the `badgeMarkdown` line is recent, and it copied the surrounding convention.

## Change

One `SITE_URL` in `src/lib/site.ts` with `profileUrl` / `badgeUrl` / `badgeMarkdown` helpers, used by everything outbound: submit response, ShareCard, badge route, repo README, both package READMEs and manifests, MCP server output.

`layout.tsx` is untouched — it was already correct, and rewriting eleven metadata strings risks a regression for no gain.

## Guard

`test/site-url.test.mts` walks `src/`, `packages/`, `public/` and the README and fails on any apex URL, so this can't drift back the way it arrived. Verified it actually fires: appending an apex URL to the README fails the suite.

```
✓ SITE_URL is the canonical host, no trailing slash
✓ profile and badge URLs are built from the canonical host
✓ handles are percent-encoded before they land in markdown
✓ badge markdown links the image to the profile it describes
✓ no apex viberank.app URL is emitted anywhere in the tree
```

Full suite passes; `npm run build` clean.

## Not covered

The published npm packages still carry apex URLs in their READMEs until `viberank-cli` and `viberank-mcp-server` are republished — that's a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZYrmUrScxFAMBV3URBp5G