### PR TITLE
fix: apply a drift verdict to the tool it is evidence about (#125, #141)

### DIFF
--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -40,10 +40,23 @@ function looksLikeGithubHandle(value) {
  * running node binary; going through node rather than the `npx.cmd` shim is
  * also what keeps this from throwing EINVAL on Windows (#137). */
 function generateCcJson(dest) {
-  const out = runNpx(['-y', 'ccusage@latest', 'daily', '--json'], {
+  const run = (extra) => runNpx(['-y', 'ccusage@latest', 'daily', '--json', ...extra], {
     encoding: 'utf8',
     maxBuffer: 256 * 1024 * 1024,
   });
+
+  // `--by-agent` adds a per-agent split to each day, which lets the server apply
+  // a Claude-transcript cleanup to Claude's tokens alone instead of taking the
+  // same day's Codex usage down with it (#125). It roughly doubles the report
+  // size and it is a newer flag, so an older ccusage on a pinned or cached
+  // resolve will reject it — fall back rather than fail the whole run, since a
+  // submission without the split is still a perfectly good submission.
+  let out;
+  try {
+    out = run(['--by-agent']);
+  } catch {
+    out = run([]);
+  }
   fs.writeFileSync(dest, out);
 }
 
@@ -260,8 +273,11 @@ async function main() {
 
   console.log(chalk.yellow.bold(`\n🚀 Viberank Submission Tool v${CLI_VERSION}\n`));
 
-  // Try to get GitHub username from remote URL first, then fall back to git config
+  // Try to get GitHub username from remote URL first, then fall back to git config.
+  // `source` matters: a GitHub remote is evidence, `git config user.name` is a
+  // guess, and only evidence is allowed to become the prompt's default (#141).
   let githubUser;
+  let source = null;
   
   // First, try to extract from GitHub remote URL
   try {
@@ -273,6 +289,7 @@ async function main() {
     const githubMatch = remoteUrl.match(/github\.com[:/]([^/]+)\//);
     if (githubMatch) {
       githubUser = githubMatch[1];
+      source = 'remote';
       console.log(chalk.gray(`Detected GitHub username from repository: ${githubUser}`));
     }
   } catch (error) {
@@ -283,19 +300,29 @@ async function main() {
   if (!githubUser) {
     try {
       githubUser = execSync('git config user.name', { encoding: 'utf8' }).trim();
-      console.log(chalk.yellow('Warning: Using git config user.name which might be your real name, not GitHub username'));
-      console.log(chalk.yellow('Please verify this is correct or enter your GitHub username manually'));
+      source = 'gitconfig';
     } catch (error) {
       console.log(chalk.yellow('Could not detect GitHub username automatically'));
     }
   }
 
-  // Always confirm with the user
+  // Always confirm with the user.
+  //
+  // Only a GitHub remote pre-fills the answer. `git config user.name` is
+  // usually a display name, and pre-filling it turned a reflexive Enter into a
+  // submission under a handle that wasn't the user's — that is how a public
+  // profile called "Matt" appeared, holding 86B tokens belonging to mattw90
+  // (#141). Validation cannot catch it: "Matt" is a perfectly well-formed
+  // GitHub handle. So the guess is shown in the question and the field starts
+  // empty, which costs one line of typing to the people it would have misfiled.
+  const guessed = source === 'gitconfig' && githubUser;
   const response = await prompts({
     type: 'text',
     name: 'username',
-    message: 'GitHub username:',
-    initial: githubUser && looksLikeGithubHandle(githubUser) ? githubUser : '',
+    message: guessed
+      ? `GitHub username (git config says "${githubUser}" — type it if that's right)`
+      : 'GitHub username:',
+    initial: source === 'remote' && looksLikeGithubHandle(githubUser) ? githubUser : '',
     validate: (value) =>
       looksLikeGithubHandle(value.trim()) ||
       'That is not a valid GitHub username (1-39 letters, digits, single hyphens)'

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viberank-cli",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",

--- a/src/lib/ccusage.ts
+++ b/src/lib/ccusage.ts
@@ -39,6 +39,13 @@ interface RawDailyEntry {
   modelsUsed?: string[];
   modelBreakdowns?: unknown;
   metadata?: { agents?: string[] };
+  /**
+   * Per-agent split of this row, present only with `ccusage daily --by-agent`.
+   * Note the shape clash: this is an array of objects, while `agents` on our
+   * own normalized entry is a list of names. Kept `unknown` so the sanitiser
+   * is the only thing that decides what it means.
+   */
+  agents?: unknown;
 }
 
 interface RawCcData {
@@ -55,6 +62,23 @@ export interface NormalizedModelBreakdown {
   cost: number;
 }
 
+/**
+ * One agent's measured share of a day.
+ *
+ * Exists so a drift verdict can be applied to the tool it is actually evidence
+ * about. The corpus scan reads ~/.claude/projects, so it says nothing about a
+ * Codex or Gemini day — but before this, a mixed day was stored as one lump and
+ * lowering the lump took the untouched tools down with it (#125).
+ */
+export interface AgentSlice {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens: number;
+  cacheReadTokens: number;
+  totalTokens: number;
+  totalCost: number;
+}
+
 /** A daily entry after normalization — always keyed by `date`, agents resolved. */
 export interface NormalizedDaily {
   date: string;
@@ -68,6 +92,74 @@ export interface NormalizedDaily {
   agents: string[];
   /** Per-model split for the day, when the report provides it. */
   modelBreakdowns?: NormalizedModelBreakdown[];
+  /**
+   * Per-agent split for the day, keyed by agent name. Absent for payloads from
+   * a CLI that predates `--by-agent`, which is most of the board — every
+   * consumer must treat it as optional and fall back to whole-slice behaviour.
+   */
+  agentBreakdowns?: Record<string, AgentSlice>;
+}
+
+/** Agents we will store a slice for. Anything else is summed into the day but
+ * not tracked separately — an unbounded key space here is a storage hazard. */
+const MAX_AGENTS_PER_DAY = 12;
+
+/**
+ * Rebuild the `--by-agent` array into a name-keyed map, field by field.
+ *
+ * The payload is user-supplied, so nothing here trusts the shape: a hostile or
+ * merely old client can send any JSON at all. Slices that don't parse are
+ * dropped rather than coerced, and the caller checks the survivors still sum to
+ * the day before using them.
+ */
+function sanitizeAgentSlices(value: unknown): Record<string, AgentSlice> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : 0);
+  const out: Record<string, AgentSlice> = {};
+  for (const item of value.slice(0, MAX_AGENTS_PER_DAY)) {
+    if (!item || typeof item !== "object") continue;
+    const row = item as Record<string, unknown>;
+    const name = typeof row.agent === "string" ? row.agent.trim().toLowerCase() : "";
+    if (!name) continue;
+    const slice: AgentSlice = {
+      inputTokens: num(row.inputTokens),
+      outputTokens: num(row.outputTokens),
+      cacheCreationTokens: num(row.cacheCreationTokens),
+      cacheReadTokens: num(row.cacheReadTokens),
+      totalTokens: num(row.totalTokens),
+      totalCost: num(row.totalCost),
+    };
+    // Sum rather than overwrite: a payload repeating an agent for one date is
+    // malformed, but dropping half its tokens would be worse than adding them.
+    const prior = out[name];
+    out[name] = prior ? addSlices(prior, slice) : slice;
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
+export function addSlices(a: AgentSlice, b: AgentSlice): AgentSlice {
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    cacheCreationTokens: a.cacheCreationTokens + b.cacheCreationTokens,
+    cacheReadTokens: a.cacheReadTokens + b.cacheReadTokens,
+    totalTokens: a.totalTokens + b.totalTokens,
+    totalCost: a.totalCost + b.totalCost,
+  };
+}
+
+/** Merge two per-agent maps by summing each agent's slice. */
+function mergeAgentMaps(
+  a: Record<string, AgentSlice> | undefined,
+  b: Record<string, AgentSlice> | undefined
+): Record<string, AgentSlice> | undefined {
+  if (!a) return b;
+  if (!b) return a;
+  const out: Record<string, AgentSlice> = { ...a };
+  for (const [name, slice] of Object.entries(b)) {
+    out[name] = out[name] ? addSlices(out[name], slice) : slice;
+  }
+  return out;
 }
 
 // Per-model day splits come straight from user-supplied JSON, so rebuild them
@@ -146,6 +238,8 @@ export interface MachineContribution {
   modelsUsed: string[];
   agents: string[];
   modelBreakdowns?: NormalizedModelBreakdown[];
+  /** Per-agent split, when the submitting CLI was new enough to send one. */
+  agentBreakdowns?: Record<string, AgentSlice>;
 }
 
 /** Aggregate of every machine's slice for a day — what the row stores/displays. */
@@ -206,6 +300,65 @@ function aggregateContributions(
  *   which machine it came from, and assuming "a different one" double-counts
  *   single-machine users (#81). It is replaced instead.
  */
+/**
+ * The tool the drift corpus is evidence about.
+ *
+ * Duplicated from drift.ts rather than imported: this module is the one the CLI
+ * and the archive re-parser both pull in, and it stays free of dependencies on
+ * the storage layer. drift.ts owns the *policy* of when a month counts as
+ * deleted; this owns the *mechanics* of applying it to one slice.
+ */
+const CORPUS_AGENT = "claude";
+
+/**
+ * Rebuild a machine's slice, taking the named agent's re-report even when it is
+ * lower, while every other agent keeps the larger of the two observations.
+ *
+ * Returns null when either side lacks a per-agent split, which is the caller's
+ * signal to fall back to whole-slice behaviour. Deliberately not a per-*field*
+ * max: within one agent the slice is still swapped whole, because mixing tokens
+ * from one run with cost from another would synthesise a slice nobody observed.
+ * Across agents it is safe, because each agent's slice was measured
+ * independently.
+ */
+function lowerOneAgent(
+  prior: MachineContribution,
+  incoming: MachineContribution,
+  agent: string
+): MachineContribution | null {
+  const p = prior.agentBreakdowns;
+  const i = incoming.agentBreakdowns;
+  if (!p || !i) return null;
+
+  const merged: Record<string, AgentSlice> = {};
+  for (const name of new Set([...Object.keys(p), ...Object.keys(i)])) {
+    if (name === agent) {
+      // The pruned tool: honour the new observation, including its absence.
+      // A user who deleted a month's transcripts should not keep its total.
+      if (i[name]) merged[name] = i[name];
+      continue;
+    }
+    const a = p[name];
+    const b = i[name];
+    if (a && b) merged[name] = b.totalCost >= a.totalCost ? b : a;
+    else merged[name] = (b ?? a)!;
+  }
+
+  const slices = Object.values(merged);
+  if (slices.length === 0) return incoming;
+  const totals = slices.reduce(addSlices);
+  return {
+    ...incoming,
+    inputTokens: totals.inputTokens,
+    outputTokens: totals.outputTokens,
+    cacheCreationTokens: totals.cacheCreationTokens,
+    cacheReadTokens: totals.cacheReadTokens,
+    totalTokens: totals.totalTokens,
+    totalCost: totals.totalCost,
+    agentBreakdowns: merged,
+  };
+}
+
 export function mergeMachineContribution(
   existing: Record<string, MachineContribution> | null | undefined,
   machineId: string,
@@ -251,7 +404,17 @@ export function mergeMachineContribution(
     // Compared on cost and swapped whole rather than per-field: taking the max
     // of each field independently would synthesise a slice that was never
     // actually observed, with tokens from one run and cost from another.
-    if (!acceptLower && prior && prior.totalCost > incoming.totalCost) {
+    if (acceptLower && prior) {
+      // The verdict is evidence about one tool. Lower that tool's slice and
+      // leave every other tool at its high-water mark, so a Claude cleanup
+      // stops dragging the same day's Codex tokens down with it (#125).
+      //
+      // Only reachable when both sides carry a split — which means a recent
+      // CLI on both submissions. Everything older falls through to the
+      // whole-slice path below and behaves exactly as it did before.
+      const scoped = lowerOneAgent(prior, incoming, CORPUS_AGENT);
+      contributions = { ...idSlices, [machineId]: scoped ?? incoming };
+    } else if (!acceptLower && prior && prior.totalCost > incoming.totalCost) {
       contributions = { ...idSlices, [machineId]: prior };
       retainedPrior = true;
     } else {
@@ -358,6 +521,21 @@ function selectAuthoritativeRows(rows: RawDailyEntry[]): RawDailyEntry[] {
 }
 
 /**
+ * A per-agent split for this row, but only if it reconciles with the row.
+ *
+ * Tolerance is a cent and one token — enough to absorb float noise in a sum of
+ * many slices, far too tight to hide a fabricated one.
+ */
+function reconciledAgentSlices(entry: RawDailyEntry): Record<string, AgentSlice> | undefined {
+  const slices = sanitizeAgentSlices(entry.agents);
+  if (!slices) return undefined;
+  const sum = Object.values(slices).reduce(addSlices);
+  const costOk = Math.abs(sum.totalCost - entry.totalCost) <= 0.01;
+  const tokensOk = Math.abs(sum.totalTokens - entry.totalTokens) <= TOKEN_SLOP;
+  return costOk && tokensOk ? slices : undefined;
+}
+
+/**
  * Normalize raw ccusage JSON into one canonical, deduped, date-keyed shape.
  * Throws validation-style Errors (message surfaced to the client) for input
  * that cannot be made sense of.
@@ -381,6 +559,12 @@ export function normalizeCcData(raw: RawCcData): NormalizedCcData {
     const agents = resolveAgents(entry);
     const models = entry.modelsUsed ?? [];
     const breakdowns = sanitizeModelBreakdowns(entry.modelBreakdowns);
+    // Only keep a per-agent split that actually reconciles with the row it
+    // claims to divide. ccusage's own output does — measured at $0.000000 drift
+    // across a real 103-day report — so a split that doesn't add up is a
+    // malformed or hostile payload, and storing it would let a caller inflate
+    // one agent while the day's headline total stayed believable.
+    const agentSplit = reconciledAgentSlices(entry);
     const existing = byDate.get(date);
 
     if (existing) {
@@ -393,6 +577,7 @@ export function normalizeCcData(raw: RawCcData): NormalizedCcData {
       existing.modelsUsed = Array.from(new Set([...existing.modelsUsed, ...models]));
       existing.agents = Array.from(new Set([...existing.agents, ...agents]));
       existing.modelBreakdowns = mergeModelBreakdowns(existing.modelBreakdowns, breakdowns);
+      existing.agentBreakdowns = mergeAgentMaps(existing.agentBreakdowns, agentSplit);
     } else {
       byDate.set(date, {
         date,
@@ -405,6 +590,7 @@ export function normalizeCcData(raw: RawCcData): NormalizedCcData {
         modelsUsed: [...models],
         agents: [...agents],
         modelBreakdowns: breakdowns,
+        agentBreakdowns: agentSplit,
       });
     }
   }

--- a/src/lib/data/supabase/client.ts
+++ b/src/lib/data/supabase/client.ts
@@ -164,6 +164,7 @@ function dailyEntryToContribution(
     modelsUsed: day.modelsUsed,
     agents: day.agents ?? [],
     modelBreakdowns: day.modelBreakdowns,
+    agentBreakdowns: day.agentBreakdowns,
   };
 }
 

--- a/src/lib/data/types.ts
+++ b/src/lib/data/types.ts
@@ -156,6 +156,17 @@ export interface SubmitData {
       // Tools/agents that contributed to this day (e.g. ["claude", "codex"]).
       // Populated by normalizeCcData from ccusage's metadata.agents.
       agents?: string[];
+      // Per-agent split of the day, keyed by agent name. Present only when the
+      // submitting CLI ran `ccusage --by-agent`; a drift verdict about one tool
+      // can then lower that tool alone instead of the whole day (#125).
+      agentBreakdowns?: Record<string, {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens: number;
+        cacheReadTokens: number;
+        totalTokens: number;
+        totalCost: number;
+      }>;
       modelBreakdowns?: Array<{
         modelName: string;
         inputTokens: number;

--- a/test/agent-drift.test.mts
+++ b/test/agent-drift.test.mts
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+
+const { normalizeCcData, mergeMachineContribution } = await import("../src/lib/ccusage.ts");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+
+const slice = (cost: number, tok: number) => ({
+  inputTokens: tok, outputTokens: 0, cacheCreationTokens: 0,
+  cacheReadTokens: 0, totalTokens: tok, totalCost: cost,
+});
+const contrib = (cost: number, tok: number, byAgent?: Record<string, ReturnType<typeof slice>>) => ({
+  ...slice(cost, tok), modelsUsed: ["m"], agents: Object.keys(byAgent ?? {}),
+  ...(byAgent ? { agentBreakdowns: byAgent } : {}),
+});
+
+/* ---------- normalization ---------- */
+
+const rawDay = (extra: Record<string, unknown> = {}) => ({
+  date: "2026-05-01",
+  inputTokens: 100, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0,
+  totalTokens: 100, totalCost: 10, modelsUsed: ["claude-opus-4-8"],
+  metadata: { agents: ["claude", "codex"] },
+  ...extra,
+});
+
+{
+  const n = normalizeCcData({ totals: {}, daily: [rawDay({
+    agents: [
+      { agent: "claude", inputTokens: 60, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 60, totalCost: 6 },
+      { agent: "codex",  inputTokens: 40, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 40, totalCost: 4 },
+    ],
+  })] } as never);
+  assert.deepEqual(Object.keys(n.daily[0].agentBreakdowns!).sort(), ["claude", "codex"]);
+  assert.equal(n.daily[0].agentBreakdowns!.claude.totalCost, 6);
+  check("a --by-agent report keeps its per-agent split");
+}
+
+{
+  // A split that does not add up to the row is a malformed or hostile payload:
+  // storing it would let a caller inflate one agent behind a believable total.
+  const n = normalizeCcData({ totals: {}, daily: [rawDay({
+    agents: [
+      { agent: "claude", inputTokens: 60, outputTokens: 0, cacheCreationTokens: 0, cacheReadTokens: 0, totalTokens: 60, totalCost: 999 },
+    ],
+  })] } as never);
+  assert.equal(n.daily[0].agentBreakdowns, undefined);
+  assert.equal(n.daily[0].totalCost, 10, "the day's own total is untouched");
+  check("a split that doesn't reconcile with the day is discarded");
+}
+
+{
+  const n = normalizeCcData({ totals: {}, daily: [rawDay()] } as never);
+  assert.equal(n.daily[0].agentBreakdowns, undefined);
+  check("a report without --by-agent normalizes exactly as before");
+}
+
+/* ---------- the #125 fix ---------- */
+
+{
+  // Claude transcripts pruned; Codex untouched. Before the fix the whole slice
+  // was swapped and the Codex $40 vanished with it.
+  const prior = { laptop: contrib(100, 1000, { claude: slice(60, 600), codex: slice(40, 400) }) };
+  const incoming = contrib(60, 600, { claude: slice(20, 200), codex: slice(40, 400) });
+  const r = mergeMachineContribution(prior, "laptop", incoming, true);
+  assert.equal(r.aggregate.totalCost, 60, "claude 20 lowered + codex 40 retained");
+  assert.equal(r.contributions.laptop.agentBreakdowns!.codex.totalCost, 40);
+  assert.equal(r.contributions.laptop.agentBreakdowns!.claude.totalCost, 20);
+  check("a Claude cleanup lowers Claude alone and leaves Codex whole (#125)");
+}
+
+{
+  // A month the user really did clear: Claude drops out of the report entirely
+  // and must not be preserved, while Codex still stands.
+  const prior = { laptop: contrib(100, 1000, { claude: slice(60, 600), codex: slice(40, 400) }) };
+  const incoming = contrib(40, 400, { codex: slice(40, 400) });
+  const r = mergeMachineContribution(prior, "laptop", incoming, true);
+  assert.equal(r.aggregate.totalCost, 40);
+  assert.equal(r.contributions.laptop.agentBreakdowns!.claude, undefined,
+    "a deleted month is honoured, not held at its high-water mark");
+  check("deletion is still honoured for the tool the corpus is evidence about");
+}
+
+{
+  // Without acceptLower nothing changes: the high-water mark still wins.
+  const prior = { laptop: contrib(100, 1000, { claude: slice(60, 600), codex: slice(40, 400) }) };
+  const r = mergeMachineContribution(prior, "laptop", contrib(60, 600, { claude: slice(20, 200), codex: slice(40, 400) }), false);
+  assert.equal(r.aggregate.totalCost, 100);
+  assert.equal(r.retainedPrior, true);
+  check("an ordinary lower re-report still holds the high-water mark (#83)");
+}
+
+{
+  // The board is mostly older payloads. They must behave exactly as before.
+  const prior = { laptop: contrib(100, 1000) };
+  const r = mergeMachineContribution(prior, "laptop", contrib(60, 600), true);
+  assert.equal(r.aggregate.totalCost, 60, "no split available -> whole-slice swap, unchanged");
+  check("payloads with no split fall back to the old behaviour");
+}
+
+{
+  // One side new, one side old — the common shape during rollout.
+  const prior = { laptop: contrib(100, 1000) };
+  const r = mergeMachineContribution(prior, "laptop", contrib(60, 600, { claude: slice(60, 600) }), true);
+  assert.equal(r.aggregate.totalCost, 60);
+  check("a half-upgraded pair falls back rather than guessing a split");
+}
+
+console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
Closes #125. Closes #141 (the prompt half — the duplicate profile still needs deleting by hand).

Both reported by @mattw90, both confirmed by measurement rather than by reading the code.

## #125 — a Claude cleanup was lowering Codex

The corpus scan reads `~/.claude/projects`, so it is evidence about Claude and nothing else. But a mixed day was stored as one lump per machine, and lowering the lump took the untouched tools with it. Reproduced before touching anything:

```
prior day:        $100 / 1000 tok  (claude + codex)
re-scan reports:  $60  /  600 tok  (claude transcripts pruned)
stored aggregate: $60  /  600 tok   ← the untouched Codex $40 is gone
```

**This is not an edge case.** Across all 57,590 daily rows:

| | rows | |
|---|---:|---|
| no agent labels (older CLI) | 25,734 | 44.68% |
| claude only | 11,964 | 20.77% |
| **mixed claude + other** | **5,286** | **9.18%** |
| no claude | 14,606 | 25.36% |

Mixed days are 9% of rows but carry **$3,768,354 of $10,975,753 — 34.33% of all cost on the board.** The heavy days are the multi-agent ones.

### Why this is fixable now

I first concluded it wasn't, because the payload has no per-agent split. That was wrong: `ccusage daily --by-agent` emits one, and it has for a while. Verified on a real 103-day report from this machine:

- the per-agent slices reconcile with their row to **$0.000000** across all 103 days
- enabling the flag **changes no existing total** — same dates, same costs (the only row that moved was today's, which grew $0.61 between the two runs)
- report size roughly doubles: 89,405 → 188,179 bytes

### The change

- **CLI** asks for `--by-agent`, and falls back to the plain report if the flag isn't recognised. An older ccusage must not break a submission — a report without the split is still a good report.
- **Normalizer** keeps a split only when it reconciles with the day it claims to divide. A split that doesn't add up is malformed or hostile, and storing it would let a caller inflate one agent while the headline total stayed believable.
- **Merge** lowers the corpus agent alone; every other tool keeps its high-water mark. Within one agent the slice is still swapped whole, because a per-field max would synthesise a slice nobody observed. Across agents it's safe — each was measured independently.
- **Deletion is still honoured.** If Claude drops out of the report entirely, its slice goes, rather than being held at a high-water mark the user deliberately erased. That was the whole point of #112 and it still works.

Payloads without a split fall through to exactly the previous behaviour, which matters because that's most of the board today.

## #141 — the prompt pre-filled a guess

`git config user.name` was the prompt's default, so a reflexive Enter submitted under it. That is how a public profile called `Matt` came to hold 86B tokens belonging to `mattw90`; both submissions share machine id `cf207bc8-…`.

Validation can't catch this class — `Matt` is a perfectly well-formed GitHub handle, so `looksLikeGithubHandle` passes it. Only a GitHub remote pre-fills now. A git-config guess is shown *in the question* instead:

```
GitHub username (git config says "Matt" — type it if that's right)
```

Costs one line of typing to exactly the people it would otherwise misfile. `quietSubmit()` was never affected — scheduled runs take identity from the API token and the server ignores the header claim.

## Tests

```
✓ a --by-agent report keeps its per-agent split
✓ a split that doesn't reconcile with the day is discarded
✓ a report without --by-agent normalizes exactly as before
✓ a Claude cleanup lowers Claude alone and leaves Codex whole (#125)
✓ deletion is still honoured for the tool the corpus is evidence about
✓ an ordinary lower re-report still holds the high-water mark (#83)
✓ payloads with no split fall back to the old behaviour
✓ a half-upgraded pair falls back rather than guessing a split
```

Also run against the real 103-day report: 103/103 days split, 0 mismatched. Full suite passes, `npm run build` clean.

## Not in this PR

- The `Matt` profile still needs deleting by hand.
- #138's silent whole-day replacement on ID-less uploads — deliberate per #81, but silent. Needs a decision on warn-vs-reject before I touch it.
- CLI bumped to 1.9.0; reaches users on publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZYrmUrScxFAMBV3URBp5G