### PR TITLE
docs: stop recommending the header that created a duplicate profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Live at **[viberank.app](https://www.viberank.app)**.
 - 📊 **Profile pages** at `viberank.app/profile/{username}` — global rank, daily charts, token breakdown, tools used
 - ⚡ **Server-rendered** — homepage, profiles, and tool boards are SSR'd with structured data (FAQPage, ProfilePage, BreadcrumbList) for fast paint and full crawlability
 - 🚀 **Four ways to submit**: `npx viberank-cli`, plain `curl`, signed-in web upload, or MCP
-- ♾️ **Autosubmit** — `viberank login` once, `viberank autosubmit` once, and your rank stays current instead of freezing on the day you first submitted
+- ♾️ **Autosubmit** — `viberank login` once, `viberank autosubmit` once, and your usage keeps arriving daily. Claude Code deletes session transcripts after 30 days by default, so this is the difference between a permanent record and whatever survived the last cleanup
 - 🔐 **GitHub OAuth + API tokens** — OAuth and token submissions show a blue check; header-only CLI submissions show a `cli` pill
 - 🖥️ **Multi-machine** — a laptop and a desktop sum into one profile instead of overwriting each other
 - 📈 **[`/stats`](https://www.viberank.app/stats)** — site-wide spend curve, monthly trend, and where your burn lands against everyone else
@@ -40,14 +40,16 @@ Live at **[viberank.app](https://www.viberank.app)**.
 npx viberank-cli
 ```
 
-This generates a fresh `cc.json` via `ccusage daily --json` (the aggregate report across **all** your detected tools) and POSTs it to `/api/submit`. It picks up your GitHub username from your git remote / `git config user.name`.
+This generates a fresh `cc.json` via `ccusage daily --json` (the aggregate report across **all** your detected tools) and POSTs it to `/api/submit`. It reads your GitHub username from your git remote and asks you to confirm it. If there is no GitHub remote it shows what `git config user.name` says but makes you type the handle yourself — that value is usually a display name, and accepting it silently created profiles belonging to nobody (#141).
 
-**Set it and forget it.** A one-off submission freezes your rank on the day you ran it. Mint a token at [viberank.app/settings/tokens](https://www.viberank.app/settings/tokens), then:
+**Set it and forget it.** A one-off submission captures only what survives on disk today, and freezes your rank there. Mint a token at [viberank.app/settings/tokens](https://www.viberank.app/settings/tokens), then:
 
 ```bash
 npx viberank-cli login       # paste the token once
 npx viberank-cli autosubmit  # daily background submission
 ```
+
+Claude Code deletes session transcripts older than `cleanupPeriodDays` — 30 by default — on startup, with no warning. Every tool that reads `~/.claude/projects` loses that history at the same moment; what has already been submitted here does not. Submitting daily is what makes the record outlive the local files. (Raising `cleanupPeriodDays` in `~/.claude/settings.json` stops the deletion at the source.)
 
 `autosubmit` registers with your platform's own scheduler — launchd, systemd user timers, or Task Scheduler — rather than running a daemon of its own, so it survives reboots and catches up after a missed run. `npx viberank-cli status` shows the token and schedule state; `autosubmit off` removes it. Token submissions are verified, so they carry a blue check without a browser sign-in.
 
@@ -57,9 +59,13 @@ npx viberank-cli autosubmit  # daily background submission
 npx ccusage@latest daily --json > cc.json
 curl -X POST https://www.viberank.app/api/submit \
   -H "Content-Type: application/json" \
-  -H "X-GitHub-User: $(git config user.name)" \
+  -H "X-GitHub-User: your-github-username" \
   -d @cc.json
 ```
+
+> Put your **GitHub username** in that header, not `$(git config user.name)` — that is usually a display name, and submitting under it creates a second profile nobody owns.
+
+> Add `--by-agent` to the `ccusage` command to include a per-tool split, so a Claude Code cleanup can be applied to Claude's numbers alone.
 
 > `ccusage` v20 keys daily entries by `period` and reports an `agent` per day; viberank normalizes this server-side, so either the new or older `ccusage` output works.
 

--- a/packages/viberank-cli/README.md
+++ b/packages/viberank-cli/README.md
@@ -17,7 +17,9 @@ This will:
 
 ## Stay on the board
 
-A one-off submission freezes your rank on the day you ran it. Two commands fix that permanently:
+Claude Code deletes session transcripts older than `cleanupPeriodDays` — **30 days by default** — on startup, with no warning and no recovery. Every tool that reads those files loses that history at the same moment. What you have already submitted here survives it.
+
+A one-off submission also freezes your rank on the day you ran it. Two commands fix both:
 
 ```bash
 npx viberank-cli login       # paste a token from viberank.app/settings/tokens
@@ -25,6 +27,8 @@ npx viberank-cli autosubmit  # submit once a day, in the background
 ```
 
 Most people run these once and never think about it again.
+
+To stop the deletion at the source as well, add `"cleanupPeriodDays": 3650` to `~/.claude/settings.json`.
 
 `autosubmit` registers with your operating system's own scheduler — **launchd** on macOS, a **systemd user timer** on Linux, **Task Scheduler** on Windows — instead of running a daemon of its own. Those already survive reboots, catch up after a missed run, and write logs; a node process sitting in your tray to fire once a day would be a worse version of software you already have.
 
@@ -87,7 +91,7 @@ The CLI detects the existing `cc.json` and asks whether to use it.
 ## Direct API usage
 
 ```bash
-GITHUB_USER=$(git config user.name)
+GITHUB_USER=your-github-username   # your GitHub login, not your display name
 
 curl -X POST https://www.viberank.app/api/submit \
   -H "Content-Type: application/json" \
@@ -105,7 +109,7 @@ Without one, the CLI falls back to an `X-GitHub-User` header — anyone can set 
 
 - **"npx viberank-cli" not found** — try `npx viberank-cli@latest` or clear the npx cache with `npx clear-npx-cache`
 - **"Failed to submit data"** — regenerate with `npx ccusage@latest daily --json > cc.json` and retry
-- **"GitHub username not found"** — run `git config --global user.name "YourGitHubUsername"`
+- **"GitHub username not found"** — just type it at the prompt. The CLI no longer pre-fills `git config user.name`, because that is usually a display name and accepting it created profiles belonging to nobody (#141)
 - **"No usage data"** — make sure you've used a supported AI coding tool at least once on this machine
 - **Autosubmit isn't firing** — `npx viberank-cli status` prints the schedule state and the last few log lines from `~/.viberank/autosubmit.log`
 - **"Invalid token"** — it may have been revoked; mint a fresh one at [viberank.app/settings/tokens](https://www.viberank.app/settings/tokens) and run `login` again


### PR DESCRIPTION
Follow-up to #143 and #144 — the docs were still describing behaviour we changed, and one example was actively harmful.

## The harmful one

Both READMEs handed people this:

```bash
-H "X-GitHub-User: $(git config user.name)"
```

That is precisely the mistake behind #141. `user.name` is usually a display name, so the submission lands on a profile the submitter doesn't own and can't delete. One such profile — `Matt` — reached **86B tokens / $74,680** before its owner had to open an issue asking for it to be removed by hand.

Replaced with a placeholder and a note explaining why.

## The stale ones

- The CLI troubleshooting entry still said *"run `git config --global user.name "YourGitHubUsername"`"*. 1.10.0 stopped pre-filling that value, so the advice described behaviour that no longer exists.
- The main README claimed the CLI *"picks up your GitHub username from your git remote / `git config user.name`"* — now only half true, and the half that changed is the important one.

## The framing

#144 rewrote the CLI's autosubmit pitch from *"keep your rank up to date"* to the real reason: Claude Code deletes session transcripts after `cleanupPeriodDays` (30 by default) with no warning, every tool reading those files loses them, and a submitted report outlives them. Both READMEs said the old thing. They now say the new one, and both mention raising `cleanupPeriodDays` to stop the loss at the source rather than only backing it up.

Also documents `--by-agent` on the curl path, since #143 uses it to scope a drift verdict to one tool.

Docs only — no code, no version bump. The CLI README ships inside the npm package, so the npm listing picks this up on the next publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZYrmUrScxFAMBV3URBp5G