### PR TITLE
docs: finish the sweep — MCP had the same username hole, CHANGELOG had a gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## CLI v1.10.0 — autosubmit is a backup, not a rank chore (August 2026)
+
+### Changed
+- **The autosubmit prompt now leads with what is actually at stake.** Claude Code deletes session transcripts older than `cleanupPeriodDays` — 30 by default — on startup, with no warning and no recovery; every tool reading `~/.claude/projects` loses that history at the same moment, and a report already submitted here survives it. The old pitch ("keep my rank up to date") was the vanity reason and converted badly: 62 of ~1,100 people had ever sent a second report. On our own data 38.7% of submissions span 31 days or less, with the 25th percentile sitting exactly at 30 — the default's fingerprint. When a report reaches back roughly that far the prompt says so, hedged, because a five-week-old install is indistinguishable from a pruned one.
+- **Saying yes without a token no longer dead-ends.** It printed two commands to run later and stopped — at the exact moment someone had just agreed. `login` is now a reusable non-fatal token flow the prompt runs inline.
+- After enabling, the CLI also says how to stop the loss at its source: `"cleanupPeriodDays": 3650`.
+
+### Fixed
+- `historyWindow` read only `date`, but ccusage's aggregate report keys days as `period` — the personalised line would have silently never appeared on a real report while passing every fixture written with `date`. Caught by rendering against a real `cc.json`.
+- The history reach was computed from the raw clock, so the same report read 29 days at midnight and 30 at noon.
+
+## CLI v1.9.0 — a Claude cleanup no longer lowers Codex (August 2026)
+
+### Fixed
+- **A drift verdict about Claude files lowered the whole day, including other tools** (#125). The corpus scan reads `~/.claude/projects` and is evidence about Claude alone, but a mixed day was stored as one lump per machine, so honouring a Claude deletion took the same day's untouched Codex tokens with it. Mixed days are 9.18% of daily rows but **34.33% of all cost on the board**. The CLI now passes `ccusage --by-agent`, whose per-agent slices reconcile with their row to $0.000000 across a real 103-day report; the server keeps a split only when it reconciles and lowers the corpus agent alone. Reports without a split behave exactly as before, and the flag is dropped silently if an older ccusage rejects it.
+- **`git config user.name` was pre-filled as the username prompt's default** (#141), so a reflexive Enter submitted under it. That created a public profile called `Matt` holding 86B tokens belonging to `mattw90` — both submissions shared a machine id. Validation cannot catch this: `Matt` is a well-formed GitHub handle. Only a GitHub remote pre-fills now; a git-config guess is shown in the question instead.
+
+## CLI v1.8.0 — you find out where you landed (August 2026)
+
+### Added
+- A successful submission now prints your rank, percentile and tier, plus a paste-ready README badge. Only 3 repositories on GitHub embedded a viberank badge, because the success path never gave anyone anything to share.
+
+## CLI v1.7.0 — autosubmit is offered where it makes sense (August 2026)
+
+### Added
+- The CLI offers autosubmit after a successful submission, defaulted to yes, instead of leaving it buried in `/settings/tokens` where almost nobody found it. Deliberately a prompt and not a silent default: it installs a scheduled job that uploads daily.
+
 ## CLI v1.6.0 — Windows submissions work again (August 2026)
 
 ### Fixed

--- a/packages/viberank-mcp-server/README.md
+++ b/packages/viberank-mcp-server/README.md
@@ -8,7 +8,7 @@ Submit your AI coding usage stats (Claude Code, Codex, Gemini CLI and more) to [
 - 📊 **Direct Submission** - Submit to Viberank leaderboard without leaving your workflow
 - 🔄 **Smart Caching** - Caches usage data for 5 minutes to reduce overhead
 - 👤 **Profile Management** - View profiles and leaderboard data
-- 🔐 **GitHub Integration** - Automatically detects your GitHub username from git config
+- 🔐 **GitHub Integration** - Reads your GitHub username from your repo's GitHub remote. Pass `username` explicitly if there isn't one — `git config user.name` is usually a display name, and submitting under it creates a profile you don't own
 
 ## Installation
 

--- a/packages/viberank-mcp-server/src/index.ts
+++ b/packages/viberank-mcp-server/src/index.ts
@@ -231,6 +231,11 @@ class ViberankMCPServer {
     }
   }
 
+  /** 1-39 alphanumerics with single interior hyphens — GitHub's own rule. */
+  private static isGithubHandle(value: string): boolean {
+    return /^[a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38}$/i.test(value);
+  }
+
   private async submitToViberank(
     githubUsername?: string,
     autoDetectUsername: boolean = true
@@ -239,13 +244,21 @@ class ViberankMCPServer {
       // Determine GitHub username
       let username = githubUsername;
       
+      // Prefer the GitHub remote, which is evidence, over `git config
+      // user.name`, which is a guess and usually a display name. The CLI hit
+      // this and it created a public profile called "Matt" holding 86B tokens
+      // that its owner could not delete (#141). The CLI could re-prompt; an MCP
+      // tool call cannot, so an unusable guess is refused rather than sent.
       if (!username && autoDetectUsername) {
         try {
-          username = execSync('git config user.name', { encoding: 'utf8' }).trim();
+          const remote = execSync('git config --get remote.origin.url', { encoding: 'utf8' }).trim();
+          username = remote.match(/github\.com[:/]([^/]+)\//)?.[1];
         } catch {
-          // Ignore git config errors
+          // No GitHub remote; fall through to asking for it explicitly.
         }
       }
+
+      if (username && !ViberankMCPServer.isGithubHandle(username)) username = undefined;
 
       if (!username) {
         return {

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -363,7 +363,7 @@ export async function POST(request: NextRequest) {
       // CLI is the one moment they are addressable.
       hint: tokenOwner
         ? null
-        : "Tip: run `npx viberank-cli login` then `npx viberank-cli autosubmit` to keep this updated automatically.",
+        : "Claude Code deletes session history after 30 days by default — what you send here outlives it. Run `npx viberank-cli login` then `npx viberank-cli autosubmit` to keep a daily backup.",
     });
 
   } catch (error) {

--- a/src/app/settings/tokens/page.tsx
+++ b/src/app/settings/tokens/page.tsx
@@ -43,7 +43,7 @@ export default async function TokensPage() {
           <p className="micro-label mb-3">Using it</p>
           <pre className="bg-surface-1 border border-border rounded-lg p-4 text-sm overflow-x-auto">
             <code>{`npx viberank-cli login       # paste the token once
-npx viberank-cli autosubmit  # submit daily, in the background`}</code>
+npx viberank-cli autosubmit  # daily backup, in the background`}</code>
           </pre>
           <p className="text-xs text-muted mt-3 leading-relaxed">
             The token is stored in <code>~/.viberank/config.json</code> with owner-only

--- a/src/components/SubmitModal.tsx
+++ b/src/components/SubmitModal.tsx
@@ -92,7 +92,8 @@ export default function SubmitModal({ open, onClose }: SubmitModalProps) {
                     profile, and burying it in /settings/tokens is why almost
                     nobody has it on. */}
                 <p className="text-[11px] text-muted mt-2.5 leading-relaxed">
-                  One submission freezes your rank at today. To keep it current:
+                  Claude Code deletes session history after 30 days by default.
+                  What you send here outlives it — keep it arriving:
                 </p>
                 <button
                   onClick={copyAutosubmit}


### PR DESCRIPTION
Checking whether the docs were current turned up two things the earlier passes missed.

## The MCP server had #141 too

```ts
if (!username && autoDetectUsername) {
  username = execSync('git config user.name', ...).trim();
}
```

Same mechanism that created the `Matt` profile — and worse here, because an MCP tool call has no prompt to correct the guess. The CLI could re-ask; this just submits.

Now reads the GitHub remote, validates against GitHub's own handle rule, and returns the "tell me your username" error rather than sending a guess. Its README advertised the old behaviour as a feature (*"Automatically detects your GitHub username from git config"*) — reworded.

## The CHANGELOG stopped at v1.6.0

Four releases missing: 1.7.0 (autosubmit prompt), 1.8.0 (rank + badge on success), 1.9.0 (per-agent drift fix, username prompt), 1.10.0 (backup repositioning). Written up with the measurements behind each.

## Three site surfaces still on the old pitch

- **Submit modal** — *"One submission freezes your rank at today"*
- **Tokens page** — *"submit daily, in the background"*
- **The API's post-submission hint** — *"to keep this updated automatically"*

That last one matters most: it's the only channel that reaches people who already submitted, since 94% never return to the site and 70% never signed in.

## Verified clean afterwards

Swept every `.md`, `llms.txt`, and copy surface for the old framing and for `$(git config user.name)`. The only remaining matches are the new warnings that quote the bad pattern to tell people not to use it.

Full suite passes, both packages build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZYrmUrScxFAMBV3URBp5G