### PR TITLE
feat(cli): pitch autosubmit as a backup, not a rank chore

### DIFF
--- a/packages/viberank-cli/cli.js
+++ b/packages/viberank-cli/cli.js
@@ -13,6 +13,7 @@ import fetch from 'node-fetch';
 import { getToken, getMachineId, readConfig, writeConfig, clearToken, looksLikeToken, CONFIG_DIR } from './lib/config.js';
 import * as autosubmit from './lib/autosubmit.js';
 import { collectCorpus } from './lib/corpus.js';
+import { autosubmitPitch, keepLocalHistoryHint } from './lib/pitch.js';
 import { runNpx } from './lib/npx.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -85,6 +86,18 @@ first submitted.
 }
 
 async function login() {
+  if (!(await acquireToken())) process.exit(1);
+  console.log(`Next: ${chalk.bold('npx viberank-cli autosubmit')} to keep a running backup.\n`);
+}
+
+/**
+ * Walk someone through creating and saving a token.
+ *
+ * Returns false instead of exiting so it can be offered mid-flow — the
+ * autosubmit prompt used to hand out two commands to run later and end there,
+ * which is a dead end at the exact moment someone has just said yes.
+ */
+async function acquireToken() {
   const url = `${SITE}/settings/tokens`;
   console.log(chalk.yellow.bold('\nConnect this machine to viberank\n'));
   console.log(`  1. Open ${chalk.cyan(url)}`);
@@ -111,8 +124,8 @@ async function login() {
   });
 
   if (!token) {
-    console.log(chalk.red('\nNo token entered.'));
-    process.exit(1);
+    console.log(chalk.gray('\nNo token entered.'));
+    return false;
   }
 
   // Prove it works before saving, so a typo fails here rather than silently
@@ -126,7 +139,7 @@ async function login() {
 
   if (res.status === 401) {
     spinner.fail('That token was rejected — it may be revoked or mistyped.');
-    process.exit(1);
+    return false;
   }
   // Any other status means the token authenticated and the empty body was
   // then rejected on its own merits, which is what we want.
@@ -134,7 +147,7 @@ async function login() {
 
   writeConfig({ token: token.trim() });
   console.log(chalk.green(`\n✓ Saved to ${CONFIG_DIR}/config.json (owner-only)\n`));
-  console.log(`Next: ${chalk.bold('npx viberank-cli autosubmit')} to keep your rank current.\n`);
+  return true;
 }
 
 function logout() {
@@ -412,12 +425,16 @@ async function main() {
   let attempt = 0;
   const maxAttempts = 3;
   const retryDelay = 5000; // 5 seconds
+  // Held outside the retry loop so the autosubmit prompt can still describe the
+  // report after cc.json may have been cleaned up.
+  let submitted = null;
   
   while (attempt < maxAttempts) {
     attempt++;
     
     try {
       const ccData = JSON.parse(fs.readFileSync(ccJsonPath, 'utf8'));
+      submitted = ccData;
 
       // Per-month corpus size, so the server can tell a transcript the runtime
       // rewrote from history the user deleted (#112). Best effort: a scan that
@@ -581,7 +598,7 @@ async function main() {
     }
   }
 
-  await offerAutosubmit();
+  await offerAutosubmit(submitted);
 
   console.log(chalk.green('\nDone! 🎉'));
 }
@@ -598,22 +615,25 @@ async function main() {
  * job that runs daily and uploads. Doing that without an explicit yes is not
  * something to spring on anyone, least of all this audience.
  */
-async function offerAutosubmit() {
+async function offerAutosubmit(ccData) {
   if (QUIET) return;                        // scheduled run; nobody to ask
   if (!autosubmit.platform()) return;       // no scheduler we can drive
   if (autosubmit.status().enabled) return;  // already on
 
-  console.log(
-    chalk.gray(
-      '\nOne submission freezes your rank at today. Autosubmit sends your\n' +
-      'usage once a day in the background so it stays current.'
-    )
-  );
+  // The pitch used to be about keeping a rank fresh. That is the vanity reason
+  // and it converts badly — 62 of ~1,100 people have ever sent a second report.
+  // The true reason is better: Claude Code deletes session transcripts after
+  // `cleanupPeriodDays`, 30 by default, with no warning and no recovery. Once
+  // it runs, the local history is gone for every tool that reads those files.
+  // What has already been submitted here survives it. That makes autosubmit a
+  // backup rather than a leaderboard chore, and it is the one thing viberank
+  // can offer that a tool reading the same folder cannot.
+  for (const line of autosubmitPitch(ccData)) console.log(chalk.gray(line));
 
   const { enable } = await prompts({
     type: 'confirm',
     name: 'enable',
-    message: 'Keep my rank up to date automatically?',
+    message: 'Keep a running backup of my usage?',
     initial: true,
   });
   if (!enable) {
@@ -621,11 +641,11 @@ async function offerAutosubmit() {
     return;
   }
 
-  // A scheduled run can't open a browser, so it needs a token first.
-  if (!getToken()) {
-    console.log(chalk.yellow('\nAutosubmit needs a token, because a background run cannot sign in.'));
-    console.log(`  1. ${chalk.bold('npx viberank-cli login')}   (paste a token from ${SITE}/settings/tokens)`);
-    console.log(`  2. ${chalk.bold('npx viberank-cli autosubmit')}\n`);
+  // A scheduled run can't open a browser, so it needs a token first. Offer to
+  // do it here rather than printing two commands to run later: they just said
+  // yes, and sending them away to read instructions is where that yes is lost.
+  if (!getToken() && !(await acquireToken())) {
+    console.log(chalk.gray(`Turn it on any time with ${chalk.bold('npx viberank-cli autosubmit')}.\n`));
     return;
   }
 
@@ -637,6 +657,9 @@ async function offerAutosubmit() {
       )
     );
     console.log(chalk.gray('  Stop any time with `npx viberank-cli autosubmit off`.'));
+    // We back the history up; we can also tell them how to stop losing it in
+    // the first place. Costs nothing and is the more useful half of the advice.
+    console.log(chalk.gray(`  ${keepLocalHistoryHint()}`));
   } catch (error) {
     console.log(chalk.yellow(`\nCould not schedule automatic submission: ${error.message}`));
     console.log(chalk.gray('Run `npx viberank-cli autosubmit` to try again.'));

--- a/packages/viberank-cli/lib/pitch.js
+++ b/packages/viberank-cli/lib/pitch.js
@@ -1,0 +1,79 @@
+/**
+ * What to say when offering autosubmit.
+ *
+ * Kept out of cli.js and free of side effects because the wording *is* the
+ * feature here: the previous pitch ("keep your rank up to date") is the vanity
+ * reason and converts badly — 62 of ~1,100 people have ever sent a second
+ * report. This one leads with the thing that is actually at stake.
+ *
+ * Claude Code deletes session transcripts older than `cleanupPeriodDays` — 30
+ * by default — on startup, with no warning and no recovery. Every tool that
+ * reads ~/.claude/projects loses that history at the same moment. A report
+ * already sent to viberank is unaffected, which is the one thing this tool can
+ * offer that a local reader cannot.
+ */
+
+/** Claude Code's default `cleanupPeriodDays`. */
+export const DEFAULT_CLEANUP_DAYS = 30;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Oldest/newest day in a ccusage report, and how far back it reaches. */
+export function historyWindow(ccData, today = new Date()) {
+  // ccusage's aggregate report keys days as `period`, not `date` — the server's
+  // normalizer already does `date ?? period` and the CLI reads the raw file, so
+  // reading only `date` here silently yielded nothing on every real report.
+  const dates = (ccData?.daily ?? [])
+    .map((d) => d?.date ?? d?.period)
+    .filter((d) => typeof d === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(d))
+    .sort();
+  if (dates.length === 0) return null;
+  const oldest = dates[0];
+  // Compare date to date. Using the raw clock made the answer depend on the
+  // time of day the CLI happened to run — the same report read 29 days at
+  // midnight and 30 at noon, which is not a distinction anyone wants surfaced.
+  const todayUtc = Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), today.getUTCDate());
+  const reachDays = Math.round((todayUtc - Date.parse(`${oldest}T00:00:00Z`)) / DAY_MS);
+  return { oldest, newest: dates[dates.length - 1], days: dates.length, reachDays };
+}
+
+/**
+ * True when the report reaches back roughly as far as the default cleanup and
+ * no further — the shape of history that has started aging out.
+ *
+ * Deliberately a *suspicion*, never asserted to the user as fact: someone who
+ * installed Claude Code five weeks ago looks identical from here, and telling
+ * them their data was deleted when it never existed would be worse than saying
+ * nothing. The caller states the default and the user's own reach, and lets
+ * them draw the conclusion.
+ */
+export function looksTruncated(window) {
+  if (!window) return false;
+  return window.reachDays >= DEFAULT_CLEANUP_DAYS - 3 && window.reachDays <= DEFAULT_CLEANUP_DAYS + 10;
+}
+
+/** Lines to print above the autosubmit prompt. Plain text; caller styles it. */
+export function autosubmitPitch(ccData, today = new Date()) {
+  const w = historyWindow(ccData, today);
+  const lines = [
+    '',
+    `Claude Code deletes session history older than ${DEFAULT_CLEANUP_DAYS} days by default,`,
+    'without warning. Every tool that reads those files loses it too.',
+  ];
+  if (w) {
+    lines.push(`Your report reaches back to ${w.oldest} — ${w.reachDays} days.`);
+    if (looksTruncated(w)) {
+      lines.push('That is about where the default cleanup starts, so you may');
+      lines.push('already be losing the oldest of it.');
+    }
+  }
+  lines.push('');
+  lines.push('What you send here is kept. Autosubmit sends once a day, so the');
+  lines.push('record stays complete even after the local files are gone.');
+  return lines;
+}
+
+/** How to stop the deletion at the source. Shown once, after enabling. */
+export function keepLocalHistoryHint() {
+  return `Tip: add "cleanupPeriodDays": 3650 to ~/.claude/settings.json to stop Claude Code deleting it locally too.`;
+}

--- a/packages/viberank-cli/package.json
+++ b/packages/viberank-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "viberank-cli",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "description": "CLI tool to submit your AI coding usage stats (Claude Code, Codex, Gemini CLI, and more via ccusage) to the Viberank leaderboard",
   "type": "module",
   "main": "cli.js",

--- a/test/pitch.test.mts
+++ b/test/pitch.test.mts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+
+const { autosubmitPitch, historyWindow, looksTruncated, DEFAULT_CLEANUP_DAYS } =
+  await import("../packages/viberank-cli/lib/pitch.js");
+
+let passed = 0;
+const check = (label: string) => { passed++; console.log(`✓ ${label}`); };
+const TODAY = new Date("2026-08-22T12:00:00Z");
+const days = (from: string, to: string, key: "date" | "period" = "date") => {
+  const out: Record<string, string>[] = [];
+  for (const d = new Date(from); d <= new Date(to); d.setDate(d.getDate() + 1)) {
+    out.push({ [key]: d.toISOString().slice(0, 10) });
+  }
+  return { daily: out };
+};
+
+{
+  // ccusage's aggregate report keys days as `period`. Reading only `date` made
+  // historyWindow return null on every real report while passing every fixture
+  // that used `date` — caught by rendering against a real cc.json, not by a test.
+  const w = historyWindow(days("2026-06-01", "2026-08-22", "period"), TODAY);
+  assert.ok(w, "a period-keyed report must be understood");
+  assert.equal(w!.oldest, "2026-06-01");
+  assert.equal(historyWindow(days("2026-06-01", "2026-08-22", "date"), TODAY)!.oldest, "2026-06-01");
+  check("both `date` and `period` day keys are read");
+}
+
+{
+  const w = historyWindow(days("2026-07-24", "2026-08-22"), TODAY)!;
+  assert.equal(w.reachDays, 29);
+  assert.equal(looksTruncated(w), true);
+  check("a report reaching back ~30 days reads as possibly truncated");
+}
+
+{
+  assert.equal(looksTruncated(historyWindow(days("2025-10-03", "2026-08-22"), TODAY)!), false);
+  assert.equal(looksTruncated(historyWindow(days("2026-08-19", "2026-08-22"), TODAY)!), false,
+    "a new install is not a deletion");
+  check("long histories and brand-new installs are not flagged");
+}
+
+{
+  // The claim must never be asserted as fact — a five-week-old install is
+  // indistinguishable from a pruned one, and telling someone their data was
+  // deleted when it never existed is worse than saying nothing.
+  const text = autosubmitPitch(days("2026-07-24", "2026-08-22"), TODAY).join(" ");
+  assert.match(text, /you may/, "hedged, not asserted");
+  assert.ok(!/your data was deleted|we lost/i.test(text));
+  check("truncation is offered as a suspicion, never stated as fact");
+}
+
+{
+  const text = autosubmitPitch(days("2026-06-01", "2026-08-22"), TODAY).join(" ");
+  assert.match(text, new RegExp(`${DEFAULT_CLEANUP_DAYS} days by default`));
+  assert.match(text, /What you send here is kept/);
+  assert.ok(!/rank/i.test(text), "the pitch is about the data, not the leaderboard");
+  check("the pitch leads with data loss and never mentions rank");
+}
+
+{
+  assert.deepEqual(historyWindow({ daily: [] }, TODAY), null);
+  assert.deepEqual(historyWindow(undefined as never, TODAY), null);
+  assert.deepEqual(historyWindow({ daily: [{ date: "not-a-date" }] } as never, TODAY), null);
+  const text = autosubmitPitch({ daily: [] }, TODAY).join(" ");
+  assert.match(text, /deletes session history/, "still says the useful part");
+  assert.ok(!/reaches back/.test(text), "but claims nothing about a report it cannot read");
+  check("a missing or malformed report degrades to the general message");
+}
+
+console.log(`\n${passed} checks passed`);


### PR DESCRIPTION
## Why

62 of ~1,100 people have ever sent a second report. The prompt I added in 1.7.0 asks at the right moment but sells the wrong thing:

> One submission freezes your rank at today. Autosubmit sends your usage once a day so it stays current.
> **Keep my rank up to date automatically?**

That's the vanity reason, and it isn't worth a daily scheduled job to anyone.

The real reason was sitting unused. Claude Code deletes session transcripts older than `cleanupPeriodDays` — **30 by default** — on startup, with no warning and no recovery path. It has four open issues ([62476](https://github.com/anthropics/claude-code/issues/62476), [59248](https://github.com/anthropics/claude-code/issues/59248), [62959](https://github.com/anthropics/claude-code/issues/62959), [64999](https://github.com/anthropics/claude-code/issues/64999)) and [coverage in The Register](https://www.theregister.com/ai-and-ml/2026/06/30/claude-code-users-complain-their-chat-records-are-being-mysteriously-wiped-out/5264673). Every tool that reads `~/.claude/projects` loses that history at the same moment. **A report already sent here survives it** — the one thing viberank can offer that a local reader cannot.

It shows in our own data. Across 1,172 submissions:

| history span | share |
|---|---:|
| ≤31 days | **38.7%** |
| 32–60 | 24.3% |
| 61–120 | 17.7% |
| >120 | 19.3% |

The 25th percentile sits exactly at 30 days — the default's fingerprint.

## What changed

**The pitch** leads with the loss and states the user's own reach:

```
Claude Code deletes session history older than 30 days by default,
without warning. Every tool that reads those files loses it too.
Your report reaches back to 2026-07-24 — 29 days.
That is about where the default cleanup starts, so you may
already be losing the oldest of it.

What you send here is kept. Autosubmit sends once a day, so the
record stays complete even after the local files are gone.
? Keep a running backup of my usage? (Y/n)
```

The last two lines only appear when the report reaches back roughly as far as the default and no further. It is deliberately hedged — someone who installed five weeks ago looks identical from here, and telling them their data was deleted when it never existed is worse than saying nothing.

**The dead end is gone.** Saying yes without a token printed two commands to run later and stopped. `login()` is split into a reusable non-fatal `acquireToken()`, so the flow now continues inline — that dead end is where the yes was being lost, and there are 32 tokens across 1,126 users.

**After enabling**, it also says how to stop the loss at the source: `"cleanupPeriodDays": 3650`.

## Bugs the test run caught

I rendered the prompt against a real `cc.json` instead of trusting fixtures. Two things fell out that no fixture would have caught:

1. **`historyWindow` read only `date`** — but ccusage's aggregate report keys days as `period`. It returned `null` on every real report, so the personalised line would have silently never appeared, while every fixture written with `date` passed.
2. **`reachDays` used the raw clock** — the same report read 29 days at midnight and 30 at noon.

A third was caught before running: `ccData` is scoped inside the retry loop, so passing it to `offerAutosubmit()` at the call site would have thrown `ReferenceError` on every successful submission.

## Tests

```
✓ both `date` and `period` day keys are read
✓ a report reaching back ~30 days reads as possibly truncated
✓ long histories and brand-new installs are not flagged
✓ truncation is offered as a suspicion, never stated as fact
✓ the pitch leads with data loss and never mentions rank
✓ a missing or malformed report degrades to the general message
```

Full suite passes, build clean. CLI 1.10.0 — reaches users on publish.

## How to tell if it worked

Token count. It's 32 today across 1,126 users; autosubmit can't be enabled without one. Worth looking again in a week.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZYrmUrScxFAMBV3URBp5G